### PR TITLE
fix(perf): stabilize throughput-benchmark Duration timing (net8 Windows CI flake)

### DIFF
--- a/src/AgentEval.Evals.Performance/PerformanceBenchmark.cs
+++ b/src/AgentEval.Evals.Performance/PerformanceBenchmark.cs
@@ -233,8 +233,13 @@ public class PerformanceBenchmark
         
         LogProgress($"   Running throughput test for {duration.TotalSeconds}s with {concurrentRequests} concurrent requests...");
 
-        var startTime = DateTimeOffset.UtcNow;
-        
+        // High-resolution, monotonic timing. DateTimeOffset.UtcNow has ~15.6ms granularity on
+        // Windows, so a short (~200ms) measurement window can quantize to a measured Duration
+        // *below* the configured window and break the "Duration > configured" invariant
+        // (intermittent failure on the loaded net8.0 Windows CI leg). Stopwatch is high-resolution
+        // and never reads below true elapsed.
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
         // Create worker tasks
         var workers = Enumerable.Range(0, concurrentRequests).Select(async _ =>
         {
@@ -291,8 +296,8 @@ public class PerformanceBenchmark
             // Expected cancellation
         }
         
-        var endTime = DateTimeOffset.UtcNow;
-        var actualDuration = endTime - startTime;
+        stopwatch.Stop();
+        var actualDuration = stopwatch.Elapsed;
 
         return new ThroughputBenchmarkResult
         {


### PR DESCRIPTION
## What

`RunThroughputBenchmarkAsync` measured wall-clock `Duration` with `DateTimeOffset.UtcNow`, whose **~15.6ms granularity on Windows** can quantize a short (~200ms) window to a measured value *below* the configured window — intermittently breaking the `result.Duration > duration` invariant in `RunThroughputBenchmarkAsync_RpsUsesConfiguredDuration_NotWallClock` on the loaded **net8.0 Windows** CI leg.

## Why it's a flake, not a regression
- The **same commit passed on every other leg** (net8/9/10 Linux, net9/10 Windows) and on the PR run, and in the release workflow's own net10 test gate.
- **RPS is unaffected** — production divides by the *configured* duration (`completedRequests / duration.TotalSeconds`), which is exact. The published `0.12.1-beta` logic is correct.

## Fix
Measure the overall duration with a high-resolution, monotonic `Stopwatch` (never reads below true elapsed). This is also a small accuracy improvement to the reported `Duration`.

**Verification:** ran the test **25/25 green** locally on net8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)