### PR TITLE
chore(samples): bump NuGetConsumer + Tests to AgentEval 0.13.1-beta (latest published)

### DIFF
--- a/samples/AgentEval.NuGetConsumer.Tests/AgentEval.NuGetConsumer.Tests.csproj
+++ b/samples/AgentEval.NuGetConsumer.Tests/AgentEval.NuGetConsumer.Tests.csproj
@@ -19,10 +19,9 @@
 
   <ItemGroup>
     <!-- AgentEval — used directly for TestCase, EvaluationOptions, assertions, harness -->
-    <!-- P0-5 (Sprint 0): bumped 0.8.1-beta → 0.10.1-beta to track the latest shipped package
-         (was lagging two minor releases; the whole point of this project is to validate the
-         published-NuGet downstream surface). -->
-    <PackageReference Include="AgentEval" Version="0.10.1-beta" />
+    <!-- Tracks the LATEST shipped package (built on MAF 1.11.1) to validate the published-NuGet
+         downstream surface; kept in lockstep with AgentEval.NuGetConsumer's reference. -->
+    <PackageReference Include="AgentEval" Version="0.13.1-beta" />
     <!-- Security: explicit transitive pin (GHSA-g94r-2vxg-569j); CPM disabled in this project -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
 

--- a/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
+++ b/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
@@ -28,18 +28,19 @@
     <ProjectReference Include="../../src/AgentEval/AgentEval.csproj" />
     -->
     
-    <!-- NUGET: For validation (0.8.1-beta — security patch for GHSA-g94r-2vxg-569j on top of MAF 1.3.0) -->
-    <PackageReference Include="AgentEval" Version="0.8.1-beta" />
-    
-    <!-- Supporting packages with explicit versions (CPM disabled) -->
+    <!-- NUGET: For validation — track the LATEST published package (built on MAF 1.11.1). -->
+    <PackageReference Include="AgentEval" Version="0.13.1-beta" />
+
+    <!-- Supporting packages with explicit versions (CPM disabled) — aligned to AgentEval 0.13.1-beta's
+         dependency baseline (MAF 1.11.1 / Microsoft.Extensions.AI 10.6.0). -->
     <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
     <PackageReference Include="System.Memory.Data" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.5.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.11.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <!-- Security: explicit transitive pin (GHSA-g94r-2vxg-569j); CPM disabled in this project.
-         Note: AgentEval 0.8.1-beta already pins this, but downstream consumers without CPM
-         transitive pinning won't inherit it — keep this explicit until MAF 1.3.1 ships. -->
+         MAF 1.11.1 already brings OpenTelemetry.Api 1.15.3 transitively, but a CPM-disabled consumer
+         won't inherit transitive pinning — keep this explicit so the resolved version is unambiguous. -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     
     <!-- Semantic Kernel — for SK-native agent demo -->


### PR DESCRIPTION
## What

The two **external-consumer validation samples** were frozen on old published packages behind a "change after publishing" gate:
- `AgentEval.NuGetConsumer` → `AgentEval` **0.8.1-beta** (MAF 1.3.0, Extensions.AI 10.5.0)
- `AgentEval.NuGetConsumer.Tests` → `AgentEval` **0.10.1-beta**

That gate is now satisfied — **0.13.1-beta is live on NuGet** (MAF 1.11.1, with the GHSA-g94r-2vxg-569j fix built in). Bumped both to consume **0.13.1-beta** and aligned the CPM-disabled support pins to its baseline (**MAF 1.11.1 / Microsoft.Extensions.AI 10.6.0**). Kept the explicit `OpenTelemetry.Api` 1.15.3 pin (CPM-disabled consumers don't inherit transitive pinning).

## Validation (against the LIVE NuGet package — the point of these samples)
- ✅ `AgentEval.NuGetConsumer` builds clean (**0 errors**) against `AgentEval` 0.13.1-beta
- ✅ `AgentEval.NuGetConsumer.Tests` **9/9 green**

So the latest published package works correctly for an external consumer.

## Scope
Sample-only (`IsPackable=false`, excluded from `AgentEval.sln`) — no effect on any released artifact. This is the documented "B2" post-publish follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)