### PR TITLE
chore(release): 0.12.2-beta — throughput-benchmark timing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2-beta] - 2026-06-18
+
+### Fixed
+- **Throughput-benchmark timing** — `PerformanceBenchmark.RunThroughputBenchmarkAsync` now measures
+  the reported `Duration` with a high-resolution `Stopwatch` instead of `DateTimeOffset.UtcNow`
+  (~15.6 ms granularity on Windows), improving `Duration` accuracy and removing an intermittent
+  net8.0/Windows CI flake. Requests-per-second was unaffected — it divides by the configured window.
+
 ## [0.12.1-beta] - 2026-06-18
 
 > Our first community-contributor release — huge thanks to **@bmerkle** and **@Javierif**. 🎉

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
          tag, so they version in lockstep. Keeping the number here (and nowhere else) makes that
          parity structural — there is no second number to drift. CI overrides this for releases
          via `dotnet pack -p:PackageVersion=<tag>`. -->
-    <Version>0.12.1-beta</Version>
+    <Version>0.12.2-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>


### PR DESCRIPTION
Patch release on top of green CI.

- Version `0.12.1-beta` → `0.12.2-beta`.
- CHANGELOG `[0.12.2-beta]` — carries the Stopwatch timing fix (#54) that removed the intermittent net8.0/Windows CI flake in the throughput benchmark and improves `Duration` accuracy.

No functional change to RPS or any shipped evaluator behaviour. Tag `v0.12.2-beta` after merge triggers publish of both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)