### PR TITLE
refactor(redteam): injectable TimeProvider for multi-turn timeouts (deterministic timing tests)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,6 +62,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" /><!-- Deferred: upgrade to 3.x requires xunit v3 migration (tracked issue) -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="Verify.Xunit" Version="28.8.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" /><!-- FakeTimeProvider: deterministic clock for timeout tests (test-only) -->
     <!-- PDF parser used only by test-side assertions (plan-13 T4.1b item 9).
          Lightweight (~500 KB), MIT-licensed; pulled in with PrivateAssets="all"
          in the test csproj so it doesn't leak into any shipped surface. -->

--- a/src/AgentEval.RedTeam/RedTeam/Models/ScanOptions.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Models/ScanOptions.cs
@@ -121,6 +121,15 @@ public class ScanOptions
     public IChatClient? JudgeClient { get; init; }
 
     /// <summary>
+    /// Time source for multi-turn timing — the per-turn timeout (<see cref="TimeoutPerTurn"/>) and the
+    /// conversation-duration clock (<see cref="MaxConversationDuration"/>) in <c>TurnOrchestrator</c>. Defaults to
+    /// <see cref="System.TimeProvider.System"/> (real wall-clock); tests inject a <c>FakeTimeProvider</c> to drive
+    /// those timeouts deterministically (no real waits, no load-sensitive flakes). Like <see cref="JudgeClient"/>
+    /// this is a runtime object, never serialized.
+    /// </summary>
+    public TimeProvider TimeProvider { get; init; } = TimeProvider.System;
+
+    /// <summary>
     /// ADR-021 (Phase B.1) / ADR-023 (B.3 flip, 2026-06-22): how the <see cref="JudgeClient"/> participates in grading.
     /// <see cref="JudgeMode.Primary"/> (NOW the default) routes Semantic + Verbal-evidence probes to the judge — the
     /// Composite Judges (<see cref="DecomposedGraders"/>) where one exists, else the single judge — as the primary grader,

--- a/src/AgentEval.RedTeam/RedTeam/MultiTurn/TurnOrchestrator.cs
+++ b/src/AgentEval.RedTeam/RedTeam/MultiTurn/TurnOrchestrator.cs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
-using System.Diagnostics;
 using AgentEval.Core;       // IEvaluableAgent, AgentResponse
 using AgentEval.Testing;    // Turn
 
@@ -75,7 +74,7 @@ public sealed class TurnOrchestrator
         var reason = "max turns reached without success";
         var truncated = true;
         AgentResponse? last = null;
-        var sw = Stopwatch.StartNew();
+        var startTs = _options.TimeProvider.GetTimestamp();   // injectable clock (FakeTimeProvider in tests) — see ScanOptions.TimeProvider
         var maxTurns = Math.Max(1, attack.MaxTurns);
 
         for (var i = 0; i < maxTurns; i++)
@@ -97,7 +96,13 @@ public sealed class TurnOrchestrator
             // LLM (PAIR / attacker-driven Crescendo) cannot silently burn the whole conversation budget. (Scripted
             // ladders never await an LLM here, so they are unaffected.)
             using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            turnCts.CancelAfter(_options.TimeoutPerTurn);
+            // Per-turn budget via the injectable TimeProvider (real wall-clock in prod; a FakeTimeProvider drives it
+            // deterministically in tests). Equivalent to CancelAfter(TimeoutPerTurn) under TimeProvider.System. The
+            // timer is declared AFTER turnCts so `using` disposes it FIRST (stops the timer before the CTS is gone),
+            // and the callback guards a disposed CTS so an in-flight fire during disposal can't throw.
+            using var turnTimer = _options.TimeProvider.CreateTimer(
+                static s => { try { ((CancellationTokenSource)s!).Cancel(); } catch (ObjectDisposedException) { } },
+                turnCts, _options.TimeoutPerTurn, Timeout.InfiniteTimeSpan);
 
             string? userMessage;
             try
@@ -210,7 +215,7 @@ public sealed class TurnOrchestrator
                 break;
             }
 
-            if (_options.MaxConversationDuration > TimeSpan.Zero && sw.Elapsed >= _options.MaxConversationDuration)
+            if (_options.MaxConversationDuration > TimeSpan.Zero && _options.TimeProvider.GetElapsedTime(startTs) >= _options.MaxConversationDuration)
             {
                 reason = $"max conversation duration ({_options.MaxConversationDuration.TotalSeconds:F0}s) reached";
                 truncated = true;

--- a/tests/AgentEval.Tests/AgentEval.Tests.csproj
+++ b/tests/AgentEval.Tests/AgentEval.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+
     <!-- Mvc.Testing 10.0 only available for net10.0; conditional so the test project
          can keep multi-targeting net8.0/net9.0/net10.0 for the rest of the suite. -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Condition="'$(TargetFramework)' == 'net10.0'" />

--- a/tests/AgentEval.Tests/RedTeam/MultiTurn/MultiTurnOrchestrationTests.cs
+++ b/tests/AgentEval.Tests/RedTeam/MultiTurn/MultiTurnOrchestrationTests.cs
@@ -7,6 +7,7 @@ using AgentEval.RedTeam.Attacks;
 using AgentEval.RedTeam.Evaluators;
 using AgentEval.Testing;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Time.Testing;   // FakeTimeProvider — deterministic per-turn-timeout tests
 using EvaluationResult = AgentEval.RedTeam.EvaluationResult;
 
 namespace AgentEval.Tests.RedTeam.MultiTurn;
@@ -83,6 +84,27 @@ public class MultiTurnOrchestrationTests
             public IReadOnlyList<Turn> History => [];
             public async Task<AgentResponse> SendAsync(string userMessage, CancellationToken ct = default)
             { await Task.Delay(delay, ct); return new AgentResponse { Text = "late" }; }
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+
+    /// <summary>Conversable agent that ADVANCES a <see cref="FakeTimeProvider"/> by <c>perTurn</c> on each call instead
+    /// of really sleeping — so per-turn-timeout / conversation-duration tests are deterministic and instant (no
+    /// wall-clock race, no load-sensitive CI flake). Pair with <c>ScanOptions.TimeProvider = clock</c>.</summary>
+    private sealed class ClockAdvancingConvoAgent(FakeTimeProvider clock, TimeSpan perTurn) : IConversableAgent
+    {
+        public string Name => "clock-advancing";
+        public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken ct = default)
+        { clock.Advance(perTurn); return Task.FromResult(new AgentResponse { Text = "ok" }); }
+        public Task<IAgentConversation> StartConversationAsync(CancellationToken ct = default)
+            => Task.FromResult<IAgentConversation>(new Convo(clock, perTurn));
+
+        private sealed class Convo(FakeTimeProvider clock, TimeSpan perTurn) : IAgentConversation
+        {
+            public ConversationFidelity Fidelity => ConversationFidelity.Native;
+            public IReadOnlyList<Turn> History => [];
+            public Task<AgentResponse> SendAsync(string userMessage, CancellationToken ct = default)
+            { clock.Advance(perTurn); return Task.FromResult(new AgentResponse { Text = "ok" }); }
             public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         }
     }
@@ -501,9 +523,13 @@ public class MultiTurnOrchestrationTests
     [Fact]
     public async Task MaxConversationDuration_SoftStops_Truncated()
     {
+        // DETERMINISTIC via FakeTimeProvider: each turn advances 15ms; MaxConversationDuration=5ms → the soft-stop
+        // fires after the first completed turn (elapsed 15ms ≥ 5ms). TimeoutPerTurn stays at its large default so the
+        // per-turn cap can't fire first. Exercises the TimeProvider.GetElapsedTime path with no real waits.
+        var clock = new FakeTimeProvider();
         var attack = new EndlessAttack();
-        var agent = new DelayingConversableAgent(TimeSpan.FromMilliseconds(15));
-        var options = new ScanOptions { MaxConversationDuration = TimeSpan.FromMilliseconds(5) };
+        var agent = new ClockAdvancingConvoAgent(clock, TimeSpan.FromMilliseconds(15));
+        var options = new ScanOptions { MaxConversationDuration = TimeSpan.FromMilliseconds(5), TimeProvider = clock };
 
         var result = await new TurnOrchestrator(agent, options).RunAsync(attack, Seed, attack.GetEvaluator(), CancellationToken.None);
 
@@ -659,14 +685,14 @@ public class MultiTurnOrchestrationTests
     [Fact]
     public async Task PerTurnBudget_ResetsEachTurn_CumulativeOverBudgetStillCompletes()
     {
-        // Regression (documented past HIGH): the per-turn timeout RESETS each turn. Cumulative agent time
-        // (4 × 400ms = 1.6s) exceeds one TimeoutPerTurn (1400ms), yet every turn is well under budget → all 4 run.
-        // The per-turn HEADROOM is deliberately large (400ms work vs a 1400ms budget = 1s slack) so a loaded CI
-        // runner's scheduling spikes can't trip the per-turn timeout and flake this test (the 4-turn design caps the
-        // ratio near 4×, so robustness comes from absolute slack, not ratio).
+        // Regression (documented past HIGH): the per-turn timeout RESETS each turn. DETERMINISTIC via FakeTimeProvider —
+        // each turn advances the fake clock by 400ms (well under the 1400ms per-turn budget), so 4 × 400ms = 1.6s of
+        // "agent time" elapses cumulatively yet no single turn's timer fires → all 4 run. No real waits, no wall-clock
+        // race (this was the recurring net8/Windows CI flake; the injectable clock removes the flake class entirely).
+        var clock = new FakeTimeProvider();
         var attack = new FourTurnAttack();
-        var agent = new DelayingConversableAgent(TimeSpan.FromMilliseconds(400));
-        var options = new ScanOptions { TimeoutPerTurn = TimeSpan.FromMilliseconds(1400) };
+        var agent = new ClockAdvancingConvoAgent(clock, TimeSpan.FromMilliseconds(400));
+        var options = new ScanOptions { TimeoutPerTurn = TimeSpan.FromMilliseconds(1400), TimeProvider = clock };
 
         var result = await new TurnOrchestrator(agent, options)
             .RunAsync(attack, Seed, attack.GetEvaluator(), CancellationToken.None);


### PR DESCRIPTION
**Stacked on #58** (base = `chore/build-health-deflake-and-docs`). Merge #58 first; this then retargets to `main` cleanly.

The durable, systemic fix for the recurring multi-turn timing flake: thread .NET's `System.TimeProvider` through `TurnOrchestrator`'s timeout path so tests advance a **fake clock** instead of racing real wall-clock — removing the load-sensitive flake *class* for this component.

## Production (zero behavior change — default `TimeProvider.System`)
- `ScanOptions.TimeProvider` — new, defaults to `TimeProvider.System`; runtime-only (not serialized), exactly like `JudgeClient`.
- `TurnOrchestrator`:
  - `Stopwatch` → `TimeProvider.GetTimestamp()` / `GetElapsedTime()` (the `MaxConversationDuration` clock).
  - per-turn `CancelAfter(TimeoutPerTurn)` → a `TimeProvider.CreateTimer` that cancels `turnCts`. The timer is declared after `turnCts` so `using` disposes it **first** (stops it before the CTS is gone), and the callback guards a disposed CTS so a late fire can't throw.

## Tests (deterministic + instant)
- Adds `Microsoft.Extensions.TimeProvider.Testing` (official, test-only) → `FakeTimeProvider`.
- New `ClockAdvancingConvoAgent` advances the fake clock per turn instead of really sleeping.
- `PerTurnBudget_ResetsEachTurn…` (the recurring net8/Windows flake) and `MaxConversationDuration_SoftStops…` now drive the fake clock — **no real waits**.
- The three timeout-FIRES / outer-cancel tests stay on their robust real-timing (huge margins, never flaky); convertible to the same pattern later if desired.

## Verification
- Multi-turn suite **34/34 × 5 consecutive runs**, ~250 ms each (was ~1 s+ with real delays).
- Full RedTeam net8 **3401/0** — no regression from the production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGXTUkPBGWXgR7HqfSDsPX