### PR TITLE
chore(release): 0.13.2-beta — live-agent compliance judging + judge-parse correctness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2-beta] - 2026-06-29
+
 ### Compliance: live-agent judging + a silent judge-parse correctness fix
 
 Community contribution — huge thanks to **[@Javierif](https://github.com/Javierif)**. 🙌
@@ -1975,7 +1977,8 @@ This release marks the transition from alpha to beta. The framework is now featu
 - `AgentEval.Tracing` (OTel + run artifacts) - planned
 - `AgentEval.Studio` (workflow visualizer / time-travel UI) - future
 
-[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.1-beta...HEAD
+[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.2-beta...HEAD
+[0.13.2-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.1-beta...v0.13.2-beta
 [0.13.1-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.13.0-beta...v0.13.1-beta
 [0.13.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.12.2-beta...v0.13.0-beta
 [0.12.2-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.12.1-beta...v0.12.2-beta

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
          tag, so they version in lockstep. Keeping the number here (and nowhere else) makes that
          parity structural — there is no second number to drift. CI overrides this for releases
          via `dotnet pack -p:PackageVersion=<tag>`. -->
-    <Version>0.13.1-beta</Version>
+    <Version>0.13.2-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>


### PR DESCRIPTION
## What

Release-prep for **`v0.13.2-beta`** — releases the work merged since 0.13.1-beta (PR #57, @Javierif):

- **Live-agent compliance judging** (`AgentScenarioEval`) — GDPR / EU AI Act benchmarks drive the real agent-under-test per scenario instead of grading one fixed `--response`.
- **Silent compliance-judge parse fix** (`snake_case` ↔ `camelCase` — every such verdict was parsing to score 0) + **`EvaluationFailed`** honesty primitive + **richer findings** + **red-team scan truncation-salvage**.

Bumps `Directory.Build.props` `<Version>` → `0.13.2-beta`, moves the CHANGELOG `[Unreleased]` entry under `[0.13.2-beta]`, and adds the reference-link def. Two files only.

## Notes
- The substantive code already merged + went through 6 Copilot review rounds on #57 (cancellation contract, culture parse, empty-response handling, evidence-gating privacy, schema validity, HTML rendering) — all green.
- The tag + GitHub release (which auto-publishes to NuGet) is a **separate step after this merges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)