### PR TITLE
chore(deps): upgrade Microsoft Agent Framework 1.10.0 → 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.13.1-beta] - 2026-06-28
 
-A maintenance release on top of the judge-primary grading flip. It adds an
-injectable clock for deterministic multi-turn timing, brings the red-team
-documentation in line with the v0.13 grading default, ships a paper /
-reproducibility companion sample, and folds in routine dependency bumps.
-**No grader-behaviour changes** — judge-primary Composite Judges shipped in
-0.13.0-beta and are unchanged here.
+A maintenance release on top of the judge-primary grading flip. It **upgrades
+Microsoft Agent Framework to 1.11.1**, adds an injectable clock for deterministic
+multi-turn timing, brings the red-team documentation in line with the v0.13
+grading default, ships a paper / reproducibility companion sample, and folds in
+routine dependency bumps. **No grader-behaviour changes** — judge-primary
+Composite Judges shipped in 0.13.0-beta and are unchanged here.
 
 ### Added
 - **`ScanOptions.TimeProvider`** — an injectable `TimeProvider` (default
@@ -44,8 +44,17 @@ reproducibility companion sample, and folds in routine dependency bumps.
 - **XML-doc warnings** — cleaned up stale `cref`/`paramref` references across the
   codebase (documentation only, no behaviour change).
 
+### Dependencies — Microsoft Agent Framework 1.11.1
+- **MAF 1.10.0 → 1.11.1** (central, via `Directory.Packages.props`): `Microsoft.Agents.AI`,
+  `Microsoft.Agents.AI.OpenAI`, `Microsoft.Agents.AI.Workflows`, `Microsoft.Agents.AI.Workflows.Generators`.
+  **No source changes were required** — the full net8.0 suite (6,619 tests) passes unchanged and
+  `maf-doctor` (v1.6.0) grades the tree clean of anti-pattern errors/warnings.
+- `Microsoft.Extensions.AI*` stays at **10.6.0** — MAF 1.11.1's declared dependency — and the
+  `OpenTelemetry.Api` **1.15.3** security pin (GHSA-g94r-2vxg-569j) remains valid, since the 1.11.1
+  Workflows packages still declare exactly that version.
+
 ### Dependencies
-- Bump the GitHub Actions group (2 updates).
+- Bump the GitHub Actions group (2 updates) + `actions/cache` 5 → 6.
 - Bump `react-router` 7.15.0 → 7.18.0 in the Mission Control SPA.
 
 ## [0.13.0-beta] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ Composite Judges shipped in 0.13.0-beta and are unchanged here.
 ### Dependencies — Microsoft Agent Framework 1.11.1
 - **MAF 1.10.0 → 1.11.1** (central, via `Directory.Packages.props`): `Microsoft.Agents.AI`,
   `Microsoft.Agents.AI.OpenAI`, `Microsoft.Agents.AI.Workflows`, `Microsoft.Agents.AI.Workflows.Generators`.
-  **No source changes were required** — the full net8.0 suite (6,619 tests) passes unchanged and
-  `maf-doctor` (v1.6.0) grades the tree clean of anti-pattern errors/warnings.
+  **No source changes were required** — the full net8.0 test suite passes unchanged and
+  `maf-doctor` grades the tree clean of anti-pattern errors/warnings.
 - `Microsoft.Extensions.AI*` stays at **10.6.0** — MAF 1.11.1's declared dependency — and the
   `OpenTelemetry.Api` **1.15.3** security pin (GHSA-g94r-2vxg-569j) remains valid, since the 1.11.1
   Workflows packages still declare exactly that version.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,10 @@
   
   <ItemGroup>
     <!-- Microsoft Agent Framework -->
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.10.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.11.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.11.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.11.1" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.11.1" />
     
     <!-- Microsoft Extensions AI -->
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
@@ -23,7 +23,7 @@
     <!-- SEC-13: Azure.AI.OpenAI is a direct ref of AgentEval.Cli (packed/published as a global
          dotnet tool), so a -beta dependency risks yank/unlist and API churn. It is pinned to beta
          deliberately: the only stable 2.x release on NuGet is 2.0.0 (Nov 2024), which predates the
-         API surface used by the Microsoft.Agents.AI 1.10.0 stack and AzureChatAgentFactory — there is
+         API surface used by the Microsoft.Agents.AI 1.11.1 stack and AzureChatAgentFactory — there is
          no recent GA to move to. Mitigations: (1) the CLI itself ships on the -prerelease channel,
          so a beta dependency is in-band; (2) the version is centrally pinned here (CPM) so it cannot
          float. ACTION: upgrade to a stable Azure.AI.OpenAI 2.x as soon as one ships (tracked, vNext). -->
@@ -31,9 +31,10 @@
     <PackageVersion Include="Azure.Identity" Version="1.18.0" />
     
     <!-- Core -->
-    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.8" /><!-- floor raised by Microsoft.Extensions.AI 10.6.0 (MAF 1.10.0) -->
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.8" /><!-- floor raised by Microsoft.Extensions.AI 10.6.0 (MAF 1.11.1 still depends on Extensions.AI 10.6.0) -->
     <PackageVersion Include="System.Memory.Data" Version="10.0.3" />
-    <!-- Security: pin to patch that resolves GHSA-g94r-2vxg-569j (transitive via MAF 1.10.0) -->
+    <!-- Security: pin to patch that resolves GHSA-g94r-2vxg-569j (transitive via MAF 1.11.1; the
+         1.11.1 Workflows packages still declare OpenTelemetry.Api 1.15.3, so this pin stays valid) -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.3" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ See the **[Getting Started Guide](docs/getting-started.md)** for a complete walk
 | [Red Team Security](docs/redteam.md) | Security probes, OWASP/MITRE coverage |
 | [Responsible AI](docs/ResponsibleAI.md) | Toxicity, bias, misinformation detection |
 | [Memory Evaluation](docs/memory-evaluation.md) | Retention, reach-back, temporal, LongMemEval, HTML reports |
-| [MAF Memory Integration](docs/maf-memory-integration.md) | How AgentEval.Memory maps to MAF 1.11.1 pipelines |
+| [MAF Memory Integration](docs/maf-memory-integration.md) | How AgentEval.Memory maps to MAF pipelines |
 | [Cross-Framework](docs/cross-framework.md) | Semantic Kernel, IChatClient adapters |
 | [CLI Tool](docs/cli.md) | Command-line evaluation guide |
 | [Migration Guide](docs/comparison.md) | Coming from Python/Node.js frameworks |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://joslat.github.io/AgentEval/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue" alt="Documentation" /></a>
   <a href="https://www.nuget.org/packages/AgentEval"><img src="https://img.shields.io/nuget/v/AgentEval.svg" alt="NuGet" /></a>
   <a href="https://github.com/AgentEvalHQ/AgentEval/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
-  <img src="https://img.shields.io/badge/MAF-1.11.1-blueviolet" alt="MAF 1.11.1" />
+  <a href="https://github.com/microsoft/agent-framework"><img src="https://img.shields.io/badge/built%20on-Microsoft%20Agent%20Framework-blueviolet" alt="Built on Microsoft Agent Framework" /></a>
   <img src="https://img.shields.io/badge/.NET-8.0%20|%209.0%20|%2010.0-512BD4" alt=".NET 8.0 | 9.0 | 10.0" />
 </p>
 
@@ -523,13 +523,7 @@ Every evidence document is cryptographically chained to its source run; `agentev
 dotnet add package AgentEval --prerelease
 ```
 
-**Compatibility:**
-
-| Dependency | Version |
-|------------|----------|
-| Microsoft Agent Framework (MAF) | `1.11.1` |
-| Microsoft.Extensions.AI | `10.6.0` |
-| .NET | 8.0, 9.0, 10.0 |
+**Compatibility:** .NET **8.0 / 9.0 / 10.0**. The Microsoft Agent Framework (MAF) and `Microsoft.Extensions.AI` versions ship centrally pinned in [`Directory.Packages.props`](Directory.Packages.props) — see the [CHANGELOG](CHANGELOG.md) for the exact versions in each release.
 
 **Single package, modular internals:**
 - `AgentEval.Abstractions` — Public contracts and interfaces

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://joslat.github.io/AgentEval/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-blue" alt="Documentation" /></a>
   <a href="https://www.nuget.org/packages/AgentEval"><img src="https://img.shields.io/nuget/v/AgentEval.svg" alt="NuGet" /></a>
   <a href="https://github.com/AgentEvalHQ/AgentEval/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License" /></a>
-  <img src="https://img.shields.io/badge/MAF-1.10.0-blueviolet" alt="MAF 1.10.0" />
+  <img src="https://img.shields.io/badge/MAF-1.11.1-blueviolet" alt="MAF 1.11.1" />
   <img src="https://img.shields.io/badge/.NET-8.0%20|%209.0%20|%2010.0-512BD4" alt=".NET 8.0 | 9.0 | 10.0" />
 </p>
 
@@ -527,7 +527,7 @@ dotnet add package AgentEval --prerelease
 
 | Dependency | Version |
 |------------|----------|
-| Microsoft Agent Framework (MAF) | `1.10.0` |
+| Microsoft Agent Framework (MAF) | `1.11.1` |
 | Microsoft.Extensions.AI | `10.6.0` |
 | .NET | 8.0, 9.0, 10.0 |
 
@@ -585,7 +585,7 @@ See the **[Getting Started Guide](docs/getting-started.md)** for a complete walk
 | [Red Team Security](docs/redteam.md) | Security probes, OWASP/MITRE coverage |
 | [Responsible AI](docs/ResponsibleAI.md) | Toxicity, bias, misinformation detection |
 | [Memory Evaluation](docs/memory-evaluation.md) | Retention, reach-back, temporal, LongMemEval, HTML reports |
-| [MAF Memory Integration](docs/maf-memory-integration.md) | How AgentEval.Memory maps to MAF 1.10.0 pipelines |
+| [MAF Memory Integration](docs/maf-memory-integration.md) | How AgentEval.Memory maps to MAF 1.11.1 pipelines |
 | [Cross-Framework](docs/cross-framework.md) | Semantic Kernel, IChatClient adapters |
 | [CLI Tool](docs/cli.md) | Command-line evaluation guide |
 | [Migration Guide](docs/comparison.md) | Coming from Python/Node.js frameworks |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ AgentEval is tested and compatible with:
 
 | Dependency | Version | Notes |
 |------------|---------|-------|
-| **Microsoft Agent Framework (MAF)** | `1.10.0` | Native integration — adapters, tool tracking, workflows |
+| **Microsoft Agent Framework (MAF)** | `1.11.1` | Native integration — adapters, tool tracking, workflows |
 | **Microsoft.Extensions.AI** | `10.6.0` | Universal `IChatClient` support |
 | **.NET 8.0** | ✅ Supported | LTS |
 | **.NET 9.0** | ✅ Supported | STS |
@@ -50,8 +50,8 @@ AgentEval ships as a single NuGet package with these key dependencies:
 
 | Package | Version | Purpose |
 |---------|---------|--------|
-| Microsoft.Agents.AI | 1.10.0 | Microsoft Agent Framework integration |
-| Microsoft.Agents.AI.Workflows | 1.10.0 | Workflow orchestration support |
+| Microsoft.Agents.AI | 1.11.1 | Microsoft Agent Framework integration |
+| Microsoft.Agents.AI.Workflows | 1.11.1 | Workflow orchestration support |
 | Microsoft.Extensions.AI | 10.6.0 | AI abstractions (IChatClient) |
 | Microsoft.Extensions.AI.Evaluation.Quality | 10.6.0 | Quality evaluation metrics |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,8 +36,8 @@ AgentEval is tested and compatible with:
 
 | Dependency | Version | Notes |
 |------------|---------|-------|
-| **Microsoft Agent Framework (MAF)** | `1.11.1` | Native integration — adapters, tool tracking, workflows |
-| **Microsoft.Extensions.AI** | `10.6.0` | Universal `IChatClient` support |
+| **Microsoft Agent Framework (MAF)** | Centrally pinned (`Directory.Packages.props`) | Native integration — adapters, tool tracking, workflows |
+| **Microsoft.Extensions.AI** | Centrally pinned (`Directory.Packages.props`) | Universal `IChatClient` support |
 | **.NET 8.0** | ✅ Supported | LTS |
 | **.NET 9.0** | ✅ Supported | STS |
 | **.NET 10.0** | ✅ Supported | Preview |
@@ -48,12 +48,14 @@ AgentEval is tested and compatible with:
 
 AgentEval ships as a single NuGet package with these key dependencies:
 
-| Package | Version | Purpose |
-|---------|---------|--------|
-| Microsoft.Agents.AI | 1.11.1 | Microsoft Agent Framework integration |
-| Microsoft.Agents.AI.Workflows | 1.11.1 | Workflow orchestration support |
-| Microsoft.Extensions.AI | 10.6.0 | AI abstractions (IChatClient) |
-| Microsoft.Extensions.AI.Evaluation.Quality | 10.6.0 | Quality evaluation metrics |
+| Package | Purpose |
+|---------|--------|
+| Microsoft.Agents.AI | Microsoft Agent Framework integration |
+| Microsoft.Agents.AI.Workflows | Workflow orchestration support |
+| Microsoft.Extensions.AI | AI abstractions (IChatClient) |
+| Microsoft.Extensions.AI.Evaluation.Quality | Quality evaluation metrics |
+
+> Exact pinned versions live in [`Directory.Packages.props`](https://github.com/AgentEvalHQ/AgentEval/blob/main/Directory.Packages.props); each release records its versions in the [CHANGELOG](https://github.com/AgentEvalHQ/AgentEval/blob/main/CHANGELOG.md).
 
 See [THIRD-PARTY-NOTICES.md](https://github.com/AgentEvalHQ/AgentEval/blob/main/THIRD-PARTY-NOTICES.md) for the complete dependency list with licenses.
 

--- a/docs/maf-memory-integration.md
+++ b/docs/maf-memory-integration.md
@@ -1,10 +1,10 @@
 # MAF ↔ AgentEval.Memory Concept Mapping
 
-This document explains how AgentEval.Memory evaluators work with Microsoft Agent Framework (MAF) 1.10.0's pipeline architecture, and why no code changes are needed.
+This document explains how AgentEval.Memory evaluators work with Microsoft Agent Framework (MAF) 1.11.1's pipeline architecture, and why no code changes are needed.
 
 ## Architecture Overlap
 
-MAF 1.10.0 and AgentEval.Memory both deal with conversation history and memory, but at different abstraction levels:
+MAF 1.11.1 and AgentEval.Memory both deal with conversation history and memory, but at different abstraction levels:
 
 - **MAF** manages memory *inside the agent pipeline*: `ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`
 - **AgentEval.Memory** *evaluates* memory quality from *outside*: it sends prompts, resets sessions, and measures retention
@@ -13,7 +13,7 @@ The two systems are complementary, not competing.
 
 ## Concept Mapping Table
 
-| AgentEval.Memory Concept | MAF 1.10.0 Equivalent | Relationship |
+| AgentEval.Memory Concept | MAF 1.11.1 Equivalent | Relationship |
 |---|---|---|
 | `ISessionResettableAgent.ResetSessionAsync()` | `agent.CreateSessionAsync()` (new session) | **Same effect.** `MAFAgentAdapter.ResetSessionAsync()` calls `CreateSessionAsync()` internally. New session = fresh conversation history. |
 | `IHistoryInjectableAgent.InjectConversationHistory()` | `ChatHistoryProvider.ProvideChatHistoryAsync()` | **Different purpose.** AgentEval injects *synthetic test data* to skip LLM setup calls. MAF providers manage *real* conversation history. `MAFAgentAdapter` implements both. |

--- a/docs/maf-memory-integration.md
+++ b/docs/maf-memory-integration.md
@@ -1,10 +1,10 @@
 # MAF ↔ AgentEval.Memory Concept Mapping
 
-This document explains how AgentEval.Memory evaluators work with Microsoft Agent Framework (MAF) 1.11.1's pipeline architecture, and why no code changes are needed.
+This document explains how AgentEval.Memory evaluators work with the Microsoft Agent Framework (MAF) pipeline architecture, and why no code changes are needed.
 
 ## Architecture Overlap
 
-MAF 1.11.1 and AgentEval.Memory both deal with conversation history and memory, but at different abstraction levels:
+MAF and AgentEval.Memory both deal with conversation history and memory, but at different abstraction levels:
 
 - **MAF** manages memory *inside the agent pipeline*: `ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`
 - **AgentEval.Memory** *evaluates* memory quality from *outside*: it sends prompts, resets sessions, and measures retention
@@ -13,7 +13,7 @@ The two systems are complementary, not competing.
 
 ## Concept Mapping Table
 
-| AgentEval.Memory Concept | MAF 1.11.1 Equivalent | Relationship |
+| AgentEval.Memory Concept | MAF Equivalent | Relationship |
 |---|---|---|
 | `ISessionResettableAgent.ResetSessionAsync()` | `agent.CreateSessionAsync()` (new session) | **Same effect.** `MAFAgentAdapter.ResetSessionAsync()` calls `CreateSessionAsync()` internally. New session = fresh conversation history. |
 | `IHistoryInjectableAgent.InjectConversationHistory()` | `ChatHistoryProvider.ProvideChatHistoryAsync()` | **Different purpose.** AgentEval injects *synthetic test data* to skip LLM setup calls. MAF providers manage *real* conversation history. `MAFAgentAdapter` implements both. |

--- a/docs/memory-evaluation.md
+++ b/docs/memory-evaluation.md
@@ -132,7 +132,7 @@ public class MemoryHealthCheck(IMemoryBenchmarkRunner runner) { /* … */ }
 
 ### 🔗 MAF Pipeline Compatibility
 
-AgentEval.Memory works **without modification** with MAF 1.10.0's pipeline (`ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`). It evaluates *behavior*, not *mechanism*. See [MAF Memory Integration](maf-memory-integration.md) for the concept-mapping table.
+AgentEval.Memory works **without modification** with MAF 1.11.1's pipeline (`ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`). It evaluates *behavior*, not *mechanism*. See [MAF Memory Integration](maf-memory-integration.md) for the concept-mapping table.
 
 ---
 
@@ -195,7 +195,7 @@ See [Sample G3 — Memory Scenarios](../samples/AgentEval.Samples/MemoryEvaluati
 
 ## See Also
 
-- [MAF Memory Integration](maf-memory-integration.md) — how AgentEval.Memory maps to MAF 1.10.0's pipeline (`AIContextProvider`, `CompactionStrategy`, `ChatHistoryProvider`)
+- [MAF Memory Integration](maf-memory-integration.md) — how AgentEval.Memory maps to MAF 1.11.1's pipeline (`AIContextProvider`, `CompactionStrategy`, `ChatHistoryProvider`)
 - [MAF 1.10.0 Upgrade Notes](maf-1.10.0-upgrade-plan.md) — the current repo-specific MAF upgrade reference
 - [Architecture](architecture.md) — where the Memory module fits
 - [Naming Conventions](naming-conventions.md) — `llm_*` / `code_*` / `embed_*` metric prefixes

--- a/docs/memory-evaluation.md
+++ b/docs/memory-evaluation.md
@@ -132,7 +132,7 @@ public class MemoryHealthCheck(IMemoryBenchmarkRunner runner) { /* … */ }
 
 ### 🔗 MAF Pipeline Compatibility
 
-AgentEval.Memory works **without modification** with MAF 1.11.1's pipeline (`ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`). It evaluates *behavior*, not *mechanism*. See [MAF Memory Integration](maf-memory-integration.md) for the concept-mapping table.
+AgentEval.Memory works **without modification** with MAF's pipeline (`ChatHistoryProvider`, `AIContextProvider`, `CompactionStrategy`). It evaluates *behavior*, not *mechanism*. See [MAF Memory Integration](maf-memory-integration.md) for the concept-mapping table.
 
 ---
 
@@ -195,8 +195,8 @@ See [Sample G3 — Memory Scenarios](../samples/AgentEval.Samples/MemoryEvaluati
 
 ## See Also
 
-- [MAF Memory Integration](maf-memory-integration.md) — how AgentEval.Memory maps to MAF 1.11.1's pipeline (`AIContextProvider`, `CompactionStrategy`, `ChatHistoryProvider`)
-- [MAF 1.10.0 Upgrade Notes](maf-1.10.0-upgrade-plan.md) — the current repo-specific MAF upgrade reference
+- [MAF Memory Integration](maf-memory-integration.md) — how AgentEval.Memory maps to MAF's pipeline (`AIContextProvider`, `CompactionStrategy`, `ChatHistoryProvider`)
+- [MAF 1.10.0 Upgrade Notes](maf-1.10.0-upgrade-plan.md) — historical record of the 1.3 → 1.10 MAF migration
 - [Architecture](architecture.md) — where the Memory module fits
 - [Naming Conventions](naming-conventions.md) — `llm_*` / `code_*` / `embed_*` metric prefixes
 

--- a/samples/AgentEval.TravelDemo.Evals/AgentEval.TravelDemo.Evals.csproj
+++ b/samples/AgentEval.TravelDemo.Evals/AgentEval.TravelDemo.Evals.csproj
@@ -10,7 +10,7 @@
 
     <!-- Eval harness for the TravelDemo agents/workflows. References the AgentEval libraries
          directly via ProjectReference (not the published NuGet package, which is still built on
-         MAF 1.3.0) so it tracks this repo's MAF 1.10.0 build in lockstep with AgentEval.TravelDemo.
+         MAF 1.3.0) so it tracks this repo's MAF 1.11.1 build in lockstep with AgentEval.TravelDemo.
          Package versions resolve from Directory.Packages.props (Central Package Management). -->
   </PropertyGroup>
 
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- MAF + Azure packages — versions resolve from Directory.Packages.props (MAF 1.10.0) -->
+    <!-- MAF + Azure packages — versions resolve from Directory.Packages.props (MAF 1.11.1) -->
     <PackageReference Include="Microsoft.Agents.AI" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" />
     <PackageReference Include="Azure.AI.OpenAI" />

--- a/samples/AgentEval.TravelDemo.Evals/AgentEval.TravelDemo.Evals.csproj
+++ b/samples/AgentEval.TravelDemo.Evals/AgentEval.TravelDemo.Evals.csproj
@@ -9,9 +9,10 @@
     <LangVersion>preview</LangVersion>
 
     <!-- Eval harness for the TravelDemo agents/workflows. References the AgentEval libraries
-         directly via ProjectReference (not the published NuGet package, which is still built on
-         MAF 1.3.0) so it tracks this repo's MAF 1.11.1 build in lockstep with AgentEval.TravelDemo.
-         Package versions resolve from Directory.Packages.props (Central Package Management). -->
+         directly via ProjectReference (not the published NuGet package, which lags behind on an
+         older MAF baseline) so it tracks this repo's current MAF build in lockstep with
+         AgentEval.TravelDemo. Package versions resolve from Directory.Packages.props (Central
+         Package Management). -->
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- MAF + Azure packages — versions resolve from Directory.Packages.props (MAF 1.11.1) -->
+    <!-- MAF + Azure packages — versions resolve from Directory.Packages.props (Central Package Management) -->
     <PackageReference Include="Microsoft.Agents.AI" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" />
     <PackageReference Include="Azure.AI.OpenAI" />

--- a/src/AgentEval.Cli/README.md
+++ b/src/AgentEval.Cli/README.md
@@ -4,7 +4,7 @@
 
 [![NuGet](https://img.shields.io/nuget/vpre/AgentEval.Cli.svg)](https://www.nuget.org/packages/AgentEval.Cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/AgentEvalHQ/AgentEval/blob/main/LICENSE)
-![MAF 1.10.0](https://img.shields.io/badge/MAF-1.10.0-blueviolet)
+![MAF 1.11.1](https://img.shields.io/badge/MAF-1.11.1-blueviolet)
 ![.NET 8.0 | 10.0](https://img.shields.io/badge/.NET-8.0%20|%2010.0-512BD4)
 
 Command-line interface for [AgentEval](https://github.com/AgentEvalHQ/AgentEval) — the comprehensive
@@ -25,7 +25,7 @@ same version from one pipeline.
 
 | Version     | MAF    | .NET      |
 |-------------|--------|-----------|
-| 0.12.0-beta | 1.10.0 | 8.0, 10.0 |
+| 0.13.1-beta | 1.11.1 | 8.0, 10.0 |
 
 > The tool multi-targets `net8.0` and `net10.0`; the dotnet-tool installer picks the highest
 > compatible runtime. The `mc serve` portal requires .NET 10.
@@ -181,7 +181,7 @@ agenteval eval --endpoint http://localhost:11434/v1 --model llama3 --dataset age
 
 - .NET 8.0 or .NET 10.0 (`mc serve` requires .NET 10.0)
 - An AI agent endpoint (Azure OpenAI, OpenAI, Ollama, or any OpenAI-compatible API) for `eval` / `redteam` / LLM-graded benchmarks
-- Built on Microsoft Agent Framework (MAF) 1.10.0 and [Microsoft.Extensions.AI](https://github.com/dotnet/extensions)
+- Built on Microsoft Agent Framework (MAF) 1.11.1 and [Microsoft.Extensions.AI](https://github.com/dotnet/extensions)
 
 ## Documentation
 

--- a/src/AgentEval.Cli/README.md
+++ b/src/AgentEval.Cli/README.md
@@ -4,7 +4,7 @@
 
 [![NuGet](https://img.shields.io/nuget/vpre/AgentEval.Cli.svg)](https://www.nuget.org/packages/AgentEval.Cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/AgentEvalHQ/AgentEval/blob/main/LICENSE)
-![MAF 1.11.1](https://img.shields.io/badge/MAF-1.11.1-blueviolet)
+[![Built on Microsoft Agent Framework](https://img.shields.io/badge/built%20on-Microsoft%20Agent%20Framework-blueviolet)](https://github.com/microsoft/agent-framework)
 ![.NET 8.0 | 10.0](https://img.shields.io/badge/.NET-8.0%20|%2010.0-512BD4)
 
 Command-line interface for [AgentEval](https://github.com/AgentEvalHQ/AgentEval) — the comprehensive
@@ -21,11 +21,9 @@ dotnet tool install --global AgentEval.Cli --prerelease
 ### Compatibility
 
 `AgentEval.Cli` ships in lockstep with the `AgentEval` library — both are released together at the
-same version from one pipeline.
-
-| Version     | MAF    | .NET      |
-|-------------|--------|-----------|
-| 0.13.1-beta | 1.11.1 | 8.0, 10.0 |
+same version from one pipeline. The pinned Microsoft Agent Framework / `Microsoft.Extensions.AI`
+versions for each release are recorded in the
+[CHANGELOG](https://github.com/AgentEvalHQ/AgentEval/blob/main/CHANGELOG.md).
 
 > The tool multi-targets `net8.0` and `net10.0`; the dotnet-tool installer picks the highest
 > compatible runtime. The `mc serve` portal requires .NET 10.

--- a/src/AgentEval.Cli/README.md
+++ b/src/AgentEval.Cli/README.md
@@ -181,7 +181,7 @@ agenteval eval --endpoint http://localhost:11434/v1 --model llama3 --dataset age
 
 - .NET 8.0 or .NET 10.0 (`mc serve` requires .NET 10.0)
 - An AI agent endpoint (Azure OpenAI, OpenAI, Ollama, or any OpenAI-compatible API) for `eval` / `redteam` / LLM-graded benchmarks
-- Built on Microsoft Agent Framework (MAF) 1.11.1 and [Microsoft.Extensions.AI](https://github.com/dotnet/extensions)
+- Built on Microsoft Agent Framework (MAF) and [Microsoft.Extensions.AI](https://github.com/dotnet/extensions)
 
 ## Documentation
 


### PR DESCRIPTION
## What

Upgrades **Microsoft Agent Framework 1.10.0 → 1.11.1** (latest), driven via **maf-doctor v1.6.0** per the repo's MAF workflow (`CLAUDE.md`).

## Verification (clean — no breaking changes for this repo)
- ✅ `maf-doctor doctor` grade **unchanged: B** — **0** anti-pattern errors, **0** warnings, before and after the bump.
- ✅ Core `net8.0` build: **0 errors** (`AgentEval.Cli`, which pulls the whole MAF surface).
- ✅ Full `net8.0` test suite: **6,619 passed / 0 failed**.
- ⚠️ `maf-doctor autofix-all` proposed exactly one rewrite — `ToolCall.Result` → `await ...` — which is a **false positive**: `.Result` here is the domain `ToolCallRecord.Result` property (sibling of `.Name`), not `Task<T>.Result`. **Reviewed and reverted**, not applied.

## Package decisions
- Bumped the four `Microsoft.Agents.AI*` packages → **1.11.1**.
- **`Microsoft.Extensions.AI*` stays at 10.6.0** — MAF 1.11.1's *declared* dependency is still 10.6.0 (not 10.7.0), so this keeps the matched/tested pair and avoids dragging in Tensors 10.0.9.
- **`OpenTelemetry.Api` 1.15.3 security pin stays** (GHSA-g94r-2vxg-569j) — the 1.11.1 Workflows packages still declare exactly 1.15.3.

## "Everywhere possible" sweep
Manifest comments · README + CLI README badges/compat tables · `docs/installation.md` · memory docs · `TravelDemo.Evals` csproj comments · CHANGELOG `[0.13.1-beta]` (folded in — release is staged but **not yet tagged**).
**Left untouched (intentional):** `docs/maf-1.10.0-upgrade-plan.md` (historical 1.3→1.10 record), CHANGELOG history, and the unrelated npm `@emnapi` 1.10.0.

## Release note
This rides into the **on-hold `v0.13.1-beta`** release. No tag/publish until the maintainer's go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)