### PR TITLE
chore(release): 0.12.1-beta — first community-contributor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1-beta] - 2026-06-18
+
+> Our first community-contributor release — huge thanks to **@bmerkle** and **@Javierif**. 🎉
+
+### Added
+- **`agenteval bench agentic --response <text>` / `--response-file <path>`** — grade a supplied
+  agent response directly instead of the built-in stub. Thanks to our second community contributor
+  **[Javier Iniesta Fernández (@Javierif)](https://github.com/Javierif)** (#47).
+
 ### Fixed
 - **Locale-dependent number/currency formatting** — scores, durations, costs and CI/exporter
   output now format with `CultureInfo.InvariantCulture`, so a comma-decimal system locale no
@@ -17,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DocFX build warnings** — removed dead markdown links to the (gitignored) `strategy/`
   directory from ADR-014/015/016 and the extensibility guide, and mapped `samples/**/*.cs`
   as a DocFX resource so sample cross-references resolve. Thanks to **@bmerkle** (#18).
+- **Pre-release accuracy pass** — README MAF badge + compatibility table and the installation
+  docs now read MAF `1.10.0` / Microsoft.Extensions.AI `10.6.0` (the shipped versions); package
+  `RepositoryUrl`/`PackageProjectUrl` corrected to the canonical `AgentEvalHQ/AgentEval`; the
+  OWASP getting-started guide reconciled to the shipped 10/10 category coverage; and three
+  observability docs (Trace Fidelity, Guardrails, Auto-Audit) surfaced in the docs navigation.
 
 ## [0.12.0-beta] - 2026-06-14
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
          tag, so they version in lockstep. Keeping the number here (and nowhere else) makes that
          parity structural — there is no second number to drift. CI overrides this for releases
          via `dotnet pack -p:PackageVersion=<tag>`. -->
-    <Version>0.12.0-beta</Version>
+    <Version>0.12.1-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ We welcome contributions! Please see:
 A heartfelt thank you to everyone who has contributed to AgentEval. 🙏
 
 - **[Bernhard Merkle (@bmerkle)](https://github.com/bmerkle)** — *first community contributor*, for making numeric/currency formatting culture-invariant (so scores render as `0.95`, not `0,95`, on comma-decimal locales) and for cleaning up the DocFX documentation build.
+- **[Javier Iniesta Fernández (@Javierif)](https://github.com/Javierif)** — *second community contributor*, for adding `--response` / `--response-file` to `agenteval bench agentic`, so you can grade a supplied agent response instead of the built-in stub.
 
 ---
 


### PR DESCRIPTION
## 0.12.1-beta — first community-contributor release 🎉

Bumps the version and promotes the CHANGELOG ahead of tagging `v0.12.1-beta`.

### Highlights
- **@Javierif** — `agenteval bench agentic --response/--response-file` (#47).
- **@bmerkle** — locale-invariant numeric formatting (#20) + DocFX build cleanup (#18).
- Pre-release doc-accuracy pass (MAF 1.10.0 badges/compat, repo URL, OWASP 10/10, docs TOC).

### Changes
- `Directory.Build.props`: `0.12.0-beta` → `0.12.1-beta`.
- `CHANGELOG.md`: new dated `[0.12.1-beta]` section.
- `README.md`: Javier Iniesta Fernández added as second community contributor.

No code changes — version + docs only. Tag `v0.12.1-beta` after merge triggers the publish workflow (both `AgentEval` and `AgentEval.Cli` to NuGet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)