### PR TITLE
fix(cli): add --response/--response-file to `bench agentic`

### DIFF
--- a/src/AgentEval.Cli/Commands/BenchAgenticCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchAgenticCommand.cs
@@ -27,9 +27,10 @@ public static class BenchAgenticCommand
         string subject,
         string? rootOverride,
         string? inputText,
+        string? responseText = null,
         string? budgetTier = null,
         CancellationToken ct = default) =>
-        RunAsync(preset, subject, rootOverride, inputText, evaluatorOverride: null, budgetTier, ct);
+        RunAsync(preset, subject, rootOverride, inputText, responseText, evaluatorOverride: null, budgetTier, ct);
 
     /// <summary>Runs the bench agentic command with optional overrides (used in tests).</summary>
     internal static async Task<int> RunAsync(
@@ -37,6 +38,7 @@ public static class BenchAgenticCommand
         string subject,
         string? rootOverride,
         string? inputText,
+        string? responseText,
         IEvaluator? evaluatorOverride,
         string? budgetTier = null,
         CancellationToken ct = default)
@@ -116,11 +118,27 @@ public static class BenchAgenticCommand
         // ── Build input ──────────────────────────────────────────────────────
         var query = inputText ??
             "Search for the latest quarterly earnings report for ACME Corp and summarize the key financial metrics.";
-        var agentResponse =
-            "I'll help you find the quarterly earnings report for ACME Corp. " +
-            "Based on the retrieved data, here are the key financial metrics: " +
-            "Revenue grew 12% year-over-year to $4.2B, operating margin was 18.3%, " +
-            "and EPS was $2.47, beating consensus estimates by $0.12.";
+        string agentResponse;
+        if (!string.IsNullOrWhiteSpace(responseText))
+        {
+            agentResponse = responseText;
+        }
+        else
+        {
+            // No real response supplied: grade a built-in FIXTURE. Warn loudly — the
+            // produced evidence does NOT reflect the named subject agent. Mirrors the
+            // gdpr / eu-ai-act fixture-warning behaviour so agentic can grade a real
+            // agent's answer via --response / --response-file (was previously hardcoded).
+            agentResponse =
+                "I'll help you find the quarterly earnings report for ACME Corp. " +
+                "Based on the retrieved data, here are the key financial metrics: " +
+                "Revenue grew 12% year-over-year to $4.2B, operating margin was 18.3%, " +
+                "and EPS was $2.47, beating consensus estimates by $0.12.";
+            Console.Error.WriteLine(
+                "[bench agentic] WARNING: no --response/--response-file supplied — grading a built-in " +
+                "FIXTURE response, not a real agent output. The produced evidence does NOT reflect subject " +
+                $"'{subject}'. Pass --response-file <path> (or --response \"...\") with the agent's actual answer.");
+        }
         var evalInput = new EvalInput(Query: query, Response: agentResponse);
 
         // ── Run benchmark ────────────────────────────────────────────────────

--- a/src/AgentEval.Cli/Program.cs
+++ b/src/AgentEval.Cli/Program.cs
@@ -188,12 +188,16 @@ var benchAgenticPresetOpt = new Option<string?>("--preset") { Description = Pres
 var benchAgenticSubjectOpt = new Option<string?>("--subject") { Description = "Subject name. REQUIRED — no default; previously defaulted to 'default-agent'." };
 var benchAgenticRootOpt = new Option<string?>("--root") { Description = "Workspace root path (default: auto-detected)" };
 var benchAgenticInputOpt = new Option<string?>("--input") { Description = "Agent input text for the evaluation (default: built-in fixture)" };
+var benchAgenticResponseOpt = new Option<string?>("--response") { Description = "The agent's actual RESPONSE to grade. If omitted, a built-in fixture is graded and a warning is emitted (the evidence then reflects no real agent)." };
+var benchAgenticResponseFileOpt = new Option<string?>("--response-file") { Description = "Path to a file containing the agent's actual response to grade (alternative to --response, for multi-line output)." };
 var benchAgenticBudgetTierOpt = new Option<string?>("--budget-tier") { Description = "Budget tier filter: trivial | low | medium | high | all (default: all). Components with a cost tier above the budget are filtered out and remaining weights are renormalized. Use 'low' or 'medium' for fast feedback loops; 'all' for full audit runs." };
 var benchAgenticCmd = new Command("agentic", "Run the agentic behavior benchmark");
 benchAgenticCmd.Add(benchAgenticPresetOpt);
 benchAgenticCmd.Add(benchAgenticSubjectOpt);
 benchAgenticCmd.Add(benchAgenticRootOpt);
 benchAgenticCmd.Add(benchAgenticInputOpt);
+benchAgenticCmd.Add(benchAgenticResponseOpt);
+benchAgenticCmd.Add(benchAgenticResponseFileOpt);
 benchAgenticCmd.Add(benchAgenticBudgetTierOpt);
 benchAgenticCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
 {
@@ -206,8 +210,10 @@ benchAgenticCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) 
     }
     var root = parseResult.GetValue(benchAgenticRootOpt);
     var input = parseResult.GetValue(benchAgenticInputOpt);
+    var response = await ResolveBenchResponseAsync(parseResult.GetValue(benchAgenticResponseOpt), parseResult.GetValue(benchAgenticResponseFileOpt), ct);
+    if (response.Error) return 1;
     var budgetTier = parseResult.GetValue(benchAgenticBudgetTierOpt);
-    return await BenchAgenticCommand.RunAsync(preset, subject, root, input, budgetTier, ct);
+    return await BenchAgenticCommand.RunAsync(preset, subject, root, input, response.Text, budgetTier, ct);
 });
 // bench agentic calibrate
 var agenticCalibrateRootOpt = new Option<string?>("--root") { Description = "Workspace root path (default: current directory)" };

--- a/tests/AgentEval.Tests/Cli/BenchAgenticCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/BenchAgenticCommandTests.cs
@@ -84,6 +84,7 @@ public class BenchAgenticCommandTests : IDisposable
             subject: "AgenticGateTestAgent",
             rootOverride: _root,
             inputText: null,
+            responseText: null,
             evaluatorOverride: null,                            // exercise the env-gate path
             budgetTier: null);
         Assert.Equal(2, exit);
@@ -101,6 +102,7 @@ public class BenchAgenticCommandTests : IDisposable
             subject: "AgenticPartialAgent",
             rootOverride: _root,
             inputText: null,
+            responseText: null,
             evaluatorOverride: null,
             budgetTier: null);
         Assert.Equal(2, exit);
@@ -124,6 +126,7 @@ public class BenchAgenticCommandTests : IDisposable
             subject: "AgenticTelemetryAgent",
             rootOverride: _root,
             inputText: null,
+            responseText: null,
             evaluatorOverride: new PassingStubEvaluator(),
             budgetTier: null);
 
@@ -150,6 +153,7 @@ public class BenchAgenticCommandTests : IDisposable
             subject: "MissingWorkspaceAgent",
             rootOverride: noWorkspaceRoot,
             inputText: null,
+            responseText: null,
             evaluatorOverride: new PassingStubEvaluator(),
             budgetTier: null);
 


### PR DESCRIPTION
## Description

Adds `--response` and `--response-file` support to `agenteval bench agentic`.

Previously, `bench agentic` always evaluated a hardcoded fixture response about ACME Corp. With this change:

- `--response` evaluates the supplied response text.
- `--response-file` evaluates the response loaded from a file.
- If neither option is supplied, the command keeps the existing fixture fallback but now prints an explicit warning that the evidence does not reflect the named subject.

This mirrors the existing behavior already used by `bench gdpr` and `bench eu-ai-act`.

## Motivation and Context

`bench agentic` could not evaluate a real agent's actual answer from the CLI. Every run graded the same built-in sample response, regardless of the selected subject or input.

That made the generated evidence misleading for integrations that need to validate real agent behavior. Consumers had to either duplicate the CLI plumbing in a custom harness or accept evidence that did not reflect the subject agent.

This PR brings `bench agentic` to parity with the other benchmark commands while preserving backward compatibility.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Existing unit tests pass
- [ ] Added new unit tests
- [x] Tested manually (describe below)

**Test Configuration**:
- .NET version(s): .NET 10 SDK pinned in `global.json`
- OS: Windows

**Test Details**:

Built the CLI project standalone:

```powershell
dotnet build src/AgentEval.Cli/AgentEval.Cli.csproj -c Debug --no-dependencies
```

Result: build succeeded with 0 errors.

Manually tested both CLI paths with `AGENTEVAL_ALLOW_STUB_JUDGE=1`:

- With `--response`: the command evaluates the supplied text and does not print the fixture warning.
- Without `--response` or `--response-file`: the command falls back to the built-in fixture and prints the explicit warning.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added XML documentation for new public APIs
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests pass
- [x] My changes generate no new compiler warnings
- [x] I have checked for breaking changes
- [x] I agree that my contributions are licensed under the MIT License and I have the right to submit this work (see [CONTRIBUTING.md](CONTRIBUTING.md))

## Screenshots (if applicable)

Not applicable.

## Additional Notes

No changes were made to `AgenticBenchmark`, `AgenticBenchmarkRunner`, or evaluator behavior. This PR only wires CLI input handling for `bench agentic`.

Existing callers that do not pass `--response` or `--response-file` still evaluate the same fixture response as before. The only behavior change in that path is the new warning.

## Breaking Changes

None.
