### PR TITLE
chore(release): 0.13.1-beta — injectable clock + red-team docs refresh + sample + dep bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1933,7 +1933,15 @@ This release marks the transition from alpha to beta. The framework is now featu
 - `AgentEval.Tracing` (OTel + run artifacts) - planned
 - `AgentEval.Studio` (workflow visualizer / time-travel UI) - future
 
-[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.8.0-beta...HEAD
+[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.1-beta...HEAD
+[0.13.1-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.0-beta...v0.13.1-beta
+[0.13.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.12.2-beta...v0.13.0-beta
+[0.12.2-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.12.1-beta...v0.12.2-beta
+[0.12.1-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.12.0-beta...v0.12.1-beta
+[0.12.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.10.1-beta...v0.12.0-beta
+[0.10.1-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.10.0-beta...v0.10.1-beta
+[0.10.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.9.0-beta...v0.10.0-beta
+[0.9.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.8.1-beta...v0.9.0-beta
 [0.8.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.7.0-beta...v0.8.0-beta
 [0.7.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.6.0-beta...v0.7.0-beta
 [0.6.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.5.4-beta...v0.6.0-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1-beta] - 2026-06-28
+
+A maintenance release on top of the judge-primary grading flip. It adds an
+injectable clock for deterministic multi-turn timing, brings the red-team
+documentation in line with the v0.13 grading default, ships a paper /
+reproducibility companion sample, and folds in routine dependency bumps.
+**No grader-behaviour changes** — judge-primary Composite Judges shipped in
+0.13.0-beta and are unchanged here.
+
+### Added
+- **`ScanOptions.TimeProvider`** — an injectable `TimeProvider` (default
+  `TimeProvider.System`) used by `TurnOrchestrator` for per-turn timeout and
+  conversation-duration timing, so multi-turn timing can be driven
+  deterministically in tests via `FakeTimeProvider`. Runtime-only, not serialized
+  (mirrors `JudgeClient`).
+- **`AgentEval.SampleGraders` head-to-head runner** (`--head-to-head`) — scores a
+  gold-set corpus with the keyword oracle, a single LLM judge, a generic
+  composite, and the production task-specific decomposition on the same cases and
+  judge, emitting `verdicts.json` for the safety-asymmetric scorer (paper /
+  reproducibility companion; consumes public APIs only, modifies no product code).
+
+### Changed
+- **Red-team documentation** — `README.md` and `docs/redteam-whats-new.md` now
+  headline judge-primary grading + Composite Judges, replacing the stale
+  pre-flip "keyword-primary" narrative so the public docs match the shipped
+  default.
+
+### Fixed
+- **Flaky net8.0/Windows CI timing tests** — `TurnOrchestrator` now measures
+  elapsed time and arms per-turn timeouts through the injectable `TimeProvider`
+  instead of wall-clock `Stopwatch`/`CancelAfter`, removing load-sensitive
+  flakes; the two timing-sensitive multi-turn tests run on a deterministic
+  `FakeTimeProvider`. The throughput-benchmark `Duration` assertion was made
+  tolerant (the deterministic requests-per-second guard is unchanged).
+- **XML-doc warnings** — cleaned up stale `cref`/`paramref` references across the
+  codebase (documentation only, no behaviour change).
+
+### Dependencies
+- Bump the GitHub Actions group (2 updates).
+- Bump `react-router` 7.15.0 → 7.18.0 in the Mission Control SPA.
+
 ## [0.13.0-beta] - 2026-06-24
 
 ### Red-team grading: judge-primary by default + Composite Judges (ADR-021/022/023/024)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
          tag, so they version in lockstep. Keeping the number here (and nowhere else) makes that
          parity structural — there is no second number to drift. CI overrides this for releases
          via `dotnet pack -p:PackageVersion=<tag>`. -->
-    <Version>0.13.0-beta</Version>
+    <Version>0.13.1-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>


### PR DESCRIPTION
## What this is

Release-prep for **`v0.13.1-beta`** — a maintenance release that bundles everything merged to `main` since the `v0.13.0-beta` tag. **No grader-behaviour changes**: judge-primary Composite Judges shipped in 0.13.0-beta and are unchanged.

Bumps `Directory.Build.props` `<Version>` (single source of truth) and adds the `CHANGELOG.md` section. The actual tag + GitHub release (which auto-publishes to NuGet) is a **separate step after this merges**.

## What's bundled (already on main)

| PR | What | CHANGELOG section |
|----|------|-------------------|
| **#58** | `ScanOptions.TimeProvider` (injectable clock for deterministic multi-turn timing) + `SampleGraders` head-to-head runner + CI timing de-flake + XML-doc cleanup | Added / Fixed |
| **#60** | README + `redteam-whats-new.md` headline judge-primary + Composite Judges | Changed |
| **#56** | GitHub Actions group bump (2) | Dependencies |
| **#49** | `react-router` 7.15.0 → 7.18.0 (Mission Control SPA) | Dependencies |

## Notes for review
- Only two files change: `Directory.Build.props` (version) + `CHANGELOG.md`.
- The CHANGELOG intentionally carries exact version numbers and specifics — that's the canonical versioned record (the *narrative* docs guideline about avoiding numbers does not apply to the changelog).
- Nothing to build/behaviour-test beyond CI; the bundled code already passed CI on its own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)