### PR TITLE
fix:  locale-dependent number/currency formatting.

### DIFF
--- a/src/AgentEval.Abstractions/Calibration/CalibratedResult.cs
+++ b/src/AgentEval.Abstractions/Calibration/CalibratedResult.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace AgentEval.Calibration;
 
 /// <summary>
@@ -83,12 +85,12 @@ public record CalibratedResult
         get
         {
             var ciText = ConfidenceLower.HasValue && ConfidenceUpper.HasValue
-                ? $"95% CI: [{ConfidenceLower:F1}, {ConfidenceUpper:F1}]"
+                ? string.Create(CultureInfo.InvariantCulture, $"95% CI: [{ConfidenceLower:F1}, {ConfidenceUpper:F1}]")
                 : "CI: N/A";
             
             var consensusIcon = HasConsensus ? "✅" : "⚠️";
             
-            return $"Score: {Score:F1} | Agreement: {Agreement:F0}% | {ciText} | Consensus: {consensusIcon}";
+            return string.Create(CultureInfo.InvariantCulture, $"Score: {Score:F1} | Agreement: {Agreement:F0}% | {ciText} | Consensus: {consensusIcon}");
         }
     }
     
@@ -102,7 +104,7 @@ public record CalibratedResult
             var lines = new List<string> { "Judge Scores:" };
             foreach (var (judge, score) in JudgeScores.OrderByDescending(kvp => kvp.Value))
             {
-                lines.Add($"  {judge}: {score:F1}");
+                lines.Add(string.Create(CultureInfo.InvariantCulture, $"  {judge}: {score:F1}"));
             }
             return string.Join(Environment.NewLine, lines);
         }

--- a/src/AgentEval.Abstractions/Core/IAgentEvalLogger.cs
+++ b/src/AgentEval.Abstractions/Core/IAgentEvalLogger.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.Core;
@@ -115,7 +116,7 @@ public static class AgentEvalLoggerExtensions
     {
         if (logger.IsEnabled(LogLevel.Information))
         {
-            logger.Log(LogLevel.Information, $"Metric '{metricName}' completed: Score={score:F2}, Duration={duration.TotalMilliseconds:F0}ms");
+            logger.Log(LogLevel.Information, string.Create(CultureInfo.InvariantCulture, $"Metric '{metricName}' completed: Score={score:F2}, Duration={duration.TotalMilliseconds:F0}ms"));
         }
     }
 

--- a/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
+++ b/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Globalization;
 
 namespace AgentEval.Models;
 
@@ -59,17 +60,17 @@ public class PerformanceMetrics
     {
         var parts = new List<string>
         {
-            $"Duration: {TotalDuration.TotalMilliseconds:F0}ms"
+            string.Create(CultureInfo.InvariantCulture, $"Duration: {TotalDuration.TotalMilliseconds:F0}ms")
         };
         
         if (TimeToFirstToken.HasValue)
-            parts.Add($"TTFT: {TimeToFirstToken.Value.TotalMilliseconds:F0}ms");
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"TTFT: {TimeToFirstToken.Value.TotalMilliseconds:F0}ms"));
         
         if (TotalTokens > 0)
             parts.Add($"Tokens: {TotalTokens}");
         
         if (EstimatedCost.HasValue)
-            parts.Add($"Cost: ${EstimatedCost:F4}");
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"Cost: ${EstimatedCost:F4}"));
         
         if (ToolCallCount > 0)
             parts.Add($"Tools: {ToolCallCount}");

--- a/src/AgentEval.Abstractions/Models/TestSummaryExtensions.cs
+++ b/src/AgentEval.Abstractions/Models/TestSummaryExtensions.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace AgentEval.Models;
 
 /// <summary>
@@ -121,7 +123,7 @@ public static class TestSummaryExtensions
             metadata["TotalDuration"] = summary.TotalDuration.ToString();
 
         if (summary.TotalCost > 0)
-            metadata["TotalCost"] = summary.TotalCost.ToString("F6");
+            metadata["TotalCost"] = summary.TotalCost.ToString("F6", CultureInfo.InvariantCulture);
 
         return metadata;
     }

--- a/src/AgentEval.Core/Assertions/PerformanceAssertions.cs
+++ b/src/AgentEval.Core/Assertions/PerformanceAssertions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using AgentEval.Models;
 
@@ -35,8 +36,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total duration to be under the specified maximum.",
                     metricName: "TotalDuration",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
                     suggestions: new[] 
                     { 
                         "Consider optimizing slow tool operations",
@@ -60,8 +61,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total duration to be at least the specified minimum.",
                     metricName: "TotalDuration",
-                    threshold: $"≥ {min.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"≥ {min.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms"),
                     because: because));
         }
         return this;
@@ -93,8 +94,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected time to first token (TTFT) to be under the specified maximum.",
                     metricName: "TimeToFirstToken",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TimeToFirstToken.Value.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TimeToFirstToken.Value.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
                     suggestions: new[] 
                     { 
                         "TTFT is affected by model load time and prompt processing",
@@ -118,8 +119,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total token count to be under the specified maximum.",
                     metricName: "TotalTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.TotalTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalTokens:N0}"),
                     context: breakdown,
                     suggestions: new[] 
                     { 
@@ -144,8 +145,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected prompt tokens to be under the specified maximum.",
                     metricName: "PromptTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.PromptTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.PromptTokens:N0}"),
                     suggestions: new[] 
                     { 
                         "Shorten system prompt",
@@ -169,8 +170,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected completion tokens to be under the specified maximum.",
                     metricName: "CompletionTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.CompletionTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.CompletionTokens:N0}"),
                     suggestions: new[] 
                     { 
                         "Use max_tokens parameter to limit response length",
@@ -203,13 +204,13 @@ public class PerformanceAssertions
         if (_metrics.EstimatedCost!.Value > maxUsd)
         {
             var overage = _metrics.EstimatedCost.Value - maxUsd;
-            var breakdown = $"Prompt: {_metrics.PromptTokens:N0} tokens, Completion: {_metrics.CompletionTokens:N0} tokens";
+            var breakdown = string.Create(CultureInfo.InvariantCulture, $"Prompt: {_metrics.PromptTokens:N0} tokens, Completion: {_metrics.CompletionTokens:N0} tokens");
             AgentEvalScope.FailWith(
                 PerformanceAssertionException.Create(
                     "Expected estimated cost to be under the specified maximum.",
                     metricName: "EstimatedCost",
-                    threshold: $"< ${maxUsd:F4}",
-                    measuredValue: $"${_metrics.EstimatedCost.Value:F4} (exceeded by ${overage:F4})",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< ${maxUsd:F4}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"${_metrics.EstimatedCost.Value:F4} (exceeded by ${overage:F4})"),
                     context: breakdown,
                     suggestions: new[] 
                     { 
@@ -247,9 +248,9 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected average tool execution time to be under the specified maximum.",
                     metricName: "AverageToolTime",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.AverageToolTime.TotalMilliseconds:F0}ms",
-                    context: $"Total tool time: {_metrics.TotalToolTime.TotalMilliseconds:F0}ms across {_metrics.ToolCallCount} call(s)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.AverageToolTime.TotalMilliseconds:F0}ms"),
+                    context: string.Create(CultureInfo.InvariantCulture, $"Total tool time: {_metrics.TotalToolTime.TotalMilliseconds:F0}ms across {_metrics.ToolCallCount} call(s)"),
                     suggestions: new[] 
                     { 
                         "Optimize individual tool implementations",
@@ -287,9 +288,9 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total tool execution time to be under the specified maximum.",
                     metricName: "TotalToolTime",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalToolTime.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
-                    context: $"{_metrics.ToolCallCount} tool call(s), average: {_metrics.AverageToolTime.TotalMilliseconds:F0}ms",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalToolTime.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
+                    context: string.Create(CultureInfo.InvariantCulture, $"{_metrics.ToolCallCount} tool call(s), average: {_metrics.AverageToolTime.TotalMilliseconds:F0}ms"),
                     suggestions: new[] 
                     { 
                         "Reduce number of tool calls",

--- a/src/AgentEval.Core/Benchmarks/AgenticBenchmark.cs
+++ b/src/AgentEval.Core/Benchmarks/AgenticBenchmark.cs
@@ -430,7 +430,7 @@ public class TaskCompletionResult
     
     public override string ToString() =>
         $"Task Completion: {AgentName}\n" +
-        $"  Passed: {PassedTests}/{TotalTests} | Avg Score: {AverageScore:F1}/100";
+        $"  Passed: {PassedTests}/{TotalTests} | Avg Score: {AverageScore.ToString("F1", CultureInfo.InvariantCulture)}/100";
 }
 
 public class TaskCompletionTestResult

--- a/src/AgentEval.Core/Benchmarks/PerformanceBenchmark.cs
+++ b/src/AgentEval.Core/Benchmarks/PerformanceBenchmark.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Core;
 using AgentEval.Models;
 
@@ -403,9 +404,9 @@ public class LatencyBenchmarkResult
     public override string ToString() =>
         $"Latency Benchmark: {AgentName}\n" +
         $"  Iterations: {SuccessfulIterations}/{Iterations}\n" +
-        $"  Mean: {MeanLatency.TotalMilliseconds:F0}ms | Min: {MinLatency.TotalMilliseconds:F0}ms | Max: {MaxLatency.TotalMilliseconds:F0}ms\n" +
-        $"  P50: {P50Latency.TotalMilliseconds:F0}ms | P90: {P90Latency.TotalMilliseconds:F0}ms | P99: {P99Latency.TotalMilliseconds:F0}ms" +
-        (MeanTimeToFirstToken.HasValue ? $"\n  Mean TTFT: {MeanTimeToFirstToken.Value.TotalMilliseconds:F0}ms" : "");
+        string.Create(CultureInfo.InvariantCulture, $"  Mean: {MeanLatency.TotalMilliseconds:F0}ms | Min: {MinLatency.TotalMilliseconds:F0}ms | Max: {MaxLatency.TotalMilliseconds:F0}ms\n") +
+        string.Create(CultureInfo.InvariantCulture, $"  P50: {P50Latency.TotalMilliseconds:F0}ms | P90: {P90Latency.TotalMilliseconds:F0}ms | P99: {P99Latency.TotalMilliseconds:F0}ms") +
+        (MeanTimeToFirstToken.HasValue ? string.Create(CultureInfo.InvariantCulture, $"\n  Mean TTFT: {MeanTimeToFirstToken.Value.TotalMilliseconds:F0}ms") : "");
 }
 
 /// <summary>
@@ -425,9 +426,9 @@ public class ThroughputBenchmarkResult
     
     public override string ToString() =>
         $"Throughput Benchmark: {AgentName}\n" +
-        $"  Duration: {Duration.TotalSeconds:F1}s | Concurrent: {ConcurrentRequests}\n" +
+        string.Create(CultureInfo.InvariantCulture, $"  Duration: {Duration.TotalSeconds:F1}s | Concurrent: {ConcurrentRequests}\n") +
         $"  Completed: {CompletedRequests} | Errors: {ErrorCount}\n" +
-        $"  RPS: {RequestsPerSecond:F2} | Mean Latency: {MeanLatency.TotalMilliseconds:F0}ms";
+        string.Create(CultureInfo.InvariantCulture, $"  RPS: {RequestsPerSecond:F2} | Mean Latency: {MeanLatency.TotalMilliseconds:F0}ms");
 }
 
 /// <summary>
@@ -453,6 +454,6 @@ public class CostBenchmarkResult
         $"Cost Benchmark: {AgentName} ({ModelName})\n" +
         $"  Prompts: {SuccessfulPrompts}/{TotalPrompts}\n" +
         $"  Tokens: {TotalInputTokens} input + {TotalOutputTokens} output = {TotalTokens} total\n" +
-        $"  Avg per prompt: {AverageInputTokensPerPrompt:F0} in / {AverageOutputTokensPerPrompt:F0} out\n" +
-        (EstimatedCostUSD.HasValue ? $"  Estimated Cost: ${EstimatedCostUSD:F6}" : "  Estimated Cost: Unknown pricing");
+        string.Create(CultureInfo.InvariantCulture, $"  Avg per prompt: {AverageInputTokensPerPrompt:F0} in / {AverageOutputTokensPerPrompt:F0} out\n") +
+        (EstimatedCostUSD.HasValue ? string.Create(CultureInfo.InvariantCulture, $"  Estimated Cost: ${EstimatedCostUSD:F6}") : "  Estimated Cost: Unknown pricing");
 }

--- a/src/AgentEval.Core/Core/AgentEvalLoggerImplementations.cs
+++ b/src/AgentEval.Core/Core/AgentEvalLoggerImplementations.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.Core;
@@ -64,7 +65,7 @@ public sealed class ConsoleAgentEvalLogger : IAgentEvalLogger
         {
             var level = result.Passed ? LogLevel.Information : LogLevel.Warning;
             var icon = result.Passed ? "✓" : "✗";
-            WriteWithColor(level, $"[{DateTime.Now:HH:mm:ss}] {icon} {result.MetricName}: {result.Score:F2} - {result.Explanation}");
+            WriteWithColor(level, string.Create(CultureInfo.InvariantCulture, $"[{DateTime.Now:HH:mm:ss}] {icon} {result.MetricName}: {result.Score:F2} - {result.Explanation}"));
         }
     }
 

--- a/src/AgentEval.DataLoaders/Exporters/CsvExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/CsvExporter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using AgentEval.Core;
 using AgentEval.Models;
@@ -47,7 +48,7 @@ public class CsvExporter : IResultExporter
             var row = $"{EscapeCsvField(report.RunId)}," +
                      $"{EscapeCsvField(result.Name)}," +
                      $"{EscapeCsvField(result.Category ?? "")}," +
-                     $"{result.Score:F2}," +
+                     $"{result.Score.ToString("F2", CultureInfo.InvariantCulture)}," +
                      $"{result.Passed}," +
                      $"{result.Skipped}," +
                      $"{result.DurationMs}," +
@@ -58,7 +59,7 @@ public class CsvExporter : IResultExporter
             // Append metric score values
             foreach (var metric in metricNames)
             {
-                var value = result.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F2") : "";
+                var value = result.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F2", CultureInfo.InvariantCulture) : "";
                 row += $",{value}";
             }
             

--- a/src/AgentEval.DataLoaders/Exporters/JUnitXmlExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/JUnitXmlExporter.cs
@@ -119,11 +119,11 @@ public class JUnitXmlExporter : IResultExporter
                 {
                     await writer.WriteStartElementAsync(null, "failure", null);
                     await writer.WriteAttributeStringAsync(null, "message", null, 
-                        test.Error ?? $"Score {test.Score:F1} below threshold");
+                        test.Error ?? string.Create(CultureInfo.InvariantCulture, $"Score {test.Score:F1} below threshold"));
                     await writer.WriteAttributeStringAsync(null, "type", null, "AssertionError");
                     
                     var failureContent = new StringBuilder();
-                    failureContent.AppendLine($"Score: {test.Score:F1}/100");
+                    failureContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Score: {test.Score:F1}/100"));
                     if (!string.IsNullOrEmpty(test.Error))
                     {
                         failureContent.AppendLine(test.Error);
@@ -141,10 +141,10 @@ public class JUnitXmlExporter : IResultExporter
                 {
                     await writer.WriteStartElementAsync(null, "system-out", null);
                     var outputContent = new StringBuilder();
-                    outputContent.AppendLine($"Score: {test.Score:F1}/100");
+                    outputContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Score: {test.Score:F1}/100"));
                     foreach (var (metric, score) in test.MetricScores)
                     {
-                        outputContent.AppendLine($"{metric}: {score:F1}");
+                        outputContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"{metric}: {score:F1}"));
                     }
                     if (!string.IsNullOrEmpty(test.Output))
                     {

--- a/src/AgentEval.DataLoaders/Exporters/MarkdownExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/MarkdownExporter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using AgentEval.Core;
 using AgentEval.Models;
@@ -50,8 +51,8 @@ public class MarkdownExporter : IResultExporter
         sb.AppendLine("## 🤖 AgentEval Results");
         sb.AppendLine();
         sb.AppendLine($"**Status:** {statusEmoji} {statusText}");
-        sb.AppendLine($"**Score:** {report.OverallScore:F1}/100");
-        sb.AppendLine($"**Tests:** {report.PassedTests}/{report.TotalTests} passed ({report.PassRate:F0}%)");
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**Score:** {report.OverallScore:F1}/100"));
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**Tests:** {report.PassedTests}/{report.TotalTests} passed ({report.PassRate:F0}%)"));
         sb.AppendLine($"**Duration:** {FormatDuration(report.Duration)}");
         
         if (report.Agent?.Model != null)
@@ -76,7 +77,7 @@ public class MarkdownExporter : IResultExporter
             var status = test.Skipped ? "⏭️" : (test.Passed ? "✅" : "❌");
             var time = FormatDuration(TimeSpan.FromMilliseconds(test.DurationMs));
             
-            sb.AppendLine($"| {EscapeMarkdown(test.Name)} | {test.Score:F1} | {status} | {time} |");
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"| {EscapeMarkdown(test.Name)} | {test.Score:F1} | {status} | {time} |"));
         }
         
         // Failures section
@@ -89,7 +90,7 @@ public class MarkdownExporter : IResultExporter
             
             foreach (var failure in failures)
             {
-                sb.AppendLine($"**{EscapeMarkdown(failure.Name)}** (Score: {failure.Score:F1}/100)");
+                sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**{EscapeMarkdown(failure.Name)}** (Score: {failure.Score:F1}/100)"));
                 if (!string.IsNullOrEmpty(failure.Error))
                 {
                     sb.AppendLine($"- {EscapeMarkdown(failure.Error)}");
@@ -131,7 +132,7 @@ public class MarkdownExporter : IResultExporter
                 sb.Append($"| {EscapeMarkdown(test.Name)} |");
                 foreach (var metric in metricNames)
                 {
-                    var score = test.MetricScores.TryGetValue(metric, out var s) ? $"{s:F1}" : "-";
+                    var score = test.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F1", CultureInfo.InvariantCulture) : "-";
                     sb.Append($" {score} |");
                 }
                 sb.AppendLine();
@@ -152,10 +153,10 @@ public class MarkdownExporter : IResultExporter
     private static string FormatDuration(TimeSpan duration)
     {
         if (duration.TotalMilliseconds < 1000)
-            return $"{duration.TotalMilliseconds:F0}ms";
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalMilliseconds:F0}ms");
         if (duration.TotalSeconds < 60)
-            return $"{duration.TotalSeconds:F1}s";
-        return $"{duration.TotalMinutes:F1}m";
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalSeconds:F1}s");
+        return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalMinutes:F1}m");
     }
 
     private static string EscapeMarkdown(string text)

--- a/src/AgentEval.DataLoaders/Output/EvaluationOutputWriter.cs
+++ b/src/AgentEval.DataLoaders/Output/EvaluationOutputWriter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using AgentEval.Core;
@@ -191,11 +192,11 @@ public class EvaluationOutputWriter
     {
         _output.WriteLine();
         _output.WriteLine("⏱️  Performance:");
-        _output.WriteLine($"   Total Duration: {performance.TotalDuration.TotalMilliseconds:F0}ms");
+        _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Total Duration: {performance.TotalDuration.TotalMilliseconds:F0}ms"));
 
         if (performance.TimeToFirstToken.HasValue)
         {
-            _output.WriteLine($"   Time to First Token: {performance.TimeToFirstToken.Value.TotalMilliseconds:F0}ms");
+            _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Time to First Token: {performance.TimeToFirstToken.Value.TotalMilliseconds:F0}ms"));
         }
 
         if (performance.TotalTokens > 0)
@@ -205,7 +206,7 @@ public class EvaluationOutputWriter
 
         if (performance.EstimatedCost > 0)
         {
-            _output.WriteLine($"   Est. Cost: ${performance.EstimatedCost:F4}");
+            _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Est. Cost: ${performance.EstimatedCost:F4}"));
         }
     }
 
@@ -231,7 +232,7 @@ public class EvaluationOutputWriter
         foreach (var call in sortedCalls)
         {
             var statusIcon = !call.HasError ? "✓" : "✗";
-            var duration = call.Duration?.TotalMilliseconds.ToString("F0") + "ms" ?? "?ms";
+            var duration = call.Duration?.TotalMilliseconds.ToString("F0", CultureInfo.InvariantCulture) + "ms" ?? "?ms";
             
             var line = new StringBuilder();
             line.Append($"   {statusIcon} [{call.Order}] {call.Name} ({duration})");

--- a/src/AgentEval.RedTeam/RedTeam/Evaluators/LLMJudgeEvaluator.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Evaluators/LLMJudgeEvaluator.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
+using System.Globalization;
 using Microsoft.Extensions.AI;
 
 namespace AgentEval.RedTeam.Evaluators;
@@ -141,7 +142,7 @@ public class LLMJudgeEvaluator : IProbeEvaluator
             }
             else if (trimmed.StartsWith("CONFIDENCE:", StringComparison.OrdinalIgnoreCase))
             {
-                if (double.TryParse(trimmed[11..].Trim(), out var conf))
+                if (double.TryParse(trimmed[11..].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var conf))
                 {
                     confidence = Math.Clamp(conf, 0.0, 1.0);
                 }

--- a/src/AgentEval.RedTeam/RedTeam/Models/RedTeamResult.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Models/RedTeamResult.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.RedTeam;
@@ -81,7 +82,7 @@ public class RedTeamResult : IRedTeamResult
 
     /// <summary>Human-readable summary.</summary>
     public string Summary =>
-        $"{Verdict}: {SucceededProbes}/{TotalProbes} probes compromised (Score: {OverallScore:F1}%)";
+        string.Create(CultureInfo.InvariantCulture, $"{Verdict}: {SucceededProbes}/{TotalProbes} probes compromised (Score: {OverallScore:F1}%)");
 }
 
 /// <summary>

--- a/src/AgentEval.RedTeam/RedTeam/Output/RedTeamOutputFormatter.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Output/RedTeamOutputFormatter.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
+using System.Globalization;
 namespace AgentEval.RedTeam.Output;
 
 /// <summary>
@@ -73,7 +74,7 @@ public class RedTeamOutputFormatter
             : (result.Passed ? "[PASS]" : "[FAIL]");
 
         var scoreColor = result.Passed ? _theme.Success : _theme.Failure;
-        WriteLine($"RedTeam: {scoreColor}{result.OverallScore:F1}%{_theme.Reset} {icon} {result.Verdict} " +
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"RedTeam: {scoreColor}{result.OverallScore:F1}%{_theme.Reset} {icon} {result.Verdict} ") +
             $"({result.TotalProbes} probes, {result.ResistedProbes} resisted)");
     }
 
@@ -96,9 +97,9 @@ public class RedTeamOutputFormatter
             ? (result.Passed ? "🛡️ " : "⚠️ ")
             : "";
 
-        WriteLine($"║  {icon}Overall Score: {scoreColor}{result.OverallScore:F1}%{_theme.Reset}");
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"║  {icon}Overall Score: {scoreColor}{result.OverallScore:F1}%{_theme.Reset}"));
         WriteLine($"║  Verdict: {_theme.StatusIcon(result.Passed, _options.UseEmoji)} {result.Verdict}");
-        WriteLine($"║  Duration: {result.Duration.TotalSeconds:F1}s | Agent: {result.AgentName}");
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"║  Duration: {result.Duration.TotalSeconds:F1}s | Agent: {result.AgentName}"));
         WriteLine($"║  Probes: {result.TotalProbes} total, {result.ResistedProbes} resisted, {result.SucceededProbes} compromised");
         WriteLine($"╠{border}╣");
     }
@@ -122,7 +123,7 @@ public class RedTeamOutputFormatter
             var rate = attack.TotalCount > 0
                 ? (double)attack.ResistedCount / attack.TotalCount
                 : 1.0;
-            var rateStr = $"{rate:P0}".PadRight(rateCol);
+            var rateStr = rate.ToString("P0", CultureInfo.InvariantCulture).PadRight(rateCol);
             var icon = _theme.RateIcon(rate, _options.UseEmoji);
 
             var severityStr = _theme.Colorize(attack.Severity.ToString(), attack.Severity);


### PR DESCRIPTION
- The system locale uses e.g. , as decimal separator instead of .
- fixed all affected classes/locations which e.g. produced 0.95 instead of 0,95 on comma-locale systems.

## Description

locale specific settings where not handeled

## Motivation and Context

need for running also in other countries

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Existing unit tests pass
- [ ] Added new unit tests
- [ ] Tested manually (describe below)

**Test Configuration**:
- .NET version(s):
- OS:

**Test Details**:
test run 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the code style of this project
- [ ] I have added XML documentation for new public APIs
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] My changes generate no new compiler warnings
- [x] I have checked for breaking changes
- [x] I agree that my contributions are licensed under the MIT License and I have the right to submit this work (see [CONTRIBUTING.md](CONTRIBUTING.md))

## Screenshots (if applicable)

<!-- Add screenshots if your PR includes UI or visual changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here and provide migration guidance -->
