### PR TITLE
Community: locale-invariant formatting + DocFX build fixes (thanks @bmerkle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Locale-dependent number/currency formatting** — scores, durations, costs and CI/exporter
+  output now format with `CultureInfo.InvariantCulture`, so a comma-decimal system locale no
+  longer emits `0,95` instead of `0.95` (which corrupted CSV/JSON/XML output). Thanks to our
+  first community contributor **[Bernhard Merkle (@bmerkle)](https://github.com/bmerkle)** (#20).
+
+### Documentation
+- **DocFX build warnings** — removed dead markdown links to the (gitignored) `strategy/`
+  directory from ADR-014/015/016 and the extensibility guide, and mapped `samples/**/*.cs`
+  as a DocFX resource so sample cross-references resolve. Thanks to **@bmerkle** (#18).
+
 ## [0.12.0-beta] - 2026-06-14
 
 ### Dependencies — Microsoft Agent Framework 1.10.0 upgrade

--- a/README.md
+++ b/README.md
@@ -632,6 +632,12 @@ We welcome contributions! Please see:
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [SECURITY.md](SECURITY.md)
 
+### Contributors
+
+A heartfelt thank you to everyone who has contributed to AgentEval. 🙏
+
+- **[Bernhard Merkle (@bmerkle)](https://github.com/bmerkle)** — *first community contributor*, for making numeric/currency formatting culture-invariant (so scores render as `0.95`, not `0,95`, on comma-decimal locales) and for cleaning up the DocFX documentation build.
+
 ---
 
 ## Commercial & Enterprise 

--- a/docs/adr/014-dataset-pipeline-two-model-architecture.md
+++ b/docs/adr/014-dataset-pipeline-two-model-architecture.md
@@ -166,7 +166,7 @@ Introduce `TestCaseSource { FromFile(DatasetTestCase), Inline(TestCase) }` and h
 
 ## Implementation
 
-See [strategy/AgentEval-dataloader-Implementation-Review-and-Refinement.md](../../strategy/AgentEval-dataloader-Implementation-Review-and-Refinement.md) for the full implementation plan, specifically:
+The full implementation plan covers specifically:
 
 - **M3** â€” `DatasetTestCase` extended model + `ToTestCase()` adapter
 - **M4** â€” `RunBatchAsync` on `MAFEvaluationHarness` accepting `DatasetTestCase`

--- a/docs/adr/015-extension-registration-manual-vs-auto-discovery.md
+++ b/docs/adr/015-extension-registration-manual-vs-auto-discovery.md
@@ -3,7 +3,7 @@
 **Status:** Accepted  
 **Date:** 2026-02-25  
 **Decision Makers:** AgentEval Contributors  
-**Related:** [ADR-006](006-service-based-architecture-di.md), [Extensibility Strategy](../../strategy/AgentEval-Extensibility-Implementation-Review-and-Refinement.md), [Extensibility Guide](../extensibility.md)
+**Related:** [ADR-006](006-service-based-architecture-di.md), [Extensibility Guide](../extensibility.md)
 
 ---
 

--- a/docs/adr/016-monolith-modularization.md
+++ b/docs/adr/016-monolith-modularization.md
@@ -100,10 +100,4 @@ See `strategy/impl/` for detailed phase plans.
 
 ## References
 
-- [Strategy Document](../../strategy/AgentEval-Monolith-Modularization-ArchitectureRefactor.md)
-- [Phase 0: Fix Coupling Anomalies](../../strategy/impl/Phase-0-Fix-Coupling-Anomalies.md)
-- [Phase 1: Extract Abstractions](../../strategy/impl/Phase-1-Extract-Abstractions.md)
-- [Phase 2: Extract Core + DataLoaders](../../strategy/impl/Phase-2-Extract-Core-DataLoaders.md)
-- [Phase 3: Extract MAF + RedTeam](../../strategy/impl/Phase-3-Extract-MAF-RedTeam.md)
-- [Phase 4: Validate, Document, CI](../../strategy/impl/Phase-4-Validate-Document.md)
 - [ADR-006: Service-Based Architecture with DI](006-service-based-architecture-di.md)

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -23,6 +23,11 @@
     "resource": [
       {
         "files": ["images/**"]
+      },
+      {
+        "src": "../samples",
+        "files": ["**/*.cs"],
+        "dest": "samples"
       }
     ],
     "output": "_site",

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -756,7 +756,6 @@ public MyMetric(double threshold = 70)
 
 - [Architecture Overview](architecture.md) - Understanding the metric hierarchy
 - [Embedding Metrics](embedding-metrics.md) - Fast similarity evaluation
-- [Extensibility Strategy](../strategy/AgentEval-Extensibility-Implementation-Review-and-Refinement.md) - Full extensibility architecture and roadmap
 - [Benchmarks Guide](benchmarks.md) - Performance benchmarking
 - [Snapshots](snapshots.md) - Snapshot comparison with `ISnapshotComparer` interface
-- [Sample 26: Extensibility](https://github.com/AgentEvalHQ/AgentEval/blob/main/samples/AgentEval.Samples/Sample26_Extensibility.cs) - End-to-end extensibility demo with custom metrics, exporters, loaders, and attack types
+- [Sample 26: Extensibility](../samples/AgentEval.Samples/Sample26_Extensibility.cs) - End-to-end extensibility demo with custom metrics, exporters, loaders, and attack types

--- a/src/AgentEval.Abstractions/Calibration/CalibratedResult.cs
+++ b/src/AgentEval.Abstractions/Calibration/CalibratedResult.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace AgentEval.Calibration;
 
 /// <summary>
@@ -83,12 +85,12 @@ public record CalibratedResult
         get
         {
             var ciText = ConfidenceLower.HasValue && ConfidenceUpper.HasValue
-                ? $"95% CI: [{ConfidenceLower:F1}, {ConfidenceUpper:F1}]"
+                ? string.Create(CultureInfo.InvariantCulture, $"95% CI: [{ConfidenceLower:F1}, {ConfidenceUpper:F1}]")
                 : "CI: N/A";
             
             var consensusIcon = HasConsensus ? "✅" : "⚠️";
             
-            return $"Score: {Score:F1} | Agreement: {Agreement:F0}% | {ciText} | Consensus: {consensusIcon}";
+            return string.Create(CultureInfo.InvariantCulture, $"Score: {Score:F1} | Agreement: {Agreement:F0}% | {ciText} | Consensus: {consensusIcon}");
         }
     }
     
@@ -102,7 +104,7 @@ public record CalibratedResult
             var lines = new List<string> { "Judge Scores:" };
             foreach (var (judge, score) in JudgeScores.OrderByDescending(kvp => kvp.Value))
             {
-                lines.Add($"  {judge}: {score:F1}");
+                lines.Add(string.Create(CultureInfo.InvariantCulture, $"  {judge}: {score:F1}"));
             }
             return string.Join(Environment.NewLine, lines);
         }

--- a/src/AgentEval.Abstractions/Core/IAgentEvalLogger.cs
+++ b/src/AgentEval.Abstractions/Core/IAgentEvalLogger.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.Core;
@@ -115,7 +116,7 @@ public static class AgentEvalLoggerExtensions
     {
         if (logger.IsEnabled(LogLevel.Information))
         {
-            logger.Log(LogLevel.Information, $"Metric '{metricName}' completed: Score={score:F2}, Duration={duration.TotalMilliseconds:F0}ms");
+            logger.Log(LogLevel.Information, string.Create(CultureInfo.InvariantCulture, $"Metric '{metricName}' completed: Score={score:F2}, Duration={duration.TotalMilliseconds:F0}ms"));
         }
     }
 

--- a/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
+++ b/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Concurrent;
+using System.Globalization;
 
 namespace AgentEval.Models;
 
@@ -59,17 +60,17 @@ public class PerformanceMetrics
     {
         var parts = new List<string>
         {
-            $"Duration: {TotalDuration.TotalMilliseconds:F0}ms"
+            string.Create(CultureInfo.InvariantCulture, $"Duration: {TotalDuration.TotalMilliseconds:F0}ms")
         };
         
         if (TimeToFirstToken.HasValue)
-            parts.Add($"TTFT: {TimeToFirstToken.Value.TotalMilliseconds:F0}ms");
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"TTFT: {TimeToFirstToken.Value.TotalMilliseconds:F0}ms"));
         
         if (TotalTokens > 0)
             parts.Add($"Tokens: {TotalTokens}");
         
         if (EstimatedCost.HasValue)
-            parts.Add($"Cost: ${EstimatedCost:F4}");
+            parts.Add(string.Create(CultureInfo.InvariantCulture, $"Cost: ${EstimatedCost:F4}"));
         
         if (ToolCallCount > 0)
             parts.Add($"Tools: {ToolCallCount}");

--- a/src/AgentEval.Abstractions/Models/TestSummaryExtensions.cs
+++ b/src/AgentEval.Abstractions/Models/TestSummaryExtensions.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace AgentEval.Models;
 
 /// <summary>
@@ -121,7 +123,7 @@ public static class TestSummaryExtensions
             metadata["TotalDuration"] = summary.TotalDuration.ToString();
 
         if (summary.TotalCost > 0)
-            metadata["TotalCost"] = summary.TotalCost.ToString("F6");
+            metadata["TotalCost"] = summary.TotalCost.ToString("F6", CultureInfo.InvariantCulture);
 
         return metadata;
     }

--- a/src/AgentEval.Core/Assertions/PerformanceAssertions.cs
+++ b/src/AgentEval.Core/Assertions/PerformanceAssertions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using AgentEval.Models;
 
@@ -35,8 +36,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total duration to be under the specified maximum.",
                     metricName: "TotalDuration",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
                     suggestions: new[] 
                     { 
                         "Consider optimizing slow tool operations",
@@ -60,8 +61,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total duration to be at least the specified minimum.",
                     metricName: "TotalDuration",
-                    threshold: $"≥ {min.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"≥ {min.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalDuration.TotalMilliseconds:F0}ms"),
                     because: because));
         }
         return this;
@@ -93,8 +94,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected time to first token (TTFT) to be under the specified maximum.",
                     metricName: "TimeToFirstToken",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TimeToFirstToken.Value.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TimeToFirstToken.Value.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
                     suggestions: new[] 
                     { 
                         "TTFT is affected by model load time and prompt processing",
@@ -118,8 +119,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total token count to be under the specified maximum.",
                     metricName: "TotalTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.TotalTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalTokens:N0}"),
                     context: breakdown,
                     suggestions: new[] 
                     { 
@@ -144,8 +145,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected prompt tokens to be under the specified maximum.",
                     metricName: "PromptTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.PromptTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.PromptTokens:N0}"),
                     suggestions: new[] 
                     { 
                         "Shorten system prompt",
@@ -169,8 +170,8 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected completion tokens to be under the specified maximum.",
                     metricName: "CompletionTokens",
-                    threshold: $"< {max:N0}",
-                    measuredValue: $"{_metrics.CompletionTokens:N0}",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max:N0}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.CompletionTokens:N0}"),
                     suggestions: new[] 
                     { 
                         "Use max_tokens parameter to limit response length",
@@ -203,13 +204,13 @@ public class PerformanceAssertions
         if (_metrics.EstimatedCost!.Value > maxUsd)
         {
             var overage = _metrics.EstimatedCost.Value - maxUsd;
-            var breakdown = $"Prompt: {_metrics.PromptTokens:N0} tokens, Completion: {_metrics.CompletionTokens:N0} tokens";
+            var breakdown = string.Create(CultureInfo.InvariantCulture, $"Prompt: {_metrics.PromptTokens:N0} tokens, Completion: {_metrics.CompletionTokens:N0} tokens");
             AgentEvalScope.FailWith(
                 PerformanceAssertionException.Create(
                     "Expected estimated cost to be under the specified maximum.",
                     metricName: "EstimatedCost",
-                    threshold: $"< ${maxUsd:F4}",
-                    measuredValue: $"${_metrics.EstimatedCost.Value:F4} (exceeded by ${overage:F4})",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< ${maxUsd:F4}"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"${_metrics.EstimatedCost.Value:F4} (exceeded by ${overage:F4})"),
                     context: breakdown,
                     suggestions: new[] 
                     { 
@@ -247,9 +248,9 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected average tool execution time to be under the specified maximum.",
                     metricName: "AverageToolTime",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.AverageToolTime.TotalMilliseconds:F0}ms",
-                    context: $"Total tool time: {_metrics.TotalToolTime.TotalMilliseconds:F0}ms across {_metrics.ToolCallCount} call(s)",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.AverageToolTime.TotalMilliseconds:F0}ms"),
+                    context: string.Create(CultureInfo.InvariantCulture, $"Total tool time: {_metrics.TotalToolTime.TotalMilliseconds:F0}ms across {_metrics.ToolCallCount} call(s)"),
                     suggestions: new[] 
                     { 
                         "Optimize individual tool implementations",
@@ -287,9 +288,9 @@ public class PerformanceAssertions
                 PerformanceAssertionException.Create(
                     "Expected total tool execution time to be under the specified maximum.",
                     metricName: "TotalToolTime",
-                    threshold: $"< {max.TotalMilliseconds:F0}ms",
-                    measuredValue: $"{_metrics.TotalToolTime.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)",
-                    context: $"{_metrics.ToolCallCount} tool call(s), average: {_metrics.AverageToolTime.TotalMilliseconds:F0}ms",
+                    threshold: string.Create(CultureInfo.InvariantCulture, $"< {max.TotalMilliseconds:F0}ms"),
+                    measuredValue: string.Create(CultureInfo.InvariantCulture, $"{_metrics.TotalToolTime.TotalMilliseconds:F0}ms (exceeded by {overage.TotalMilliseconds:F0}ms)"),
+                    context: string.Create(CultureInfo.InvariantCulture, $"{_metrics.ToolCallCount} tool call(s), average: {_metrics.AverageToolTime.TotalMilliseconds:F0}ms"),
                     suggestions: new[] 
                     { 
                         "Reduce number of tool calls",

--- a/src/AgentEval.Core/Core/AgentEvalLoggerImplementations.cs
+++ b/src/AgentEval.Core/Core/AgentEvalLoggerImplementations.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.Core;
@@ -64,7 +65,7 @@ public sealed class ConsoleAgentEvalLogger : IAgentEvalLogger
         {
             var level = result.Passed ? LogLevel.Information : LogLevel.Warning;
             var icon = result.Passed ? "✓" : "✗";
-            WriteWithColor(level, $"[{DateTime.Now:HH:mm:ss}] {icon} {result.MetricName}: {result.Score:F2} - {result.Explanation}");
+            WriteWithColor(level, string.Create(CultureInfo.InvariantCulture, $"[{DateTime.Now:HH:mm:ss}] {icon} {result.MetricName}: {result.Score:F2} - {result.Explanation}"));
         }
     }
 

--- a/src/AgentEval.DataLoaders/Exporters/CsvExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/CsvExporter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using AgentEval.Core;
 using AgentEval.Models;
@@ -47,7 +48,7 @@ public class CsvExporter : IResultExporter
             var row = $"{EscapeCsvField(report.RunId)}," +
                      $"{EscapeCsvField(result.Name)}," +
                      $"{EscapeCsvField(result.Category ?? "")}," +
-                     $"{result.Score:F2}," +
+                     $"{result.Score.ToString("F2", CultureInfo.InvariantCulture)}," +
                      $"{result.Passed}," +
                      $"{result.Skipped}," +
                      $"{result.DurationMs}," +
@@ -58,7 +59,7 @@ public class CsvExporter : IResultExporter
             // Append metric score values
             foreach (var metric in metricNames)
             {
-                var value = result.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F2") : "";
+                var value = result.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F2", CultureInfo.InvariantCulture) : "";
                 row += $",{value}";
             }
             

--- a/src/AgentEval.DataLoaders/Exporters/JUnitXmlExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/JUnitXmlExporter.cs
@@ -119,11 +119,11 @@ public class JUnitXmlExporter : IResultExporter
                 {
                     await writer.WriteStartElementAsync(null, "failure", null);
                     await writer.WriteAttributeStringAsync(null, "message", null, 
-                        test.Error ?? $"Score {test.Score:F1} below threshold");
+                        test.Error ?? string.Create(CultureInfo.InvariantCulture, $"Score {test.Score:F1} below threshold"));
                     await writer.WriteAttributeStringAsync(null, "type", null, "AssertionError");
                     
                     var failureContent = new StringBuilder();
-                    failureContent.AppendLine($"Score: {test.Score:F1}/100");
+                    failureContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Score: {test.Score:F1}/100"));
                     if (!string.IsNullOrEmpty(test.Error))
                     {
                         failureContent.AppendLine(test.Error);
@@ -141,10 +141,10 @@ public class JUnitXmlExporter : IResultExporter
                 {
                     await writer.WriteStartElementAsync(null, "system-out", null);
                     var outputContent = new StringBuilder();
-                    outputContent.AppendLine($"Score: {test.Score:F1}/100");
+                    outputContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Score: {test.Score:F1}/100"));
                     foreach (var (metric, score) in test.MetricScores)
                     {
-                        outputContent.AppendLine($"{metric}: {score:F1}");
+                        outputContent.AppendLine(string.Create(CultureInfo.InvariantCulture, $"{metric}: {score:F1}"));
                     }
                     if (!string.IsNullOrEmpty(test.Output))
                     {

--- a/src/AgentEval.DataLoaders/Exporters/MarkdownExporter.cs
+++ b/src/AgentEval.DataLoaders/Exporters/MarkdownExporter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using AgentEval.Core;
 using AgentEval.Models;
@@ -50,8 +51,8 @@ public class MarkdownExporter : IResultExporter
         sb.AppendLine("## 🤖 AgentEval Results");
         sb.AppendLine();
         sb.AppendLine($"**Status:** {statusEmoji} {statusText}");
-        sb.AppendLine($"**Score:** {report.OverallScore:F1}/100");
-        sb.AppendLine($"**Tests:** {report.PassedTests}/{report.TotalTests} passed ({report.PassRate:F0}%)");
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**Score:** {report.OverallScore:F1}/100"));
+        sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**Tests:** {report.PassedTests}/{report.TotalTests} passed ({report.PassRate:F0}%)"));
         sb.AppendLine($"**Duration:** {FormatDuration(report.Duration)}");
         
         if (report.Agent?.Model != null)
@@ -76,7 +77,7 @@ public class MarkdownExporter : IResultExporter
             var status = test.Skipped ? "⏭️" : (test.Passed ? "✅" : "❌");
             var time = FormatDuration(TimeSpan.FromMilliseconds(test.DurationMs));
             
-            sb.AppendLine($"| {EscapeMarkdown(test.Name)} | {test.Score:F1} | {status} | {time} |");
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"| {EscapeMarkdown(test.Name)} | {test.Score:F1} | {status} | {time} |"));
         }
         
         // Failures section
@@ -89,7 +90,7 @@ public class MarkdownExporter : IResultExporter
             
             foreach (var failure in failures)
             {
-                sb.AppendLine($"**{EscapeMarkdown(failure.Name)}** (Score: {failure.Score:F1}/100)");
+                sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**{EscapeMarkdown(failure.Name)}** (Score: {failure.Score:F1}/100)"));
                 if (!string.IsNullOrEmpty(failure.Error))
                 {
                     sb.AppendLine($"- {EscapeMarkdown(failure.Error)}");
@@ -131,7 +132,7 @@ public class MarkdownExporter : IResultExporter
                 sb.Append($"| {EscapeMarkdown(test.Name)} |");
                 foreach (var metric in metricNames)
                 {
-                    var score = test.MetricScores.TryGetValue(metric, out var s) ? $"{s:F1}" : "-";
+                    var score = test.MetricScores.TryGetValue(metric, out var s) ? s.ToString("F1", CultureInfo.InvariantCulture) : "-";
                     sb.Append($" {score} |");
                 }
                 sb.AppendLine();
@@ -152,10 +153,10 @@ public class MarkdownExporter : IResultExporter
     private static string FormatDuration(TimeSpan duration)
     {
         if (duration.TotalMilliseconds < 1000)
-            return $"{duration.TotalMilliseconds:F0}ms";
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalMilliseconds:F0}ms");
         if (duration.TotalSeconds < 60)
-            return $"{duration.TotalSeconds:F1}s";
-        return $"{duration.TotalMinutes:F1}m";
+            return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalSeconds:F1}s");
+        return string.Create(CultureInfo.InvariantCulture, $"{duration.TotalMinutes:F1}m");
     }
 
     // Delegates to the centralised helper so there is a single Markdown-escape implementation

--- a/src/AgentEval.DataLoaders/Output/EvaluationOutputWriter.cs
+++ b/src/AgentEval.DataLoaders/Output/EvaluationOutputWriter.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using AgentEval.Core;
@@ -191,11 +192,11 @@ public class EvaluationOutputWriter
     {
         _output.WriteLine();
         _output.WriteLine("⏱️  Performance:");
-        _output.WriteLine($"   Total Duration: {performance.TotalDuration.TotalMilliseconds:F0}ms");
+        _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Total Duration: {performance.TotalDuration.TotalMilliseconds:F0}ms"));
 
         if (performance.TimeToFirstToken.HasValue)
         {
-            _output.WriteLine($"   Time to First Token: {performance.TimeToFirstToken.Value.TotalMilliseconds:F0}ms");
+            _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Time to First Token: {performance.TimeToFirstToken.Value.TotalMilliseconds:F0}ms"));
         }
 
         if (performance.TotalTokens > 0)
@@ -205,7 +206,7 @@ public class EvaluationOutputWriter
 
         if (performance.EstimatedCost > 0)
         {
-            _output.WriteLine($"   Est. Cost: ${performance.EstimatedCost:F4}");
+            _output.WriteLine(string.Create(CultureInfo.InvariantCulture, $"   Est. Cost: ${performance.EstimatedCost:F4}"));
         }
     }
 
@@ -231,7 +232,7 @@ public class EvaluationOutputWriter
         foreach (var call in sortedCalls)
         {
             var statusIcon = !call.HasError ? "✓" : "✗";
-            var duration = call.Duration?.TotalMilliseconds.ToString("F0") + "ms" ?? "?ms";
+            var duration = call.Duration?.TotalMilliseconds.ToString("F0", CultureInfo.InvariantCulture) + "ms" ?? "?ms";
             
             var line = new StringBuilder();
             line.Append($"   {statusIcon} [{call.Order}] {call.Name} ({duration})");

--- a/src/AgentEval.RedTeam/RedTeam/Models/RedTeamResult.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Models/RedTeamResult.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Globalization;
 using AgentEval.Models;
 
 namespace AgentEval.RedTeam;
@@ -188,9 +189,9 @@ public class RedTeamResult : IRedTeamResult
     {
         get
         {
-            var summary = $"{Verdict}: {SucceededProbes}/{TotalProbes} probes compromised " +
-                $"(Score: {OverallScore:F1}%, ConclusiveScore: {ConclusiveScore:F1}%, " +
-                $"Coverage: {Coverage:F1}%, Inconclusive: {InconclusiveProbes}/{TotalProbes})";
+            // Invariant-culture formatting so decimal scores render as "0.95" not "0,95" on comma-decimal locales (thanks @bmerkle).
+            var summary = string.Create(CultureInfo.InvariantCulture,
+                $"{Verdict}: {SucceededProbes}/{TotalProbes} probes compromised (Score: {OverallScore:F1}%, ConclusiveScore: {ConclusiveScore:F1}%, Coverage: {Coverage:F1}%, Inconclusive: {InconclusiveProbes}/{TotalProbes})");
 
             if (HasExecutionErrors)
                 summary += $" [!] {ErroredProbes} execution error(s)";

--- a/src/AgentEval.RedTeam/RedTeam/Output/RedTeamOutputFormatter.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Output/RedTeamOutputFormatter.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
+using System.Globalization;
 namespace AgentEval.RedTeam.Output;
 
 /// <summary>
@@ -75,7 +76,7 @@ public class RedTeamOutputFormatter
             : (result.Passed ? "[PASS]" : "[FAIL]");
 
         var scoreColor = result.Passed ? _theme.Success : _theme.Failure;
-        WriteLine($"RedTeam: {scoreColor}{result.OverallScore:F1}%{_theme.Reset} {icon} {result.Verdict} " +
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"RedTeam: {scoreColor}{result.OverallScore:F1}%{_theme.Reset} {icon} {result.Verdict} ") +
             $"({result.TotalProbes} probes, {result.ResistedProbes} resisted)");
     }
 
@@ -98,12 +99,12 @@ public class RedTeamOutputFormatter
             ? (result.Passed ? "🛡️ " : "⚠️ ")
             : "";
 
-        WriteLine($"║  {icon}Overall Score: {scoreColor}{result.OverallScore:F1}%{_theme.Reset}");
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"║  {icon}Overall Score: {scoreColor}{result.OverallScore:F1}%{_theme.Reset}"));
         WriteLine($"║  Verdict: {_theme.StatusIcon(result.Passed, _options.UseEmoji)} {result.Verdict}");
-        WriteLine($"║  Duration: {result.Duration.TotalSeconds:F1}s | Agent: {result.AgentName}");
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"║  Duration: {result.Duration.TotalSeconds:F1}s | Agent: {result.AgentName}"));
         WriteLine($"║  Probes: {result.TotalProbes} total, {result.ResistedProbes} resisted, {result.SucceededProbes} compromised, {result.InconclusiveProbes} inconclusive");
         // N-09: surface coverage + conclusive-only score so a green Verdict on a low-coverage scan is visibly caveated.
-        WriteLine($"║  Coverage: {result.Coverage:F0}% (conclusive) | Conclusive Score: {result.ConclusiveScore:F1}%");
+        WriteLine(string.Create(CultureInfo.InvariantCulture, $"║  Coverage: {result.Coverage:F0}% (conclusive) | Conclusive Score: {result.ConclusiveScore:F1}%"));
         // Review: a FailFast-truncated scan executed only part of its plan — say so, so the counts above are not read as the whole scan.
         if (result.WasTruncated)
             WriteLine($"║  {_theme.Warning}[TRUNCATED] FailFast stopped after {result.TotalProbes}/{result.PlannedProbes} probes; {result.SkippedProbes} skipped — coverage understated.{_theme.Reset}");
@@ -129,7 +130,7 @@ public class RedTeamOutputFormatter
             var rate = attack.TotalCount > 0
                 ? (double)attack.ResistedCount / attack.TotalCount
                 : 1.0;
-            var rateStr = $"{rate:P0}".PadRight(rateCol);
+            var rateStr = rate.ToString("P0", CultureInfo.InvariantCulture).PadRight(rateCol);
             var icon = _theme.RateIcon(rate, _options.UseEmoji);
 
             var severityStr = _theme.Colorize(attack.Severity.ToString(), attack.Severity);


### PR DESCRIPTION
## Recognizing our first community contributor — Bernhard Merkle (@bmerkle) 🎉

This PR lands the work from **@bmerkle**'s PRs #20 and #18, rebased onto current `main` (both had drifted over ~3.5 months and could not merge as-is). **Original authorship is preserved** on the two fix commits.

### What's included
1. **Locale-invariant number/currency formatting** (from #20, `699aadf`)
   - Wraps numeric/currency/duration/cost formatting in `CultureInfo.InvariantCulture` so a comma-decimal system locale no longer renders `0,95` instead of `0.95` — which corrupted CSV/JSON/JUnit-XML output and broke downstream parsing.
   - **Rebase notes:** two files he edited (`AgenticBenchmark.cs`, `PerformanceBenchmark.cs`) were removed with the legacy benchmark in v0.9, so those hunks were dropped. In `LLMJudgeEvaluator` the invariant parse already exists on `main`; in `RedTeamResult`/`RedTeamOutputFormatter` his intent was applied to the current (richer) output lines.

2. **DocFX build cleanup** (from #18)
   - Removes dead markdown links to the gitignored `strategy/` directory from ADR-014/015/016 + the extensibility guide (DocFX couldn't resolve them → build warnings), and maps `samples/**/*.cs` as a DocFX resource.
   - **Rebase notes:** his `benchmarks.md`/`redteam.md`/`workflows.md` edits were superseded by later doc rebuilds (e.g. `redteam.md` now uses absolute GitHub sample URLs), so those were not carried over.

3. **Recognition** — README *Contributors* section crediting Bernhard as **first community contributor**, plus an `[Unreleased]` CHANGELOG entry.

### Verification
- net8.0 full suite green: **5547 / 0**.
- No conflict markers; `strategy/` not staged.

Closes #20 · Closes #18 · Closes #21 · Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)