### PR TITLE
feat(maf): hybrid Foundry+local evals — composer, AsEvalLeaf, MAF 1.12.0 + samples

### DIFF
--- a/AgentEval.sln
+++ b/AgentEval.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentEval.SampleGraders", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentEval.MafEvalLightPath", "samples\AgentEval.MafEvalLightPath\AgentEval.MafEvalLightPath.csproj", "{0552F952-E8B6-4D86-A265-7F6480E2E32D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentEval.MafEvalFoundryAlongsideLocal", "samples\AgentEval.MafEvalFoundryAlongsideLocal\AgentEval.MafEvalFoundryAlongsideLocal.csproj", "{27F909AB-1273-4C07-AFC9-486A52848C8A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -355,6 +357,18 @@ Global
 		{0552F952-E8B6-4D86-A265-7F6480E2E32D}.Release|x64.Build.0 = Release|Any CPU
 		{0552F952-E8B6-4D86-A265-7F6480E2E32D}.Release|x86.ActiveCfg = Release|Any CPU
 		{0552F952-E8B6-4D86-A265-7F6480E2E32D}.Release|x86.Build.0 = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|x64.Build.0 = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Debug|x86.Build.0 = Debug|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|x64.ActiveCfg = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|x64.Build.0 = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|x86.ActiveCfg = Release|Any CPU
+		{27F909AB-1273-4C07-AFC9-486A52848C8A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -384,5 +398,6 @@ Global
 		{5D802D5F-709B-467F-AA49-5E9B77239F28} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{0876E98A-6FE8-4809-B266-724E5558A748} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{0552F952-E8B6-4D86-A265-7F6480E2E32D} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{27F909AB-1273-4C07-AFC9-486A52848C8A} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 EndGlobal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into its branch and surfaces a provider report URL as branch evidence.
 - **`CircuitBreaker`** — a minimal consecutive-failure breaker (injectable clock) that skips a
   persistently-failing source fast.
+- **Sample** — `samples/AgentEval.MafEvalFoundryAlongsideLocal`: an end-to-end hybrid eval that scores one
+  MAF agent run with an AgentEval Composite Eval + Azure AI Foundry evals and renders both in one
+  source-tagged HTML report (Pattern A: MAF-native mix; Pattern B: `CompositeAgentEvaluator`).
 - **Docs** — a "several evaluators in one report" section in
   [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
+
+#### Changed
+- **Microsoft Agent Framework bumped to 1.12.0** (from 1.11.1) across the solution — no breaking changes
+  for AgentEval (full suite green on net8/9/10). The Foundry evals package
+  (`Microsoft.Agents.AI.Foundry`) has no stable release yet, so it's pinned to its `1.12.0-preview` and
+  referenced **only** by the hybrid sample; the core libraries remain provider-agnostic.
 
 ## [0.13.2-beta] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Microsoft Agent Framework bumped to 1.12.0** (from 1.11.1) across the solution — no breaking changes
   for AgentEval (full suite green on net8/9/10). The Foundry evals package
   (`Microsoft.Agents.AI.Foundry`) has no stable release yet, so it's pinned to its `1.12.0-preview` and
-  referenced **only** by the hybrid sample; the core libraries remain provider-agnostic.
+  referenced **only** by the samples (the standalone hybrid sample + the `AgentEval.Samples` H12/H13
+  benchmarks); the shipping libraries remain provider-agnostic.
 
 ## [0.13.2-beta] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Microsoft Agent Framework: hybrid evaluation (several evaluators, one report)
+
+#### Added
+- **`CompositeAgentEvaluator`** (`AgentEval.MAF.Evaluators`) — runs several MAF `IAgentEvaluator`s over
+  the same agent run **concurrently**, isolating each (a failing or slow source becomes a visible
+  "skipped" branch instead of losing the whole run), with an optional per-source timeout and an optional
+  `CircuitBreaker`. Pass it as a single evaluator to `agent.EvaluateAsync` — for example an AgentEval
+  composite alongside any other provider's evaluator (such as an Azure AI Foundry `FoundryEvals`
+  instance). Metrics from each source are merged under a `"{source}:"` key prefix so identically-named
+  metrics never collide; `CapturedPerSource` exposes the untouched per-source results.
+- **`UnifiedEvalReport`** — merges the per-source results into one source-tagged `EvalResult` tree (a
+  branch per source) for the HTML/PDF renderers; splices an AgentEval composite's full weighted hierarchy
+  into its branch and surfaces a provider report URL as branch evidence.
+- **`CircuitBreaker`** — a minimal consecutive-failure breaker (injectable clock) that skips a
+  persistently-failing source fast.
+- **Docs** — a "several evaluators in one report" section in
+  [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
+
 ## [0.13.2-beta] - 2026-06-29
 
 ### Compliance: live-agent judging + a silent judge-parse correctness fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into its branch and surfaces a provider report URL as branch evidence.
 - **`CircuitBreaker`** — a minimal consecutive-failure breaker (injectable clock) that skips a
   persistently-failing source fast.
-- **Sample** — `samples/AgentEval.MafEvalFoundryAlongsideLocal`: an end-to-end hybrid eval that scores one
-  MAF agent run with an AgentEval Composite Eval + Azure AI Foundry evals and renders both in one
-  source-tagged HTML report (Pattern A: MAF-native mix; Pattern B: `CompositeAgentEvaluator`).
-- **Docs** — a "several evaluators in one report" section in
-  [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
+- **`AgentEvaluatorEvalLeaf` / `IAgentEvaluator.AsEvalLeaf()`** — the inverse adapter: wraps a MAF
+  `IAgentEvaluator` (e.g. a Foundry eval) as an AgentEval `IEval`, so a provider's evaluator can be a
+  **weighted leaf inside an AgentEval `CompositeEval`** — Foundry evals as first-class components of a
+  hierarchical benchmark, under the same weighting/thresholding/aggregation. Provider-agnostic
+  (AgentEval.MAF holds no Foundry reference).
+- **Samples** —
+  `samples/AgentEval.MafEvalFoundryAlongsideLocal` (standalone) plus two `AgentEval.Samples` Benchmarks
+  entries: **Foundry Hybrid** (a Foundry eval inside a `CompositeAgentEvaluator`, batched) and **Foundry
+  Hierarchy** (Foundry evals as weighted leaves interleaved in a composite benchmark tree). Each scores one
+  MAF agent run and renders a source-tagged HTML report; the Foundry branch is gated on
+  `FOUNDRY_PROJECT_ENDPOINT`.
+- **Docs** — "several evaluators in one report" (§3d) and "a provider's eval as a weighted leaf" (§3e)
+  sections in [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
 
 #### Changed
 - **Microsoft Agent Framework bumped to 1.12.0** (from 1.11.1) across the solution — no breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Hierarchy** (Foundry evals as weighted leaves interleaved in a composite benchmark tree). Each scores one
   MAF agent run and renders a source-tagged HTML report; the Foundry branch is gated on
   `FOUNDRY_PROJECT_ENDPOINT`.
-- **Docs** — "several evaluators in one report" (§3d) and "a provider's eval as a weighted leaf" (§3e)
-  sections in [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
+- **Docs** — a dedicated [Foundry Evals Integration](docs/foundry-evals-integration.md) guide (surfaced in
+  the README Integration section + Documentation table), plus "several evaluators in one report" (§3d) and
+  "a provider's eval as a weighted leaf" (§3e) sections in
+  [`using-agenteval-with-maf-evals.md`](docs/using-agenteval-with-maf-evals.md).
 
 #### Changed
 - **Microsoft Agent Framework bumped to 1.12.0** (from 1.11.1) across the solution — no breaking changes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,17 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <!-- Microsoft Agent Framework -->
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.11.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.11.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.11.1" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.11.1" />
+    <!-- Microsoft Agent Framework — core packages on 1.12.0 (stable), bumped from 1.11.1.
+         Microsoft.Agents.AI.Foundry has no stable 1.12.0 yet (published preview-only), so it's pinned to
+         the matching 1.12.0-preview and is referenced ONLY by the AgentEval.MafEvalFoundryAlongsideLocal
+         sample — the core libraries stay provider-agnostic. Stable core 1.12.0 satisfies the preview's
+         Microsoft.Agents.AI dependency (a stable version outranks a same-version prerelease). -->
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.12.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.12.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.12.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.12.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Foundry" Version="1.12.0-preview.260629.1" /><!-- preview-only; sample-only -->
+    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.3" /><!-- required by Microsoft.Agents.AI.Foundry -->
     
     <!-- Microsoft Extensions AI -->
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,9 @@
   <ItemGroup>
     <!-- Microsoft Agent Framework — core packages on 1.12.0 (stable), bumped from 1.11.1.
          Microsoft.Agents.AI.Foundry has no stable 1.12.0 yet (published preview-only), so it's pinned to
-         the matching 1.12.0-preview and is referenced ONLY by the AgentEval.MafEvalFoundryAlongsideLocal
-         sample — the core libraries stay provider-agnostic. Stable core 1.12.0 satisfies the preview's
+         the matching 1.12.0-preview and is referenced only by the SAMPLES (the
+         AgentEval.MafEvalFoundryAlongsideLocal standalone + the AgentEval.Samples H12/H13 benchmarks) —
+         the shipping libraries stay provider-agnostic. Stable core 1.12.0 satisfies the preview's
          Microsoft.Agents.AI dependency (a stable version outranks a same-version prerelease). -->
     <PackageVersion Include="Microsoft.Agents.AI" Version="1.12.0" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.12.0" />

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Every evidence document is cryptographically chained to its source run; `agentev
 - Semantic Kernel bridge via `AIFunctionFactory.Create()` (see NuGetConsumer sample)
 
 ### Integration
+- **⭐ Azure AI Foundry evals** — run Foundry evals **alongside** (batched, one source-tagged report) and **inside** (as weighted leaves in a composite benchmark) your AgentEval evals, from a single agent run. See [Foundry Evals Integration](docs/foundry-evals-integration.md).
 - CI/CD integration - JUnit XML, Markdown, JSON, SARIF export
 - Benchmarks - custom patterns with dataset loaders (JSON, YAML, CSV, JSONL)
 - Comprehensive multi-framework evaluation suite across all supported TFMs
@@ -580,6 +581,8 @@ See the **[Getting Started Guide](docs/getting-started.md)** for a complete walk
 | [Responsible AI](docs/ResponsibleAI.md) | Toxicity, bias, misinformation detection |
 | [Memory Evaluation](docs/memory-evaluation.md) | Retention, reach-back, temporal, LongMemEval, HTML reports |
 | [MAF Memory Integration](docs/maf-memory-integration.md) | How AgentEval.Memory maps to MAF pipelines |
+| [MAF Eval Integration](docs/using-agenteval-with-maf-evals.md) | Run AgentEval through MAF's `agent.EvaluateAsync()` |
+| [⭐ Foundry Evals Integration](docs/foundry-evals-integration.md) | Run Azure AI Foundry evals **alongside** and **inside** AgentEval evals |
 | [Cross-Framework](docs/cross-framework.md) | Semantic Kernel, IChatClient adapters |
 | [CLI Tool](docs/cli.md) | Command-line evaluation guide |
 | [Migration Guide](docs/comparison.md) | Coming from Python/Node.js frameworks |

--- a/docs/foundry-evals-integration.md
+++ b/docs/foundry-evals-integration.md
@@ -1,0 +1,85 @@
+# Foundry evals + AgentEval
+
+AgentEval runs **Azure AI Foundry evals alongside — and inside — its own evals**: one agent run, one
+source-tagged report. Foundry's cloud evaluators and AgentEval's local Composite Evals become peers, so you
+can mix cloud-graded and local-graded signals in a single benchmark **without running the agent twice**.
+
+Both integration points live in **`AgentEval.MAF`** and work with **any** MAF `IAgentEvaluator` — Foundry is
+the motivating example, but nothing in the shipping libraries references Foundry (see [Dependencies](#dependencies)).
+
+## Two ways to combine them
+
+| Direction | Entry point | Shape | When |
+|-----------|-------------|-------|------|
+| **Alongside** | `CompositeAgentEvaluator` | Foundry and AgentEval run as sibling *sources* over one agent run — concurrent, per-source isolated + timed-out — merged into one report. | The default. Efficient: Foundry batches all items in one call. |
+| **Inside** | `IAgentEvaluator.AsEvalLeaf()` | A Foundry eval becomes a *weighted leaf* inside an AgentEval `CompositeEval`, next to AgentEval leaves, under the same weighting / threshold / aggregation. | A single hierarchical benchmark whose leaves mix providers. Foundry runs once per input — best for small item counts. |
+
+### Alongside — `CompositeAgentEvaluator`
+
+```csharp
+using AgentEval.MAF.Evaluators;
+
+var local   = AgenticBenchmark.AgenticExecution(judge).AsMeaiEvaluator().AsAgentEvaluator(chatConfig);
+var foundry = new FoundryEvals(projectClient, model, /* … */ FoundryEvals.TaskAdherence, FoundryEvals.Relevance);
+
+var hybrid = new CompositeAgentEvaluator(
+[
+    ("agenteval-local", local,   null),                        // fast; no ceiling
+    ("foundry",         foundry, TimeSpan.FromMinutes(2)),     // bound the cloud call
+]);
+
+var merged = await agent.EvaluateAsync(queries, hybrid);       // the agent runs ONCE
+EvalResult report = UnifiedEvalReport.Build(hybrid.CapturedPerSource);   // one branch per source
+```
+
+- A Foundry failure/timeout becomes a **visible "skipped" branch** — the local results survive.
+- Each source's metrics are merged under a `"{source}:"` prefix, so identically-named metrics never collide.
+
+### Inside — `AsEvalLeaf`
+
+```csharp
+IEval foundryRelevance = new FoundryEvals(projectClient, model, /* … */ FoundryEvals.Relevance)
+    .AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+
+var benchmark = new CompositeEval(
+    "hybrid.benchmark", "Hybrid Benchmark", "hybrid", "1.0.0",
+    components:
+    [
+        new(AgenticBenchmark.ToolCallAccuracy(judge), 0.5),    // AgentEval sub-composite (multi-dimension)
+        new(foundryRelevance, 0.5),                            // Foundry eval as a weighted leaf
+    ],
+    WeightedSumAggregation.Instance, threshold: 0.75);
+
+EvalResult tree = await benchmark.EvaluateAsync(new EvalInput(query, response));
+```
+
+## Surface (`AgentEval.MAF.Evaluators`)
+
+| Type | Role |
+|------|------|
+| `CompositeAgentEvaluator` | run several `IAgentEvaluator`s over one run — concurrent, isolated, per-source timeout, optional `CircuitBreaker` |
+| `UnifiedEvalReport` | merge per-source results into one source-tagged `EvalResult` tree (a branch per source) |
+| `AsEvalLeaf` / `AgentEvaluatorEvalLeaf` | wrap a MAF `IAgentEvaluator` as an AgentEval `IEval` leaf for a `CompositeEval` (inverse of `AsAgentEvaluator`) |
+| `CircuitBreaker` | skip a persistently-failing source fast |
+
+## Samples
+
+| Sample | Direction |
+|--------|-----------|
+| `AgentEval.Samples` → Benchmarks → **Foundry Hybrid** | Alongside (batched) |
+| `AgentEval.Samples` → Benchmarks → **Foundry Hierarchy** | Inside (weighted leaves) |
+| [`samples/AgentEval.MafEvalFoundryAlongsideLocal`](../samples/AgentEval.MafEvalFoundryAlongsideLocal) | Alongside, standalone end-to-end |
+
+Set `FOUNDRY_PROJECT_ENDPOINT` (+ Azure credentials) to include the Foundry branch; without it the samples run
+AgentEval-local-only and say so.
+
+## Dependencies
+
+The Foundry evals package is currently published **preview-only**, so it is referenced **only by the samples** —
+never by the shipping libraries. `AgentEval`, `AgentEval.MAF`, and the CLI pull **nothing** Foundry (no transitive
+`Microsoft.Agents.AI.Foundry` or `Azure.AI.Projects`). The core stays provider-agnostic: every type above works
+with any `IAgentEvaluator`, so a stable Foundry package — or any other provider's evaluator — drops in unchanged.
+
+## See also
+
+- [Using AgentEval with MAF evals](using-agenteval-with-maf-evals.md) — §3d (alongside) and §3e (inside), in depth.

--- a/docs/using-agenteval-with-maf-evals.md
+++ b/docs/using-agenteval-with-maf-evals.md
@@ -153,6 +153,37 @@ EvalResult tree = UnifiedEvalReport.Build(hybrid.CapturedPerSource, composite); 
 - A genuine caller `CancellationToken` still propagates; only an inner evaluator's own failure/timeout is
   isolated into a "skipped" branch.
 
+### 3e. A provider's eval as a weighted LEAF inside a composite — `AsEvalLeaf`
+
+The inverse of §3a's `AsAgentEvaluator`: wrap any MAF `IAgentEvaluator` (e.g. a Foundry `FoundryEvals`
+instance) as an AgentEval `IEval` so it becomes a **weighted component inside a `CompositeEval`** — a
+Foundry eval sitting next to AgentEval leaves in one hierarchical benchmark, under the same weighting,
+thresholding, and aggregation.
+
+```csharp
+using AgentEval.Evals;          // CompositeEval, EvalComponent, WeightedSumAggregation
+using AgentEval.MAF.Evaluators; // AsEvalLeaf
+
+IEval foundryRelevance = new FoundryEvals(projectClient, model, /* … */ FoundryEvals.Relevance)
+    .AsEvalLeaf("foundry.relevance", "Foundry Relevance", judgeModel: model);
+
+var benchmark = new CompositeEval(
+    "hybrid.benchmark", "Hybrid Benchmark", "hybrid", "1.0.0",
+    components:
+    [
+        new(AgenticBenchmark.ToolCallAccuracy(judge), 0.5),   // AgentEval sub-composite (multi-dim)
+        new(foundryRelevance, 0.5),                            // Foundry eval as a weighted leaf
+    ],
+    WeightedSumAggregation.Instance, threshold: 0.75);
+
+EvalResult tree = await benchmark.EvaluateAsync(new EvalInput(query, response));
+```
+
+The leaf is provider-agnostic (AgentEval.MAF holds no Foundry reference). **Cost:** a composite evaluates
+once per input, so each leaf makes one provider call per input — fine for a benchmark; for large item
+counts prefer the batched §3d path (run the provider once over the whole set). The `AgentEval.Samples`
+Benchmarks menu has both: **Foundry Hybrid** (§3d, batched) and **Foundry Hierarchy** (this, interleaved).
+
 ---
 
 ## 4. Getting an HTML report out
@@ -201,6 +232,7 @@ adapter, but missed entirely via the MEAI-only path. For timing/cost fidelity us
 | `CompositeAgentEvaluator` | runs several `IAgentEvaluator`s concurrently over one run — isolated + per-source timeout + optional `CircuitBreaker`; merges into one result and captures per-source detail (`CapturedPerSource`) |
 | `UnifiedEvalReport` | merges per-source results into one source-tagged `EvalResult` tree (a branch per source) for rendering |
 | `CircuitBreaker` | optional consecutive-failure breaker that skips a persistently-failing source fast |
+| `AgentEvaluatorEvalLeaf` / `AsEvalLeaf` | wraps a MAF `IAgentEvaluator` (e.g. Foundry) as an AgentEval `IEval` leaf, so a provider's eval can be a weighted component inside a `CompositeEval` (inverse of `AsAgentEvaluator`) |
 
 Mapping to MAF's own samples (`dotnet/samples/.../Evaluation/`): `Evaluation_SimpleEval` →
 `AgentEvalEvaluators.Quality(judge)`; `Evaluation_CustomEvals` → `AgentEvalEvaluators.Custom(...)`;

--- a/docs/using-agenteval-with-maf-evals.md
+++ b/docs/using-agenteval-with-maf-evals.md
@@ -115,6 +115,44 @@ EvalResult tree = compositeEval.CapturedResults[0];                     // full 
 // Tool Call Accuracy → Tool Selection / Input(Schema+Semantic) / Output / Success / Efficiency
 ```
 
+### 3d. Several evaluators in one report — `CompositeAgentEvaluator` + `UnifiedEvalReport`
+
+Run more than one `IAgentEvaluator` over the **same** agent run and merge them into a single
+source-tagged report — for example an AgentEval composite alongside any other provider's evaluator
+(such as an Azure AI Foundry `FoundryEvals` instance). `CompositeAgentEvaluator` fans the inner
+evaluators out **concurrently**, isolates each one (a failing or slow source becomes a visible
+"skipped" branch rather than losing the whole run), gives each an optional per-source timeout, and can
+be guarded by a `CircuitBreaker`. You pass the composite as a *single* evaluator, so the agent still
+runs once.
+
+```csharp
+using AgentEval.MAF.Evaluators;
+using AgentEval.Benchmarks;   // AgenticBenchmark
+using AgentEval.Core;         // ChatClientEvaluator
+
+var composite = AgenticBenchmark.ToolCallAccuracy(new ChatClientEvaluator(judge)).AsMeaiEvaluator();
+var local     = composite.AsAgentEvaluator(chatConfig);           // AgentEval-local (rich composite)
+IAgentEvaluator other = /* any second IAgentEvaluator, e.g. a FoundryEvals instance */;
+
+var hybrid = new CompositeAgentEvaluator(
+[
+    ("agenteval-local", local, null),                             // no per-source timeout
+    ("foundry",         other, TimeSpan.FromMinutes(2)),          // bound a slow cloud evaluator
+]);
+
+var merged = await agent.EvaluateAsync([query], hybrid);          // one run; both sources, concurrent + isolated
+
+EvalResult tree = UnifiedEvalReport.Build(hybrid.CapturedPerSource, composite);   // one branch per source
+```
+
+- Each source's metrics are merged under a `"{source}:"` key prefix, so identically-named metrics from
+  different sources never collide.
+- Passing the `AgentEvalCompositeEvaluator` to `UnifiedEvalReport.Build` splices its full weighted
+  hierarchy into the local branch; a provider's report URL (when present) is surfaced as evidence on its
+  branch. `tree` renders with the same `HtmlEvalResultRenderer` as §4.
+- A genuine caller `CancellationToken` still propagates; only an inner evaluator's own failure/timeout is
+  isolated into a "skipped" branch.
+
 ---
 
 ## 4. Getting an HTML report out
@@ -160,6 +198,9 @@ adapter, but missed entirely via the MEAI-only path. For timing/cost fidelity us
 | `AgentEvalCompositeEvaluator` | wraps an AgentEval `IEval`/composite as an MEAI `IEvaluator`; captures the `EvalResult` tree |
 | `MeaiToEvalResultBridge` | `AgentEvaluationResults` (MEAI) → AgentEval `EvalResult` tree, for rendering |
 | `AgentEvaluatorExtensions` | `.AsAgentEvaluator(chatConfig)` / `.AsMeaiEvaluator()` fluent helpers |
+| `CompositeAgentEvaluator` | runs several `IAgentEvaluator`s concurrently over one run — isolated + per-source timeout + optional `CircuitBreaker`; merges into one result and captures per-source detail (`CapturedPerSource`) |
+| `UnifiedEvalReport` | merges per-source results into one source-tagged `EvalResult` tree (a branch per source) for rendering |
+| `CircuitBreaker` | optional consecutive-failure breaker that skips a persistently-failing source fast |
 
 Mapping to MAF's own samples (`dotnet/samples/.../Evaluation/`): `Evaluation_SimpleEval` →
 `AgentEvalEvaluators.Quality(judge)`; `Evaluation_CustomEvals` → `AgentEvalEvaluators.Custom(...)`;

--- a/samples/AgentEval.MafEvalFoundryAlongsideLocal/AgentEval.MafEvalFoundryAlongsideLocal.csproj
+++ b/samples/AgentEval.MafEvalFoundryAlongsideLocal/AgentEval.MafEvalFoundryAlongsideLocal.csproj
@@ -25,7 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Agents.AI" />
-    <!-- Foundry evals — the only project in the repo that references it (keeps the core provider-agnostic). -->
+    <!-- Foundry evals (preview) — sample-only: this project + the AgentEval.Samples H12/H13 benchmarks.
+         The shipping AgentEval libraries never reference it, so the core stays provider-agnostic. -->
     <PackageReference Include="Microsoft.Agents.AI.Foundry" />
     <PackageReference Include="Azure.AI.Projects" />
     <!-- Aliased: Azure.AI.Projects' beta pulls Azure.Core 1.57, which also declares

--- a/samples/AgentEval.MafEvalFoundryAlongsideLocal/AgentEval.MafEvalFoundryAlongsideLocal.csproj
+++ b/samples/AgentEval.MafEvalFoundryAlongsideLocal/AgentEval.MafEvalFoundryAlongsideLocal.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>AgentEval.MafEvalFoundryAlongsideLocal</RootNamespace>
+
+    <!-- Standalone demo of the hybrid eval path: score one MAF agent run with an AgentEval Composite
+         Eval AND Azure AI Foundry evals, merged into one source-tagged HTML report via
+         CompositeAgentEvaluator + UnifiedEvalReport (AgentEval.MAF). Kept as a separate project so the
+         Foundry dependency (Microsoft.Agents.AI.Foundry) stays out of the main libraries. Package
+         versions resolve from Directory.Packages.props (Central Package Management). -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/AgentEval.Abstractions/AgentEval.Abstractions.csproj" />
+    <ProjectReference Include="../../src/AgentEval.Core/AgentEval.Core.csproj" />
+    <ProjectReference Include="../../src/AgentEval.MAF/AgentEval.MAF.csproj" />
+    <ProjectReference Include="../../src/AgentEval.Evals.Agentic/AgentEval.Evals.Agentic.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Agents.AI" />
+    <!-- Foundry evals — the only project in the repo that references it (keeps the core provider-agnostic). -->
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" />
+    <PackageReference Include="Azure.AI.Projects" />
+    <!-- Aliased: Azure.AI.Projects' beta pulls Azure.Core 1.57, which also declares
+         Azure.Identity.DefaultAzureCredential — the extern alias disambiguates (CS0433). -->
+    <PackageReference Include="Azure.Identity" Aliases="azureidentity" />
+    <!-- Azure-backed judge + fallback SUT agent. -->
+    <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.Evaluation.Quality" />
+    <PackageReference Include="System.Memory.Data" />
+    <!-- Security: transitive pin (GHSA-g94r-2vxg-569j) -->
+    <PackageReference Include="OpenTelemetry.Api" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AgentEval.MafEvalFoundryAlongsideLocal/Program.cs
+++ b/samples/AgentEval.MafEvalFoundryAlongsideLocal/Program.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+//
+// Hybrid eval sample — score ONE MAF agent run with an AgentEval Composite Eval AND Azure AI Foundry
+// evals, then render BOTH in one source-tagged HTML report. Two patterns:
+//   [A] MAF's native multi-evaluator mix: agent.EvaluateAsync(queries, IAgentEvaluator[])  (sequential)
+//   [B] CompositeAgentEvaluator: concurrent + per-source isolation + bounded Foundry timeout (recommended)
+//
+// Env: AZURE_OPENAI_ENDPOINT / _API_KEY / _DEPLOYMENT   (the judge + the fallback SUT agent)
+//      FOUNDRY_PROJECT_ENDPOINT / FOUNDRY_MODEL          (Foundry evals + the Foundry-hosted SUT)
+// If FOUNDRY_PROJECT_ENDPOINT is unset, the sample runs AgentEval-local-only (Foundry branch skipped).
+
+extern alias azureidentity;         // disambiguate DefaultAzureCredential (also in Azure.Core via the Foundry beta)
+
+using Azure;                        // AzureKeyCredential
+using Azure.AI.OpenAI;              // AzureOpenAIClient
+using Azure.AI.Projects;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+using AgentEval.Benchmarks;                 // AgenticBenchmark
+using AgentEval.Core;                        // ChatClientEvaluator
+using AgentEval.Core.Evals.Rendering;        // HtmlEvalResultRenderer, EvalResultRenderOptions
+using AgentEval.Evals;                        // EvalResult
+using AgentEval.Output;                       // SubjectIdentity, SubjectKind
+using AgentEval.MAF.Evaluators;               // .AsAgentEvaluator / .AsMeaiEvaluator / UnifiedEvalReport / CompositeAgentEvaluator
+
+using FoundryEvals = Microsoft.Agents.AI.Foundry.FoundryEvals;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Setup — SUT agent, Foundry project, and the AgentEval judge
+// ─────────────────────────────────────────────────────────────────────────────
+string? foundryEndpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
+string model = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? "gpt-4o-mini";
+bool foundryAvailable = !string.IsNullOrWhiteSpace(foundryEndpoint);
+
+// The Foundry project client doubles as the SUT-agent host AND the Foundry evals backend.
+AIProjectClient? projectClient = foundryAvailable
+    ? new AIProjectClient(new Uri(foundryEndpoint!), new azureidentity::Azure.Identity.DefaultAzureCredential())
+    : null;
+
+// System-under-test agent. When Foundry is configured we host it there; otherwise fall back to an
+// Azure OpenAI IChatClient-backed agent so the local half still runs.
+AIAgent agent = projectClient is not null
+    ? projectClient.AsAIAgent(model: model, instructions: "You are a helpful travel advisor.", name: "TravelAdvisor")
+    : CreateFallbackAzureOpenAIAgent();
+
+// The AgentEval judge (LLM-as-judge for the Composite Eval). Any IChatClient works.
+IChatClient judge = CreateJudgeChatClient();
+var chatConfig = new ChatConfiguration(judge);
+
+string[] queries =
+{
+    "Plan a 3-day trip to Kyoto for a family with two kids.",
+    "What's the cheapest way to get from Paris to London next week?",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Build the two evaluators
+// ─────────────────────────────────────────────────────────────────────────────
+
+// AgentEval Composite Eval — the multi-dimension, deterministic (temp 0), evidence-bearing grader.
+// AgenticExecution is AgentEval's agentic composite (its CapturedResults hold the full weighted tree).
+var compositeEvaluator = AgenticBenchmark
+    .AgenticExecution(new ChatClientEvaluator(judge), judgeModel: model)   // CompositeEval (IEval)
+    .AsMeaiEvaluator();                                                     // -> AgentEvalCompositeEvaluator (captures tree)
+
+IAgentEvaluator local = compositeEvaluator.AsAgentEvaluator(chatConfig);    // conversation-preserving
+
+// Foundry cloud evaluator — BOUNDED timeout (it's a polling cloud job; the default is 300s).
+IAgentEvaluator? foundry = projectClient is not null
+    ? new FoundryEvals(projectClient, model, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120,
+                       FoundryEvals.TaskAdherence, FoundryEvals.Relevance)
+    : null;
+
+const string reportTitle = "Hybrid eval — AgentEval Composite ⊕ Azure AI Foundry";
+var subject = new SubjectIdentity(SubjectKind.Agent, agent.Name ?? "agent", ModelId: model, Framework: "MAF");
+var renderOpts = new EvalResultRenderOptions(Subject: subject, Title: reportTitle);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3a. PATTERN A — MAF-native "mix" (simplest). Sequential + all-or-nothing; fine for a reliable demo.
+//     The agent runs ONCE; each evaluator scores the same outputs; one result per evaluator.
+// ─────────────────────────────────────────────────────────────────────────────
+if (foundry is not null)
+{
+    IReadOnlyList<AgentEvaluationResults> mixed = await agent.EvaluateAsync(
+        queries, new IAgentEvaluator[] { local, foundry });
+
+    foreach (var r in mixed)
+        Console.WriteLine($"[A] {r.ProviderName}: {r.Passed}/{r.Total} passed" +
+                          (r.ReportUrl is not null ? $"  (Foundry portal: {r.ReportUrl})" : ""));
+
+    // UnifiedEvalReport takes a per-source list — zip the native-mix results with their source labels.
+    var perSourceA = new (string Source, AgentEvaluationResults Result)[]
+    {
+        ("agenteval-local", mixed[0]),
+        ("foundry", mixed[1]),
+    };
+    EvalResult unifiedA = UnifiedEvalReport.Build(perSourceA, compositeEvaluator, title: reportTitle);
+    await File.WriteAllBytesAsync("report-mixed-A.html",
+        await new HtmlEvalResultRenderer().RenderAsync(unifiedA, renderOpts));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3b. PATTERN B — CompositeAgentEvaluator (recommended for the real hybrid).
+//     Runs the inners CONCURRENTLY with per-source ISOLATION + a bounded Foundry timeout:
+//       - local returns in ms while Foundry polls  -> wall-clock ≈ Foundry time, not local+Foundry
+//       - a Foundry failure/timeout does NOT lose the local (Composite) results — it becomes a
+//         visible "skipped" branch. That is the difference from Pattern A.
+// ─────────────────────────────────────────────────────────────────────────────
+var inners = new List<(string Source, IAgentEvaluator Evaluator, TimeSpan? Timeout)>
+{
+    ("agenteval-local", local, null),                               // local is fast; no ceiling needed
+};
+if (foundry is not null)
+    inners.Add(("foundry", foundry, TimeSpan.FromSeconds(150)));    // hard ceiling ≥ FoundryEvals' own timeoutSeconds
+
+var composite = new CompositeAgentEvaluator(inners, name: "Foundry ⊕ AgentEval");
+AgentEvaluationResults hybrid = await agent.EvaluateAsync(queries, composite);   // ONE call, agent runs once
+
+Console.WriteLine($"[B] merged {hybrid.Passed}/{hybrid.Total} passed across {composite.CapturedPerSource.Count} source(s)");
+
+// The report consumes the per-source detail the composite captured (one code path with Pattern A).
+EvalResult unifiedB = UnifiedEvalReport.Build(composite.CapturedPerSource, compositeEvaluator, title: reportTitle);
+await File.WriteAllBytesAsync("report-hybrid-B.html",
+    await new HtmlEvalResultRenderer().RenderAsync(unifiedB, renderOpts));
+
+Console.WriteLine(foundryAvailable
+    ? "Done — wrote report-hybrid-B.html with both AgentEval-local and Foundry branches."
+    : "Done — AgentEval-local only (set FOUNDRY_PROJECT_ENDPOINT to include the Foundry branch).");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers (Azure OpenAI–backed judge + fallback SUT agent)
+// ─────────────────────────────────────────────────────────────────────────────
+static IChatClient CreateJudgeChatClient()
+{
+    var ep = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT") ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT not set (judge model).");
+    var key = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY") ?? throw new InvalidOperationException("AZURE_OPENAI_API_KEY not set.");
+    var dep = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT") ?? "gpt-4o-mini";
+    return new AzureOpenAIClient(new Uri(ep), new AzureKeyCredential(key)).GetChatClient(dep).AsIChatClient();
+}
+
+static AIAgent CreateFallbackAzureOpenAIAgent() =>
+    CreateJudgeChatClient().AsAIAgent(name: "TravelAdvisor", instructions: "You are a helpful travel advisor.");

--- a/samples/AgentEval.MafEvalFoundryAlongsideLocal/README.md
+++ b/samples/AgentEval.MafEvalFoundryAlongsideLocal/README.md
@@ -39,7 +39,8 @@ branch keeps its full weighted composite hierarchy; the Foundry branch surfaces 
 ## Notes
 
 - Uses the **preview** `Microsoft.Agents.AI.Foundry` package (the Foundry evals SDK has no stable release
-  yet); the rest of the MAF stack is on the stable release. This is the only project in the repo that
-  references Foundry — the core AgentEval libraries stay provider-agnostic.
+  yet); the rest of the MAF stack is on the stable release. Foundry is **sample-only** — referenced by this
+  project and the `AgentEval.Samples` H12/H13 benchmarks, but **never** by the shipping AgentEval libraries,
+  which stay provider-agnostic.
 - The composer, report merge, and circuit breaker live in `AgentEval.MAF` (`CompositeAgentEvaluator`,
   `UnifiedEvalReport`, `CircuitBreaker`) and work with **any** `IAgentEvaluator`, not just Foundry.

--- a/samples/AgentEval.MafEvalFoundryAlongsideLocal/README.md
+++ b/samples/AgentEval.MafEvalFoundryAlongsideLocal/README.md
@@ -1,0 +1,45 @@
+# AgentEval — Foundry evals alongside local evals (hybrid)
+
+Score **one** MAF agent run with an **AgentEval Composite Eval** *and* **Azure AI Foundry** evals, and
+render **both** in a single source-tagged HTML report. Demonstrates two patterns:
+
+- **[A] MAF-native mix** — `agent.EvaluateAsync(queries, IAgentEvaluator[] { local, foundry })`. Simple;
+  runs the evaluators sequentially and returns one result per evaluator.
+- **[B] `CompositeAgentEvaluator`** *(recommended)* — one evaluator that fans out to both **concurrently**,
+  isolates each (a Foundry failure/timeout becomes a visible "skipped" branch instead of losing the local
+  results), bounds the slow cloud call with a per-source timeout, and merges into one report via
+  `UnifiedEvalReport`.
+
+## Prerequisites
+
+```bash
+# The AgentEval judge + the fallback (non-Foundry) agent:
+export AZURE_OPENAI_ENDPOINT="https://<your>.openai.azure.com/"
+export AZURE_OPENAI_API_KEY="<key>"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
+
+# The Foundry evals backend + the Foundry-hosted agent (optional — omit to run local-only):
+export FOUNDRY_PROJECT_ENDPOINT="https://<your-foundry-project>..."
+export FOUNDRY_MODEL="gpt-4o-mini"
+```
+
+`FOUNDRY_PROJECT_ENDPOINT` uses `DefaultAzureCredential` (dev-friendly; use a specific credential in
+production). If it's unset, the sample runs **AgentEval-local only** and the Foundry branch is skipped.
+
+## Run
+
+```bash
+dotnet run --project samples/AgentEval.MafEvalFoundryAlongsideLocal
+```
+
+Writes `report-hybrid-B.html` (Pattern B) — and, when Foundry is configured, `report-mixed-A.html`
+(Pattern A) — to the working directory. Each report has **one branch per source**: the AgentEval-local
+branch keeps its full weighted composite hierarchy; the Foundry branch surfaces its portal report URL.
+
+## Notes
+
+- Uses the **preview** `Microsoft.Agents.AI.Foundry` package (the Foundry evals SDK has no stable release
+  yet); the rest of the MAF stack is on the stable release. This is the only project in the repo that
+  references Foundry — the core AgentEval libraries stay provider-agnostic.
+- The composer, report merge, and circuit breaker live in `AgentEval.MAF` (`CompositeAgentEvaluator`,
+  `UnifiedEvalReport`, `CircuitBreaker`) and work with **any** `IAgentEvaluator`, not just Foundry.

--- a/samples/AgentEval.Samples/AgentEval.Samples.csproj
+++ b/samples/AgentEval.Samples/AgentEval.Samples.csproj
@@ -23,11 +23,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />
-    <!-- Aliased for the Foundry-hybrid benchmark (H12): Azure.AI.Projects' beta pulls Azure.Core 1.57,
+    <!-- Aliased for the Foundry benchmarks (H12/H13): Azure.AI.Projects' beta pulls Azure.Core 1.57,
          which also declares Azure.Identity.DefaultAzureCredential — the extern alias disambiguates (CS0433).
-         Safe project-wide: no other sample references Azure.Identity types directly. -->
+         Safe project-wide: the H12/H13 samples reach DefaultAzureCredential through the `azureidentity::`
+         alias, and no sample references Azure.Identity types UNALIASED. -->
     <PackageReference Include="Azure.Identity" Aliases="azureidentity" />
-    <!-- Foundry evals (preview) — only for the H12 hybrid benchmark sample. -->
+    <!-- Foundry evals (preview) — for the H12 (Foundry Hybrid) and H13 (Foundry Hierarchy) benchmarks. -->
     <PackageReference Include="Microsoft.Agents.AI.Foundry" />
     <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" />

--- a/samples/AgentEval.Samples/AgentEval.Samples.csproj
+++ b/samples/AgentEval.Samples/AgentEval.Samples.csproj
@@ -23,7 +23,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />
-    <PackageReference Include="Azure.Identity" />
+    <!-- Aliased for the Foundry-hybrid benchmark (H12): Azure.AI.Projects' beta pulls Azure.Core 1.57,
+         which also declares Azure.Identity.DefaultAzureCredential — the extern alias disambiguates (CS0433).
+         Safe project-wide: no other sample references Azure.Identity types directly. -->
+    <PackageReference Include="Azure.Identity" Aliases="azureidentity" />
+    <!-- Foundry evals (preview) — only for the H12 hybrid benchmark sample. -->
+    <PackageReference Include="Microsoft.Agents.AI.Foundry" />
+    <PackageReference Include="Azure.AI.Projects" />
     <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows.Generators" PrivateAssets="all" />

--- a/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+extern alias azureidentity;   // disambiguate DefaultAzureCredential (also in Azure.Core via the Foundry beta)
+
+using Azure.AI.OpenAI;
+using Azure.AI.Projects;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using AgentEval.Benchmarks;
+using AgentEval.Core;
+using AgentEval.Core.Evals.Rendering;
+using AgentEval.Evals;
+using AgentEval.MAF.Evaluators;
+using AgentEval.Output;
+
+using FoundryEvals = Microsoft.Agents.AI.Foundry.FoundryEvals;
+
+namespace AgentEval.Samples.Benchmarks;
+
+/// <summary>
+/// Benchmarks H12: <b>Foundry ⊕ AgentEval hybrid</b> — puts an Azure AI Foundry eval <i>inside</i> a
+/// composite eval (<see cref="CompositeAgentEvaluator"/>), scores one MAF agent run with both the
+/// AgentEval Composite Eval and the Foundry eval, and renders both in one source-tagged HTML report.
+/// </summary>
+/// <remarks>
+/// Requires Azure OpenAI credentials (the judge + the fallback agent). The Foundry branch runs only when
+/// <c>FOUNDRY_PROJECT_ENDPOINT</c> is set; otherwise the sample runs AgentEval-local-only and says so.
+/// </remarks>
+public static class FoundryHybridBenchmarkSample
+{
+    public static async Task RunAsync()
+    {
+        BenchmarkSampleHelpers.PrintHeader(
+            "Benchmarks H12: Foundry ⊕ AgentEval (hybrid)",
+            "A Foundry eval INSIDE a composite eval — one agent run, one source-tagged report.");
+
+        if (!AIConfig.IsConfigured)
+        {
+            BenchmarkSampleHelpers.PrintMissingCredentialsBox("BENCHMARKS H12 — FOUNDRY HYBRID");
+            return;
+        }
+
+        // ── The AgentEval judge + a composite (local, deterministic, multi-dimension) ──────────────
+        var azure = new AzureOpenAIClient(AIConfig.Endpoint, AIConfig.KeyCredential);
+        IChatClient judgeChat = azure.GetChatClient(AIConfig.ModelDeployment).AsIChatClient();
+        var chatConfig = new ChatConfiguration(judgeChat);
+
+        var composite = AgenticBenchmark
+            .AgenticExecution(new ChatClientEvaluator(judgeChat), judgeModel: AIConfig.ModelDeployment)
+            .AsMeaiEvaluator();
+        IAgentEvaluator local = composite.AsAgentEvaluator(chatConfig);
+
+        // ── The Foundry eval — only when a Foundry project is configured ───────────────────────────
+        var foundryEndpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
+        var foundryModel = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? AIConfig.ModelDeployment;
+        bool foundryOn = !string.IsNullOrWhiteSpace(foundryEndpoint);
+
+        AIProjectClient? projectClient = foundryOn
+            ? new AIProjectClient(new Uri(foundryEndpoint!), new azureidentity::Azure.Identity.DefaultAzureCredential())
+            : null;
+
+        // System-under-test agent: Foundry-hosted when available, else Azure OpenAI.
+        AIAgent agent = projectClient is not null
+            ? projectClient.AsAIAgent(model: foundryModel, instructions: "You are a helpful travel advisor.", name: "TravelAdvisor")
+            : judgeChat.AsAIAgent(name: "TravelAdvisor", instructions: "You are a helpful travel advisor.");
+
+        // ── Put the Foundry eval INTO the composite, alongside the AgentEval-local one ─────────────
+        var inners = new List<(string Source, IAgentEvaluator Evaluator, TimeSpan? Timeout)>
+        {
+            ("agenteval-local", local, null),
+        };
+        if (projectClient is not null)
+        {
+            inners.Add(("foundry",
+                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120,
+                                 FoundryEvals.TaskAdherence, FoundryEvals.Relevance),
+                TimeSpan.FromSeconds(150)));
+        }
+
+        var hybrid = new CompositeAgentEvaluator(inners, name: "Foundry ⊕ AgentEval");
+
+        Console.WriteLine($"   Sources: {string.Join(", ", inners.Select(i => i.Source))}"
+                          + (foundryOn ? "" : "   (set FOUNDRY_PROJECT_ENDPOINT to add the Foundry branch)"));
+
+        string[] queries = { "Plan a 3-day trip to Kyoto for a family with two kids." };
+
+        // One call: the agent runs once; the composite fans out to both evaluators concurrently.
+        AgentEvaluationResults results = await agent.EvaluateAsync(queries, hybrid);
+
+        Console.WriteLine($"   Merged verdict: {results.Passed}/{results.Total} passed across "
+                          + $"{hybrid.CapturedPerSource.Count} source(s).");
+
+        // One source-tagged report (a branch per source; the local branch keeps its full hierarchy).
+        EvalResult tree = UnifiedEvalReport.Build(hybrid.CapturedPerSource, composite);
+        var subject = new SubjectIdentity(SubjectKind.Agent, agent.Name ?? "agent", ModelId: foundryModel, Framework: "MAF");
+        var html = await new HtmlEvalResultRenderer().RenderAsync(tree, new EvalResultRenderOptions(
+            Subject: subject, Title: "Foundry ⊕ AgentEval — hybrid eval"));
+
+        var dir = BenchmarkSampleHelpers.EnsureRunDirectory("foundry-hybrid");
+        var htmlPath = System.IO.Path.Combine(dir, "report.html");
+        await System.IO.File.WriteAllBytesAsync(htmlPath, html);
+
+        Console.WriteLine();
+        Console.WriteLine($"   Report: {htmlPath}");
+        Console.WriteLine();
+        Console.WriteLine("   KEY TAKEAWAY:");
+        Console.WriteLine("   - A Foundry eval sits INSIDE a CompositeAgentEvaluator, next to the AgentEval composite.");
+        Console.WriteLine("   - One agent run, both evaluators (concurrent + isolated), one source-tagged report.");
+        Console.WriteLine("   - A Foundry failure/timeout becomes a visible 'skipped' branch — the local results survive.");
+    }
+}

--- a/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+extern alias azureidentity;   // disambiguate DefaultAzureCredential (also in Azure.Core via the Foundry beta)
+
+using Azure.AI.OpenAI;
+using Azure.AI.Projects;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using AgentEval.Benchmarks;
+using AgentEval.Core;
+using AgentEval.Core.Evals.Rendering;
+using AgentEval.Evals;
+using AgentEval.MAF.Evaluators;
+using AgentEval.Output;
+
+using FoundryEvals = Microsoft.Agents.AI.Foundry.FoundryEvals;
+
+namespace AgentEval.Samples.Benchmarks;
+
+/// <summary>
+/// Benchmarks H13: <b>Foundry evals INSIDE a composite hierarchy</b>. Builds one weighted AgentEval
+/// <see cref="CompositeEval"/> whose components are a mix — an AgentEval sub-composite (multi-dimension,
+/// itself a tree) plus Foundry evals turned into weighted leaves via <c>IAgentEvaluator.AsEvalLeaf()</c>.
+/// The rendered report is a single benchmark hierarchy where <i>some of the leaves are Foundry evals</i>.
+/// </summary>
+/// <remarks>
+/// Requires Azure OpenAI (the judge + the SUT agent). The Foundry leaves are added only when
+/// <c>FOUNDRY_PROJECT_ENDPOINT</c> is set. NOTE: a composite evaluates once per input, so each Foundry leaf
+/// makes one cloud call per scenario — fine for a benchmark; for large runs prefer the batched
+/// "Foundry alongside local" path (Benchmarks H12 / the MafEvalFoundryAlongsideLocal sample).
+/// </remarks>
+public static class FoundryHierarchyBenchmarkSample
+{
+    public static async Task RunAsync()
+    {
+        BenchmarkSampleHelpers.PrintHeader(
+            "Benchmarks H13: Foundry evals inside a composite hierarchy",
+            "One weighted benchmark tree: AgentEval sub-composite ⊕ Foundry evals as weighted leaves.");
+
+        if (!AIConfig.IsConfigured)
+        {
+            BenchmarkSampleHelpers.PrintMissingCredentialsBox("BENCHMARKS H13 — FOUNDRY HIERARCHY");
+            return;
+        }
+
+        var azure = new AzureOpenAIClient(AIConfig.Endpoint, AIConfig.KeyCredential);
+        IChatClient judgeChat = azure.GetChatClient(AIConfig.ModelDeployment).AsIChatClient();
+        var judge = new ChatClientEvaluator(judgeChat);
+
+        var foundryEndpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
+        var foundryModel = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? AIConfig.ModelDeployment;
+        bool foundryOn = !string.IsNullOrWhiteSpace(foundryEndpoint);
+
+        AIProjectClient? projectClient = foundryOn
+            ? new AIProjectClient(new Uri(foundryEndpoint!), new azureidentity::Azure.Identity.DefaultAzureCredential())
+            : null;
+
+        // ── Build the benchmark hierarchy: an AgentEval sub-composite + (optional) Foundry leaves ──────
+        // ToolCallAccuracy is itself a 5-dimension composite — so this benchmark is genuinely multi-level.
+        var components = new List<EvalComponent>
+        {
+            new(AgenticBenchmark.ToolCallAccuracy(judge, foundryModel), foundryOn ? 0.5 : 1.0),
+        };
+
+        if (projectClient is not null)
+        {
+            // One FoundryEvals per evaluator → each becomes its own weighted leaf in the tree.
+            components.Add(new(
+                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.Relevance)
+                    .AsEvalLeaf("foundry.relevance", "Foundry Relevance", judgeModel: foundryModel),
+                0.25));
+            components.Add(new(
+                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.TaskAdherence)
+                    .AsEvalLeaf("foundry.task_adherence", "Foundry Task Adherence", judgeModel: foundryModel),
+                0.25));
+        }
+
+        var benchmark = new CompositeEval(
+            key: "hybrid.trip_planner",
+            name: "Trip-Planner Hybrid Benchmark",
+            category: "hybrid",
+            version: "1.0.0",
+            components: components,
+            aggregation: WeightedSumAggregation.Instance,
+            threshold: 0.75);
+
+        Console.WriteLine($"   Components: {string.Join(", ", components.Select(c => $"{c.Eval.Name} (w={c.Weight})"))}");
+        Console.WriteLine(foundryOn ? "" : "   (set FOUNDRY_PROJECT_ENDPOINT to weave Foundry evals into the hierarchy)");
+
+        // ── Run the SUT agent once, then score its answer with the whole benchmark tree ───────────────
+        AIAgent agent = judgeChat.AsAIAgent(name: "TravelAdvisor", instructions: "You are a helpful travel advisor.");
+        const string query = "Plan a 3-day trip to Kyoto for a family with two kids.";
+        var runResponse = await agent.RunAsync(query);
+
+        EvalResult result = await benchmark.EvaluateAsync(new EvalInput(query, runResponse.Text));
+
+        Console.WriteLine($"   Benchmark score: {result.Score.Value:P0} ({result.Score.Label}) across "
+                          + $"{result.Details.SubResults?.Count ?? 0} top-level component(s).");
+
+        var subject = new SubjectIdentity(SubjectKind.Agent, agent.Name ?? "agent", ModelId: foundryModel, Framework: "MAF");
+        var html = await new HtmlEvalResultRenderer().RenderAsync(result, new EvalResultRenderOptions(
+            Subject: subject, Title: "Trip-Planner Hybrid Benchmark — AgentEval ⊕ Foundry leaves"));
+
+        var dir = BenchmarkSampleHelpers.EnsureRunDirectory("foundry-hierarchy");
+        var htmlPath = System.IO.Path.Combine(dir, "report.html");
+        await System.IO.File.WriteAllBytesAsync(htmlPath, html);
+
+        Console.WriteLine();
+        Console.WriteLine($"   Report: {htmlPath}");
+        Console.WriteLine();
+        Console.WriteLine("   KEY TAKEAWAY:");
+        Console.WriteLine("   - Foundry evals are WEIGHTED LEAVES inside one AgentEval CompositeEval, next to a");
+        Console.WriteLine("     multi-dimension AgentEval sub-composite — a single hierarchical benchmark tree.");
+        Console.WriteLine("   - Same weighting / thresholding / aggregation applies to Foundry and AgentEval leaves alike.");
+        Console.WriteLine("   - For a large item count, prefer the BATCHED path (H12) so Foundry runs once, not per item.");
+    }
+}

--- a/samples/AgentEval.Samples/Program.cs
+++ b/samples/AgentEval.Samples/Program.cs
@@ -111,6 +111,7 @@ public static class Program
             new("NIST AI RMF",               "MEASURE security/privacy/validity evidence; governance Not Applicable",   NistBenchmarkSample.RunAsync),
             new("LongMemEval",               "Real history-injectable agent + judge (ICLR 2025); preset-driven",    LongMemEvalBenchmarkSample.RunAsync),
             new("Memory",                    "Comprehensive memory benchmark — preset-driven",                      MemoryBenchmarkSample.RunAsync),
+            new("Foundry Hybrid",            "A Foundry eval INSIDE a composite eval — one run, one report",        FoundryHybridBenchmarkSample.RunAsync),
             new("Report Browser",            "Open previously-generated JSON / HTML / PDF runs",                    ReportBrowserBenchmark.RunAsync),
         ]),
 

--- a/samples/AgentEval.Samples/Program.cs
+++ b/samples/AgentEval.Samples/Program.cs
@@ -112,6 +112,7 @@ public static class Program
             new("LongMemEval",               "Real history-injectable agent + judge (ICLR 2025); preset-driven",    LongMemEvalBenchmarkSample.RunAsync),
             new("Memory",                    "Comprehensive memory benchmark — preset-driven",                      MemoryBenchmarkSample.RunAsync),
             new("Foundry Hybrid",            "A Foundry eval INSIDE a composite eval — one run, one report",        FoundryHybridBenchmarkSample.RunAsync),
+            new("Foundry Hierarchy",         "Foundry evals as weighted leaves inside a composite benchmark tree",  FoundryHierarchyBenchmarkSample.RunAsync),
             new("Report Browser",            "Open previously-generated JSON / HTML / PDF runs",                    ReportBrowserBenchmark.RunAsync),
         ]),
 

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
@@ -86,12 +86,13 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
         }
         catch (Exception ex) when (ct.IsCancellationRequested is false)
         {
-            // Isolate a provider failure into a failing leaf — never take down the whole composite.
-            return Fail($"evaluator '{Name}' threw: {ex.Message}");
+            // Isolate a provider failure into a neutral "error" leaf — never take down the whole composite.
+            // Include the exception type: ex.Message alone can be empty and is far less diagnostic.
+            return ErrorLeaf($"evaluator '{Name}' threw {ex.GetType().Name}: {ex.Message}");
         }
 
         if (results.Error is not null || results.Items.Count == 0)
-            return Fail(results.Error ?? "no results returned");
+            return ErrorLeaf(results.Error ?? "no results returned");
 
         // Reuse the existing MEAI -> EvalResult bridge for robust metric normalisation, then re-key its
         // aggregate as THIS leaf so it participates (by weight) in the parent CompositeEval.
@@ -116,9 +117,12 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
             EvaluatedAt: DateTimeOffset.UtcNow);
     }
 
-    private EvalResult Fail(string reason) => new(
+    // An infrastructure/provider failure is surfaced as a neutral "error" leaf (severity none), matching the
+    // repo convention (AtomicLlmEval / AgentScenarioEval): it must NOT masquerade as a confirmed
+    // low-scoring/violating result in roll-ups or renderers, which reserve fail/medium for real verdicts.
+    private EvalResult ErrorLeaf(string reason) => new(
         Metric: new EvalMetadata(Key, Name, Category, Version),
-        Score: new EvalScore(0.0, Ordinal: null, Label: "fail", Passed: false, Threshold: _threshold, Severity: "medium", Confidence: null),
+        Score: new EvalScore(0.0, Ordinal: null, Label: "error", Passed: false, Threshold: _threshold, Severity: "none", Confidence: null),
         Details: new EvalDetails(null, new[] { new EvalEvidence("provider", Key, reason) }, null, null, null),
         Provenance: new EvalProvenance("atomic-llm", _judgeModel, null, null, null, 0, false),
         EvaluatedAt: DateTimeOffset.UtcNow);

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+
+using AgentEval.Evals;
+using Microsoft.Agents.AI;
+
+namespace AgentEval.MAF.Evaluators;
+
+/// <summary>
+/// Adapts a MAF <see cref="IAgentEvaluator"/> (e.g. an Azure AI Foundry <c>FoundryEvals</c> instance) so it
+/// can be used as an AgentEval <see cref="IEval"/> — i.e. a <b>weighted leaf inside an AgentEval
+/// <c>CompositeEval</c></b>. This is the inverse of <see cref="AgentEvaluatorExtensions.AsAgentEvaluator"/>
+/// (which wraps an AgentEval/MEAI evaluator as a MAF <see cref="IAgentEvaluator"/>): it lets a provider's
+/// evaluator become a first-class, weighted component of a hierarchical AgentEval benchmark.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The leaf is provider-agnostic — it holds no reference to Foundry. Each call builds a single-item
+/// <see cref="EvalItem"/> from the <see cref="EvalInput"/>, invokes the wrapped evaluator, and reuses
+/// <see cref="MeaiToEvalResultBridge"/> to normalise the returned metrics into an AgentEval score, so the
+/// scale matches how MAF results are rendered everywhere else in the repo.
+/// </para>
+/// <para>
+/// COST NOTE: a <c>CompositeEval</c> evaluates once per <see cref="EvalInput"/>. If the wrapped evaluator is
+/// a cloud/batch job (Foundry), each leaf makes one call per input — fine for a benchmark with a handful of
+/// scenarios, but for large item counts prefer running the provider ONCE over the whole batch and composing
+/// the results with <see cref="UnifiedEvalReport"/> instead (see the "Foundry alongside local" sample).
+/// </para>
+/// </remarks>
+public sealed class AgentEvaluatorEvalLeaf : IEval
+{
+    private readonly IAgentEvaluator _inner;
+    private readonly string? _judgeModel;
+    private readonly double? _threshold;
+
+    /// <param name="inner">The MAF evaluator to wrap (e.g. a <c>FoundryEvals</c> configured with one evaluator).</param>
+    /// <param name="key">Machine id for the leaf (e.g. <c>"foundry.relevance"</c>).</param>
+    /// <param name="name">Human-readable name (e.g. <c>"Foundry Relevance"</c>).</param>
+    /// <param name="category">Eval category (default <c>"hybrid"</c>).</param>
+    /// <param name="version">Semver string (default <c>"1.0.0"</c>).</param>
+    /// <param name="judgeModel">Recorded on the result's provenance; the provider's judge model, if known.</param>
+    /// <param name="threshold">Pass threshold recorded on the score (informational; default 0.70).</param>
+    public AgentEvaluatorEvalLeaf(
+        IAgentEvaluator inner,
+        string key,
+        string name,
+        string category = "hybrid",
+        string version = "1.0.0",
+        string? judgeModel = null,
+        double? threshold = 0.70)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        Key = key ?? throw new ArgumentNullException(nameof(key));
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Category = category;
+        Version = version;
+        _judgeModel = judgeModel;
+        _threshold = threshold;
+    }
+
+    /// <inheritdoc />
+    public string Key { get; }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public string Category { get; }
+
+    /// <inheritdoc />
+    public string Version { get; }
+
+    /// <inheritdoc />
+    public async Task<EvalResult> EvaluateAsync(EvalInput input, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var item = new EvalItem(input.Query, input.Response ?? string.Empty);
+        if (input.Context is not null) item.Context = input.Context;
+        if (input.GroundTruth is not null) item.ExpectedOutput = input.GroundTruth;
+
+        AgentEvaluationResults results;
+        try
+        {
+            results = await _inner.EvaluateAsync(new[] { item }, Key, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ct.IsCancellationRequested is false)
+        {
+            // Isolate a provider failure into a failing leaf — never take down the whole composite.
+            return Fail($"evaluator '{Name}' threw: {ex.Message}");
+        }
+
+        if (results.Error is not null || results.Items.Count == 0)
+            return Fail(results.Error ?? "no results returned");
+
+        // Reuse the existing MEAI -> EvalResult bridge for robust metric normalisation, then re-key its
+        // aggregate as THIS leaf so it participates (by weight) in the parent CompositeEval.
+        EvalResult tree = MeaiToEvalResultBridge.Build(Name, new[] { input.Query }, results, _judgeModel);
+        EvalScore agg = tree.Score;
+
+        return new EvalResult(
+            Metric: new EvalMetadata(Key, Name, Category, Version),
+            Score: new EvalScore(
+                Value: agg.Value, Ordinal: null, Label: agg.Label, Passed: agg.Passed,
+                Threshold: _threshold, Severity: agg.Severity, Confidence: null),
+            Details: new EvalDetails(
+                Dimensions: null,
+                Evidence: new[] { new EvalEvidence("provider", Key, $"{results.Passed}/{results.Total} metric(s) passed") },
+                Recommendations: null,
+                // Keep the provider's per-metric breakdown as a sub-tree so the hierarchy shows depth.
+                SubResults: tree.Details.SubResults,
+                AggregationStrategy: tree.Details.AggregationStrategy),
+            Provenance: new EvalProvenance(
+                Type: "atomic-llm", JudgeModel: _judgeModel, PromptId: null, PromptHash: null,
+                TokensUsed: null, EstimatedCost: 0, CacheHit: false),
+            EvaluatedAt: DateTimeOffset.UtcNow);
+    }
+
+    private EvalResult Fail(string reason) => new(
+        Metric: new EvalMetadata(Key, Name, Category, Version),
+        Score: new EvalScore(0.0, Ordinal: null, Label: "fail", Passed: false, Threshold: _threshold, Severity: "medium", Confidence: null),
+        Details: new EvalDetails(null, new[] { new EvalEvidence("provider", Key, reason) }, null, null, null),
+        Provenance: new EvalProvenance("atomic-llm", _judgeModel, null, null, null, 0, false),
+        EvaluatedAt: DateTimeOffset.UtcNow);
+}

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorExtensions.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.AI.Evaluation;
 using AgentEval.Evals;
 
 using MEAIIEvaluator = Microsoft.Extensions.AI.Evaluation.IEvaluator;
+using MafIAgentEvaluator = Microsoft.Agents.AI.IAgentEvaluator;
 
 namespace AgentEval.MAF.Evaluators;
 
@@ -34,4 +35,19 @@ public static class AgentEvaluatorExtensions
     /// <see cref="AgentEvalCompositeEvaluator.CapturedResults"/> for rendering.
     /// </summary>
     public static AgentEvalCompositeEvaluator AsMeaiEvaluator(this IEval composite) => new(composite);
+
+    /// <summary>
+    /// Wraps a MAF <see cref="MafIAgentEvaluator"/> (e.g. an Azure AI Foundry <c>FoundryEvals</c> instance)
+    /// as an AgentEval <see cref="IEval"/> leaf, so a provider's evaluator can be a <b>weighted component
+    /// inside an AgentEval <c>CompositeEval</c></b> — the inverse of <see cref="AsAgentEvaluator"/>. See
+    /// <see cref="AgentEvaluatorEvalLeaf"/> for the per-input cost note (prefer batching for large runs).
+    /// </summary>
+    public static IEval AsEvalLeaf(
+        this MafIAgentEvaluator evaluator,
+        string key,
+        string name,
+        string category = "hybrid",
+        string version = "1.0.0",
+        string? judgeModel = null,
+        double? threshold = 0.70) => new AgentEvaluatorEvalLeaf(evaluator, key, name, category, version, judgeModel, threshold);
 }

--- a/src/AgentEval.MAF/Evaluators/CircuitBreaker.cs
+++ b/src/AgentEval.MAF/Evaluators/CircuitBreaker.cs
@@ -43,6 +43,12 @@ public sealed class CircuitBreaker
     public void OnFailure(string source)
     {
         var s = _states.GetOrAdd(source, _ => new State());
-        lock (s) { if (++s.Failures >= _threshold) s.OpenedUntil = _now() + _cooldown; }
+        lock (s)
+        {
+            // Once the cooldown has elapsed the breaker is closed again, so restart the consecutive-failure
+            // count — otherwise a single stale failure would immediately re-open it even when threshold > 1.
+            if (s.OpenedUntil != default && _now() >= s.OpenedUntil) { s.Failures = 0; s.OpenedUntil = default; }
+            if (++s.Failures >= _threshold) s.OpenedUntil = _now() + _cooldown;
+        }
     }
 }

--- a/src/AgentEval.MAF/Evaluators/CircuitBreaker.cs
+++ b/src/AgentEval.MAF/Evaluators/CircuitBreaker.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+using System.Collections.Concurrent;
+
+namespace AgentEval.MAF.Evaluators;
+
+/// <summary>Minimal consecutive-failure circuit breaker, keyed by source. Thread-safe. Opt-in (off unless injected).</summary>
+public sealed class CircuitBreaker
+{
+    private sealed class State { public int Failures; public DateTimeOffset OpenedUntil; }
+
+    private readonly int _threshold;
+    private readonly TimeSpan _cooldown;
+    private readonly Func<DateTimeOffset> _now;
+    private readonly ConcurrentDictionary<string, State> _states = new();
+
+    /// <param name="threshold">Consecutive failures before the breaker opens for a source.</param>
+    /// <param name="cooldown">How long the breaker stays open after tripping. Defaults to 1 minute.</param>
+    /// <param name="now">Clock; inject a fake in tests. Defaults to UTC now.</param>
+    public CircuitBreaker(int threshold = 3, TimeSpan? cooldown = null, Func<DateTimeOffset>? now = null)
+    {
+        if (threshold < 1) throw new ArgumentOutOfRangeException(nameof(threshold));
+        _threshold = threshold;
+        _cooldown = cooldown ?? TimeSpan.FromMinutes(1);
+        _now = now ?? (() => DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>True while the breaker for <paramref name="source"/> is open (caller should skip the call).</summary>
+    public bool IsOpen(string source)
+    {
+        if (!_states.TryGetValue(source, out var s)) return false;
+        lock (s) { return s.OpenedUntil > _now(); }
+    }
+
+    /// <summary>Records a success for <paramref name="source"/>, resetting its failure count.</summary>
+    public void OnSuccess(string source)
+    {
+        var s = _states.GetOrAdd(source, _ => new State());
+        lock (s) { s.Failures = 0; s.OpenedUntil = default; }
+    }
+
+    /// <summary>Records a failure for <paramref name="source"/>; opens the breaker at the threshold.</summary>
+    public void OnFailure(string source)
+    {
+        var s = _states.GetOrAdd(source, _ => new State());
+        lock (s) { if (++s.Failures >= _threshold) s.OpenedUntil = _now() + _cooldown; }
+    }
+}

--- a/src/AgentEval.MAF/Evaluators/CompositeAgentEvaluator.cs
+++ b/src/AgentEval.MAF/Evaluators/CompositeAgentEvaluator.cs
@@ -63,7 +63,7 @@ public sealed class CompositeAgentEvaluator : IAgentEvaluator
         var perSource = await Task.WhenAll(_inners.Select(async p =>
         {
             if (_breaker?.IsOpen(p.Source) == true)                                          // breaker: skip fast, no call
-                return (p.Source, SkippedResults(items, p.Source, "circuit open"));
+                return (p.Source, SkippedResults(items, p.Source, "circuit breaker open", label: "skipped"));
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (p.Timeout is { } t) cts.CancelAfter(t);                                       // per-inner hard ceiling

--- a/src/AgentEval.MAF/Evaluators/CompositeAgentEvaluator.cs
+++ b/src/AgentEval.MAF/Evaluators/CompositeAgentEvaluator.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+using Microsoft.Agents.AI;
+using static AgentEval.MAF.Evaluators.HybridEvalInterop;
+
+namespace AgentEval.MAF.Evaluators;
+
+/// <summary>
+/// Runs several inner <see cref="IAgentEvaluator"/>s (e.g. AgentEval-local ⊕ Foundry) over the same
+/// items <b>concurrently</b>, each isolated and individually time-boxed, and merges them into one
+/// <see cref="AgentEvaluationResults"/>. Pass ONE instance to <c>agent.EvaluateAsync(queries, composite)</c>
+/// — the agent still runs once, and this composite fans out to the inner evaluators over its items.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why not just pass an array to <c>agent.EvaluateAsync(queries, IAgentEvaluator[])</c>?</b> MAF's
+/// multi-evaluator overload runs the inners <i>sequentially</i> and does not isolate failures — a slow or
+/// failing cloud evaluator (Foundry) blocks the others and can lose their results. This composer runs them
+/// with <c>Task.WhenAll</c> (wall-clock ≈ the slowest inner, not the sum) and wraps each in a
+/// per-inner <c>try/catch</c> + linked-CTS timeout, so a Foundry timeout becomes a visible "skipped" branch
+/// while the local results survive.
+/// </para>
+/// <para>
+/// A genuine <i>caller</i> cancellation still propagates (see the <c>when</c> guard); only an inner's own
+/// failure/timeout is isolated. An optional <see cref="CircuitBreaker"/> skips a persistently-failing
+/// source fast instead of paying its timeout every call.
+/// </para>
+/// </remarks>
+public sealed class CompositeAgentEvaluator : IAgentEvaluator
+{
+    private readonly IReadOnlyList<(string Source, IAgentEvaluator Evaluator, TimeSpan? Timeout)> _inners;
+    private readonly CircuitBreaker? _breaker;
+
+    /// <summary>Creates a composite over the given inner evaluators.</summary>
+    /// <param name="inners">
+    /// The inner evaluators, each tagged with a stable <c>Source</c> label (used to prefix its metrics and
+    /// to tag its report branch) and an optional per-inner hard <c>Timeout</c> ceiling.
+    /// </param>
+    /// <param name="name">Display name for this evaluator.</param>
+    /// <param name="breaker">Optional shared circuit breaker; when open for a source, that source is skipped.</param>
+    public CompositeAgentEvaluator(
+        IReadOnlyList<(string Source, IAgentEvaluator Evaluator, TimeSpan? Timeout)> inners,
+        string name = "Foundry ⊕ AgentEval",
+        CircuitBreaker? breaker = null)
+    {
+        _inners = inners ?? throw new ArgumentNullException(nameof(inners));
+        Name = name;
+        _breaker = breaker;
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <summary>The untouched per-source results from the last call — feed to <c>UnifiedEvalReport.Build</c>.</summary>
+    public IReadOnlyList<(string Source, AgentEvaluationResults Result)> CapturedPerSource { get; private set; } = [];
+
+    /// <inheritdoc/>
+    public async Task<AgentEvaluationResults> EvaluateAsync(
+        IReadOnlyList<EvalItem> items, string evalName = "Composite", CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        var perSource = await Task.WhenAll(_inners.Select(async p =>
+        {
+            if (_breaker?.IsOpen(p.Source) == true)                                          // breaker: skip fast, no call
+                return (p.Source, SkippedResults(items, p.Source, "circuit open"));
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (p.Timeout is { } t) cts.CancelAfter(t);                                       // per-inner hard ceiling
+            try
+            {
+                var r = await p.Evaluator.EvaluateAsync(items, evalName, cts.Token).ConfigureAwait(false);
+                _breaker?.OnSuccess(p.Source);
+                return (p.Source, r);
+            }
+            catch (Exception ex) when (cancellationToken.IsCancellationRequested is false)    // isolate inner failure/timeout;
+            {                                                                                 // genuine CALLER cancel still bubbles
+                _breaker?.OnFailure(p.Source);
+                return (p.Source, SkippedResults(items, p.Source, ex));
+            }
+        })).ConfigureAwait(false);
+
+        CapturedPerSource = perSource;
+        return Merge(perSource, items, evalName);
+    }
+}

--- a/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
+++ b/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI.Evaluation;
+
+namespace AgentEval.MAF.Evaluators;
+
+/// <summary>
+/// Internal helpers for the hybrid (Foundry ⊕ AgentEval-local) evaluator path: build a visible
+/// "skipped" result for a source that failed/timed out, and merge per-source results into one.
+/// </summary>
+internal static class HybridEvalInterop
+{
+    /// <summary>
+    /// One failed <see cref="EvaluationResult"/> per item, so a down/timed-out source is VISIBLE in the
+    /// merged output (not a silently lost run). The metric key is prefixed with the source name.
+    /// </summary>
+    public static AgentEvaluationResults SkippedResults(IReadOnlyList<EvalItem> items, string source, string reason)
+    {
+        var results = new List<EvaluationResult>(items.Count);
+        for (int i = 0; i < items.Count; i++)
+        {
+            var r = new EvaluationResult();
+            // NumericMetric(name, value, reason) + EvaluationMetricInterpretation(rating, failed, reason):
+            // the exact ctor shapes AgentEvalCompositeEvaluator / FoundryEvals.ParseOutputItem use.
+            r.Metrics[$"{source}:status"] = new NumericMetric($"{source}:status", 0.0, reason)
+            {
+                Interpretation = new EvaluationMetricInterpretation(
+                    rating: EvaluationRating.Unacceptable, failed: true, reason: reason),
+            };
+            results.Add(r);
+        }
+        return new AgentEvaluationResults($"{source} (skipped)", results, inputItems: items) { Error = reason };
+    }
+
+    /// <summary>Convenience overload that formats an exception into the skip reason.</summary>
+    public static AgentEvaluationResults SkippedResults(IReadOnlyList<EvalItem> items, string source, Exception ex)
+        => SkippedResults(items, source, $"{ex.GetType().Name}: {ex.Message}");
+
+    /// <summary>
+    /// Per query <c>i</c>, unions each source's metrics into one <see cref="EvaluationResult"/> with a
+    /// <c>"{source}:"</c> key prefix so metrics from different sources never collide.
+    /// </summary>
+    public static AgentEvaluationResults Merge(
+        IReadOnlyList<(string Source, AgentEvaluationResults Result)> perSource,
+        IReadOnlyList<EvalItem> items, string evalName)
+    {
+        var merged = new List<EvaluationResult>(items.Count);
+        for (int i = 0; i < items.Count; i++)
+        {
+            var e = new EvaluationResult();
+            foreach (var (source, res) in perSource)
+                if (i < res.Items.Count)
+                    foreach (var kv in res.Items[i].Metrics)
+                        e.Metrics[$"{source}:{kv.Key}"] = kv.Value;   // prefix -> no cross-source collisions
+            merged.Add(e);
+        }
+        return new AgentEvaluationResults(evalName, merged, inputItems: items);
+    }
+}

--- a/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
+++ b/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
@@ -17,16 +17,19 @@ internal static class HybridEvalInterop
     /// </summary>
     public static AgentEvaluationResults SkippedResults(IReadOnlyList<EvalItem> items, string source, string reason)
     {
+        // Render as a neutral "skipped"/NOT-TESTED leaf (NOT a confirmed fail): this score marker is what
+        // MeaiToEvalResultBridge parses to recover the label/severity, so a down/timed-out source doesn't
+        // masquerade as a genuine low-scoring result.
+        var marker = $"AgentEval score: 0/100 (skipped, severity none) — {reason}";
         var results = new List<EvaluationResult>(items.Count);
         for (int i = 0; i < items.Count; i++)
         {
             var r = new EvaluationResult();
-            // NumericMetric(name, value, reason) + EvaluationMetricInterpretation(rating, failed, reason):
-            // the exact ctor shapes AgentEvalCompositeEvaluator / FoundryEvals.ParseOutputItem use.
-            r.Metrics[$"{source}:status"] = new NumericMetric($"{source}:status", 0.0, reason)
+            // UNPREFIXED key: Merge() adds the "{source}:" prefix exactly once (no double-prefixing).
+            r.Metrics["status"] = new NumericMetric("status", 0.0, marker)
             {
                 Interpretation = new EvaluationMetricInterpretation(
-                    rating: EvaluationRating.Unacceptable, failed: true, reason: reason),
+                    rating: EvaluationRating.Inconclusive, failed: true, reason: marker),
             };
             results.Add(r);
         }
@@ -52,7 +55,11 @@ internal static class HybridEvalInterop
             foreach (var (source, res) in perSource)
                 if (i < res.Items.Count)
                     foreach (var kv in res.Items[i].Metrics)
-                        e.Metrics[$"{source}:{kv.Key}"] = kv.Value;   // prefix -> no cross-source collisions
+                    {
+                        // Prefix exactly once: guard against an inner that already returns source-prefixed keys.
+                        var mkey = kv.Key.StartsWith($"{source}:", StringComparison.Ordinal) ? kv.Key : $"{source}:{kv.Key}";
+                        e.Metrics[mkey] = kv.Value;   // -> no cross-source collisions, no double-prefix
+                    }
             merged.Add(e);
         }
         return new AgentEvaluationResults(evalName, merged, inputItems: items);

--- a/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
+++ b/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
@@ -12,15 +12,20 @@ namespace AgentEval.MAF.Evaluators;
 internal static class HybridEvalInterop
 {
     /// <summary>
-    /// One failed <see cref="EvaluationResult"/> per item, so a down/timed-out source is VISIBLE in the
-    /// merged output (not a silently lost run). The metric key is prefixed with the source name.
+    /// One neutral <see cref="EvaluationResult"/> per item, so a down/timed-out or intentionally-skipped
+    /// source is VISIBLE in the merged output (not a silently lost run) WITHOUT masquerading as a real
+    /// low-scoring failure.
     /// </summary>
-    public static AgentEvaluationResults SkippedResults(IReadOnlyList<EvalItem> items, string source, string reason)
+    /// <param name="label">
+    /// <c>"error"</c> for an infrastructure failure (timeout/exception — the default), or <c>"skipped"</c>
+    /// for an intentional skip (e.g. circuit breaker open). Renders neutral (severity none) either way; the
+    /// distinction drives the rendered label and the <see cref="UnifiedEvalReport"/> branch.
+    /// </param>
+    public static AgentEvaluationResults SkippedResults(
+        IReadOnlyList<EvalItem> items, string source, string reason, string label = "error")
     {
-        // Render as a neutral "skipped"/NOT-TESTED leaf (NOT a confirmed fail): this score marker is what
-        // MeaiToEvalResultBridge parses to recover the label/severity, so a down/timed-out source doesn't
-        // masquerade as a genuine low-scoring result.
-        var marker = $"AgentEval score: 0/100 (skipped, severity none) — {reason}";
+        // The score marker is what MeaiToEvalResultBridge parses to recover the label/severity.
+        var marker = $"AgentEval score: 0/100 ({label}, severity none) — {reason}";
         var results = new List<EvaluationResult>(items.Count);
         for (int i = 0; i < items.Count; i++)
         {
@@ -33,12 +38,13 @@ internal static class HybridEvalInterop
             };
             results.Add(r);
         }
-        return new AgentEvaluationResults($"{source} (skipped)", results, inputItems: items) { Error = reason };
+        // ProviderName carries the neutral label so UnifiedEvalReport renders the matching neutral branch.
+        return new AgentEvaluationResults($"{source} ({label})", results, inputItems: items) { Error = reason };
     }
 
-    /// <summary>Convenience overload that formats an exception into the skip reason.</summary>
+    /// <summary>Convenience overload for an exception — surfaced as a neutral <c>"error"</c> branch.</summary>
     public static AgentEvaluationResults SkippedResults(IReadOnlyList<EvalItem> items, string source, Exception ex)
-        => SkippedResults(items, source, $"{ex.GetType().Name}: {ex.Message}");
+        => SkippedResults(items, source, $"{ex.GetType().Name}: {ex.Message}", label: "error");
 
     /// <summary>
     /// Per query <c>i</c>, unions each source's metrics into one <see cref="EvaluationResult"/> with a

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -35,7 +35,14 @@ public static class UnifiedEvalReport
                 : Enumerable.Range(0, result.Items.Count).Select(i => $"query[{i}]").ToList();
 
             EvalResult branch;
-            if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0 && result.Items.Count > 0)
+            if (result.Error is not null)
+            {
+                // Neutral infra branch (timeout / exception / breaker-open). Do NOT bridge it: the bridge
+                // produces a fail/high composite that would sink the whole report. Render it neutral instead.
+                var neutralLabel = result.ProviderName.EndsWith("(skipped)", StringComparison.Ordinal) ? "skipped" : "error";
+                branch = NeutralBranch($"hybrid.{Sanitize(source)}", source, neutralLabel, result.Error);
+            }
+            else if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0 && result.Items.Count > 0)
             {
                 // Rich branch: the composite's full weighted hierarchy (one tree per query). CapturedResults
                 // ACCUMULATES across calls and is never cleared, so splice only the most recent Items.Count
@@ -68,19 +75,35 @@ public static class UnifiedEvalReport
         source.Contains("local", StringComparison.OrdinalIgnoreCase) ||
         source.Contains("agenteval", StringComparison.OrdinalIgnoreCase);
 
-    // Mean-aggregated node tagged with `provenanceType` (mirrors MeaiToEvalResultBridge.Composite).
+    private static bool IsNeutral(EvalResult r) => r.Score.Label is "error" or "skipped";
+
+    // Mean-aggregated node tagged with `provenanceType`. Rolls up over NON-neutral sub-results only: a
+    // neutral "error"/"skipped" branch is visible in the tree but never drags the parent to fail/high.
+    // If EVERY sub-result is neutral, the parent is itself neutral (severity none) — nothing was evaluated.
     private static EvalResult Node(string key, string name, string category,
         IReadOnlyList<EvalResult> subs, string provenanceType)
     {
-        var avg = subs.Count == 0 ? 0 : subs.Average(s => s.Score.Value);
-        var passed = subs.Count > 0 && subs.All(s => s.Score.Passed);
+        var real = subs.Where(s => !IsNeutral(s)).ToList();
+        var avg = real.Count == 0 ? 0 : real.Average(s => s.Score.Value);
+        var passed = real.Count > 0 && real.All(s => s.Score.Passed);
+        var (label, severity) = real.Count == 0
+            ? (subs.Any(s => s.Score.Label == "error") ? "error" : "skipped", "none")
+            : (passed ? "pass" : "fail", passed ? "none" : "high");
         return new EvalResult(
             Metric: new EvalMetadata(key, name, category, "1.0.0"),
-            Score: new EvalScore(avg, null, passed ? "pass" : "fail", passed, 0.70, passed ? "none" : "high", null),
+            Score: new EvalScore(avg, null, label, passed, 0.70, severity, null),
             Details: new EvalDetails(null, null, null, subs, "mean"),
             Provenance: new EvalProvenance(provenanceType, null, null, null, null, 0, false),
             EvaluatedAt: DateTimeOffset.UtcNow);
     }
+
+    // A neutral infra branch (label "error"/"skipped", severity none) — visible but never a real failure.
+    private static EvalResult NeutralBranch(string key, string name, string label, string reason) => new(
+        Metric: new EvalMetadata(key, name, "agentic", "1.0.0"),
+        Score: new EvalScore(0.0, null, label, false, 0.70, "none", null),
+        Details: new EvalDetails(null, new[] { new EvalEvidence(name, label, reason) }, null, null, null),
+        Provenance: new EvalProvenance(label, null, null, null, null, 0, false),
+        EvaluatedAt: DateTimeOffset.UtcNow);
 
     private static string Sanitize(string s) =>
         new string(s.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+using Microsoft.Agents.AI;
+using AgentEval.Evals;
+
+namespace AgentEval.MAF.Evaluators;
+
+/// <summary>
+/// Merges the per-source results of a hybrid eval (Foundry ⊕ AgentEval-local) into one source-tagged
+/// <see cref="EvalResult"/> tree for rendering (HTML / PDF / <c>.agenteval</c>). One branch per source.
+/// </summary>
+/// <remarks>
+/// Feed it either the per-source list captured by <see cref="CompositeAgentEvaluator.CapturedPerSource"/>,
+/// or (for MAF's native <c>agent.EvaluateAsync(queries, IAgentEvaluator[])</c>) the returned results zipped
+/// with their source labels. When the optional <c>composite</c> is supplied, the AgentEval-local
+/// branch is spliced from its full weighted hierarchy (<see cref="AgentEvalCompositeEvaluator.CapturedResults"/>);
+/// otherwise every branch is bridged flat via <see cref="MeaiToEvalResultBridge"/>.
+/// </remarks>
+public static class UnifiedEvalReport
+{
+    /// <summary>Builds the unified, source-tagged report tree.</summary>
+    public static EvalResult Build(
+        IReadOnlyList<(string Source, AgentEvaluationResults Result)> perSource,
+        AgentEvalCompositeEvaluator? composite = null,
+        string title = "Foundry ⊕ AgentEval")
+    {
+        ArgumentNullException.ThrowIfNull(perSource);
+        var branches = new List<EvalResult>(perSource.Count);
+
+        foreach (var (source, result) in perSource)
+        {
+            // Recover queries from the shared input items (same agent run for every source).
+            var queries = result.InputItems is { Count: > 0 }
+                ? result.InputItems.Select((it, i) => string.IsNullOrEmpty(it.Query) ? $"query[{i}]" : it.Query).ToList()
+                : Enumerable.Range(0, result.Items.Count).Select(i => $"query[{i}]").ToList();
+
+            EvalResult branch;
+            if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0)
+            {
+                // Rich branch: the composite's full weighted hierarchy (one tree per query).
+                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", composite.CapturedResults, source);
+            }
+            else
+            {
+                // Flat branch: reuse the bridge (per-query -> per-metric leaves), re-tagged as this source.
+                var bridged = MeaiToEvalResultBridge.Build(source, queries, result, judgeModel: null);
+                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", new[] { bridged }, source);
+            }
+
+            // Attach the Foundry portal link (when present) as evidence on the branch.
+            if (result.ReportUrl is not null)
+            {
+                var evidence = new[] { new EvalEvidence("foundry", "report_url", result.ReportUrl.ToString()) };
+                branch = branch with { Details = branch.Details with { Evidence = evidence } };
+            }
+
+            branches.Add(branch);
+        }
+
+        return Node("hybrid.eval", title, "agentic", branches, "composite");
+    }
+
+    private static bool IsLocalAgentEval(string source) =>
+        source.Contains("local", StringComparison.OrdinalIgnoreCase) ||
+        source.Contains("agenteval", StringComparison.OrdinalIgnoreCase);
+
+    // Mean-aggregated node tagged with `provenanceType` (mirrors MeaiToEvalResultBridge.Composite).
+    private static EvalResult Node(string key, string name, string category,
+        IReadOnlyList<EvalResult> subs, string provenanceType)
+    {
+        var avg = subs.Count == 0 ? 0 : subs.Average(s => s.Score.Value);
+        var passed = subs.Count > 0 && subs.All(s => s.Score.Passed);
+        return new EvalResult(
+            Metric: new EvalMetadata(key, name, category, "1.0.0"),
+            Score: new EvalScore(avg, null, passed ? "pass" : "fail", passed, 0.70, passed ? "none" : "high", null),
+            Details: new EvalDetails(null, null, null, subs, "mean"),
+            Provenance: new EvalProvenance(provenanceType, null, null, null, null, 0, false),
+            EvaluatedAt: DateTimeOffset.UtcNow);
+    }
+
+    private static string Sanitize(string s) =>
+        new string(s.Select(c => char.IsLetterOrDigit(c) ? c : '-').ToArray());
+}

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -35,10 +35,13 @@ public static class UnifiedEvalReport
                 : Enumerable.Range(0, result.Items.Count).Select(i => $"query[{i}]").ToList();
 
             EvalResult branch;
-            if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0)
+            if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0 && result.Items.Count > 0)
             {
-                // Rich branch: the composite's full weighted hierarchy (one tree per query).
-                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", composite.CapturedResults, source);
+                // Rich branch: the composite's full weighted hierarchy (one tree per query). CapturedResults
+                // ACCUMULATES across calls and is never cleared, so splice only the most recent Items.Count
+                // trees — otherwise a reused composite instance would leak prior runs' trees into this report.
+                var recent = composite.CapturedResults.TakeLast(result.Items.Count).ToList();
+                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", recent, source);
             }
             else
             {
@@ -47,10 +50,11 @@ public static class UnifiedEvalReport
                 branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", new[] { bridged }, source);
             }
 
-            // Attach the Foundry portal link (when present) as evidence on the branch.
+            // Attach the provider's portal link (when present) as evidence on the branch. Use the actual
+            // source label (not a hard-coded "foundry") so a non-Foundry provider isn't misattributed.
             if (result.ReportUrl is not null)
             {
-                var evidence = new[] { new EvalEvidence("foundry", "report_url", result.ReportUrl.ToString()) };
+                var evidence = new[] { new EvalEvidence(source, "report_url", result.ReportUrl.ToString()) };
                 branch = branch with { Details = branch.Details with { Evidence = evidence } };
             }
 

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -35,12 +35,14 @@ public static class UnifiedEvalReport
                 : Enumerable.Range(0, result.Items.Count).Select(i => $"query[{i}]").ToList();
 
             EvalResult branch;
-            if (result.Error is not null)
+            if (result.Error is not null || result.Items.Count == 0)
             {
-                // Neutral infra branch (timeout / exception / breaker-open). Do NOT bridge it: the bridge
-                // produces a fail/high composite that would sink the whole report. Render it neutral instead.
+                // Neutral infra branch (timeout / exception / breaker-open / empty result set). Do NOT bridge:
+                // the bridge yields a fail/high composite (an empty composite is "not passed") that would
+                // sink the whole report. Render it neutral instead.
+                var reason = result.Error ?? "no results returned";
                 var neutralLabel = result.ProviderName.EndsWith("(skipped)", StringComparison.Ordinal) ? "skipped" : "error";
-                branch = NeutralBranch($"hybrid.{Sanitize(source)}", source, neutralLabel, result.Error);
+                branch = NeutralBranch($"hybrid.{Sanitize(source)}", source, neutralLabel, reason);
             }
             else if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0 && result.Items.Count > 0)
             {
@@ -58,10 +60,12 @@ public static class UnifiedEvalReport
             }
 
             // Attach the provider's portal link (when present) as evidence on the branch. Use the actual
-            // source label (not a hard-coded "foundry") so a non-Foundry provider isn't misattributed.
+            // source label (not a hard-coded "foundry") so a non-Foundry provider isn't misattributed, and
+            // APPEND so it never clobbers evidence the branch already carries (e.g. a neutral error branch).
             if (result.ReportUrl is not null)
             {
-                var evidence = new[] { new EvalEvidence(source, "report_url", result.ReportUrl.ToString()) };
+                var link = new EvalEvidence(source, "report_url", result.ReportUrl.ToString());
+                var evidence = branch.Details.Evidence is { } existing ? existing.Append(link).ToArray() : new[] { link };
                 branch = branch with { Details = branch.Details with { Evidence = evidence } };
             }
 

--- a/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
@@ -31,7 +31,7 @@ public class AgentEvaluatorEvalLeafTests
     }
 
     [Fact]
-    public async Task AsEvalLeaf_failing_evaluator_is_isolated_into_a_failing_leaf()
+    public async Task AsEvalLeaf_failing_evaluator_is_isolated_into_a_neutral_error_leaf()
     {
         IEval leaf = Throws("foundry").AsEvalLeaf("foundry.relevance", "Foundry Relevance");
 
@@ -39,7 +39,9 @@ public class AgentEvaluatorEvalLeafTests
 
         Assert.False(result.Score.Passed);
         Assert.Equal(0.0, result.Score.Value);
-        Assert.Contains(result.Details.Evidence!, e => e.Message.Contains("boom"));
+        Assert.Equal("error", result.Score.Label);       // infra failure != a confirmed "fail"
+        Assert.Equal("none", result.Score.Severity);     // neutral — must not masquerade as a violation
+        Assert.Contains(result.Details.Evidence!, e => e.Message.Contains("InvalidOperationException") && e.Message.Contains("boom"));
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Evals;
+using AgentEval.MAF.Evaluators;
+using Xunit;
+
+using static AgentEval.Tests.MAF.Evaluators.HybridEvalTestHelpers;
+
+namespace AgentEval.Tests.MAF.Evaluators;
+
+/// <summary>
+/// Tests <see cref="AgentEvaluatorEvalLeaf"/> / <c>AsEvalLeaf()</c> — a MAF <c>IAgentEvaluator</c> (e.g.
+/// Foundry) wrapped as an AgentEval <c>IEval</c> so it can be a weighted leaf inside a <c>CompositeEval</c>.
+/// </summary>
+public class AgentEvaluatorEvalLeafTests
+{
+    [Fact]
+    public async Task AsEvalLeaf_passing_evaluator_produces_a_passing_leaf()
+    {
+        IEval leaf = Fast("foundry").AsEvalLeaf("foundry.relevance", "Foundry Relevance", judgeModel: "gpt-4o-mini");
+
+        var result = await leaf.EvaluateAsync(new EvalInput("What is the capital of France?", "Paris."));
+
+        Assert.Equal("foundry.relevance", result.Metric.Key);
+        Assert.Equal("Foundry Relevance", result.Metric.Name);
+        Assert.True(result.Score.Passed);
+        Assert.True(result.Score.Value > 0.0);
+        Assert.Equal("gpt-4o-mini", result.Provenance.JudgeModel);
+    }
+
+    [Fact]
+    public async Task AsEvalLeaf_failing_evaluator_is_isolated_into_a_failing_leaf()
+    {
+        IEval leaf = Throws("foundry").AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+
+        var result = await leaf.EvaluateAsync(new EvalInput("q", "r"));   // must NOT throw
+
+        Assert.False(result.Score.Passed);
+        Assert.Equal(0.0, result.Score.Value);
+        Assert.Contains(result.Details.Evidence!, e => e.Message.Contains("boom"));
+    }
+
+    [Fact]
+    public async Task AsEvalLeaf_composes_as_a_weighted_component_in_a_CompositeEval()
+    {
+        IEval foundryLeaf = Fast("foundry").AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+        IEval agentEvalLeaf = new StubComposite(Leaf("task_completion", 1.0));
+
+        var benchmark = new CompositeEval(
+            key: "hybrid.benchmark", name: "Hybrid Benchmark", category: "hybrid", version: "1.0.0",
+            components: new[]
+            {
+                new EvalComponent(agentEvalLeaf, 0.5),   // AgentEval leaf
+                new EvalComponent(foundryLeaf, 0.5),     // Foundry eval as a weighted leaf
+            },
+            aggregation: WeightedSumAggregation.Instance,
+            threshold: 0.5);
+
+        var result = await benchmark.EvaluateAsync(new EvalInput("q", "r"));
+
+        Assert.Equal(2, result.Details.SubResults!.Count);
+        Assert.Contains(result.Details.SubResults!, r => r.Metric.Key == "foundry.relevance");
+        Assert.True(result.Score.Passed);          // both components pass -> weighted sum clears 0.5
+        Assert.True(result.Score.Value > 0.0);
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/CircuitBreakerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/CircuitBreakerTests.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Evaluators;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Evaluators;
+
+/// <summary>Unit coverage for <see cref="CircuitBreaker"/> — threshold, reset, cooldown (fake clock), per-source isolation.</summary>
+public class CircuitBreakerTests
+{
+    [Fact]
+    public void NotOpen_Initially()
+    {
+        var b = new CircuitBreaker(threshold: 2);
+        Assert.False(b.IsOpen("x"));
+    }
+
+    [Fact]
+    public void Opens_AtThreshold()
+    {
+        var b = new CircuitBreaker(threshold: 2);
+        b.OnFailure("x");
+        Assert.False(b.IsOpen("x"));   // 1 < 2
+        b.OnFailure("x");
+        Assert.True(b.IsOpen("x"));    // 2 >= 2 -> open
+    }
+
+    [Fact]
+    public void Resets_OnSuccess()
+    {
+        var b = new CircuitBreaker(threshold: 2);
+        b.OnFailure("x");
+        b.OnSuccess("x");              // resets the count
+        b.OnFailure("x");
+        Assert.False(b.IsOpen("x"));   // only 1 failure since reset
+    }
+
+    [Fact]
+    public void Reopens_AfterCooldown_WithFakeClock()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var b = new CircuitBreaker(threshold: 1, cooldown: TimeSpan.FromMinutes(1), now: () => now);
+        b.OnFailure("x");
+        Assert.True(b.IsOpen("x"));    // open
+        now = now.AddMinutes(2);       // cooldown elapsed
+        Assert.False(b.IsOpen("x"));   // closed again
+    }
+
+    [Fact]
+    public void IsPerSource()
+    {
+        var b = new CircuitBreaker(threshold: 1);
+        b.OnFailure("a");
+        Assert.True(b.IsOpen("a"));
+        Assert.False(b.IsOpen("b"));   // independent per source
+    }
+
+    [Fact]
+    public void Ctor_RejectsThresholdBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new CircuitBreaker(threshold: 0));
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/CircuitBreakerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/CircuitBreakerTests.cs
@@ -49,6 +49,23 @@ public class CircuitBreakerTests
     }
 
     [Fact]
+    public void Cooldown_ResetsFailureCount_NextWindowNeedsThresholdAgain()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var b = new CircuitBreaker(threshold: 2, cooldown: TimeSpan.FromMinutes(1), now: () => now);
+        b.OnFailure("x"); b.OnFailure("x");   // 2 consecutive -> open
+        Assert.True(b.IsOpen("x"));
+
+        now = now.AddMinutes(2);              // cooldown elapsed -> closed
+        Assert.False(b.IsOpen("x"));
+
+        b.OnFailure("x");                     // a SINGLE stale failure must NOT immediately re-open
+        Assert.False(b.IsOpen("x"));
+        b.OnFailure("x");                     // 2 consecutive since cooldown -> open again
+        Assert.True(b.IsOpen("x"));
+    }
+
+    [Fact]
     public void IsPerSource()
     {
         var b = new CircuitBreaker(threshold: 1);

--- a/tests/AgentEval.Tests/MAF/Evaluators/CompositeAgentEvaluatorTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/CompositeAgentEvaluatorTests.cs
@@ -16,14 +16,29 @@ namespace AgentEval.Tests.MAF.Evaluators;
 public class CompositeAgentEvaluatorTests
 {
     [Fact]
-    public async Task Concurrency_InnersRunInParallel_NotSummed()
+    public async Task Concurrency_InnersStartBeforeEitherCompletes()
     {
-        // Two 300ms inners: sequential ≈ 600ms, concurrent ≈ 300ms.
-        var comp = new CompositeAgentEvaluator([("a", Slow("a", 300), null), ("b", Slow("b", 300), null)]);
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        await comp.EvaluateAsync(Items(2), "t", CancellationToken.None);
-        sw.Stop();
-        Assert.True(sw.ElapsedMilliseconds < 500, $"expected concurrent (<500ms), took {sw.ElapsedMilliseconds}ms");
+        // Deterministic (no wall-clock): both inner bodies signal "started" then block on a shared gate.
+        // If the composite ran them sequentially, the second would never start and WhenAll would hang.
+        var aStarted = new TaskCompletionSource();
+        var bStarted = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        FakeEvaluator Gated(string s, TaskCompletionSource started) => new(s, async (items, _) =>
+        {
+            started.SetResult();
+            await release.Task;
+            return Pass(items, s);
+        });
+
+        var comp = new CompositeAgentEvaluator([("a", Gated("a", aStarted), null), ("b", Gated("b", bStarted), null)]);
+        var eval = comp.EvaluateAsync(Items(1), "t", CancellationToken.None);
+
+        await Task.WhenAll(aStarted.Task, bStarted.Task).WaitAsync(TimeSpan.FromSeconds(5));   // both started
+        Assert.False(eval.IsCompleted);          // neither finished — both blocked on the gate -> concurrent
+        release.SetResult();
+        await eval;
+        Assert.Equal(2, comp.CapturedPerSource.Count);
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/MAF/Evaluators/CompositeAgentEvaluatorTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/CompositeAgentEvaluatorTests.cs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Evaluators;
+using Xunit;
+using static AgentEval.Tests.MAF.Evaluators.HybridEvalTestHelpers;
+
+namespace AgentEval.Tests.MAF.Evaluators;
+
+/// <summary>
+/// Unit coverage for <see cref="CompositeAgentEvaluator"/>: concurrent fan-out, per-source failure
+/// isolation, per-inner timeout, caller-cancellation propagation, source-prefixed merge, and the
+/// circuit breaker. All in-memory via <c>FakeEvaluator</c> — no LLM / no live Foundry.
+/// </summary>
+public class CompositeAgentEvaluatorTests
+{
+    [Fact]
+    public async Task Concurrency_InnersRunInParallel_NotSummed()
+    {
+        // Two 300ms inners: sequential ≈ 600ms, concurrent ≈ 300ms.
+        var comp = new CompositeAgentEvaluator([("a", Slow("a", 300), null), ("b", Slow("b", 300), null)]);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await comp.EvaluateAsync(Items(2), "t", CancellationToken.None);
+        sw.Stop();
+        Assert.True(sw.ElapsedMilliseconds < 500, $"expected concurrent (<500ms), took {sw.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task Isolation_ThrowingInner_OtherSurvives()
+    {
+        var comp = new CompositeAgentEvaluator([("local", Fast("local"), null), ("foundry", Throws("foundry"), null)]);
+
+        var merged = await comp.EvaluateAsync(Items(2), "t", CancellationToken.None);   // must NOT throw
+
+        Assert.Equal(2, comp.CapturedPerSource.Count);
+        Assert.NotNull(comp.CapturedPerSource.Single(s => s.Source == "foundry").Result.Error);   // skipped
+        Assert.Null(comp.CapturedPerSource.Single(s => s.Source == "local").Result.Error);        // survived
+        Assert.Contains(merged.Items[0].Metrics.Keys, k => k.StartsWith("local:", StringComparison.Ordinal));
+        Assert.Contains(merged.Items[0].Metrics.Keys, k => k.StartsWith("foundry:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Timeout_PerInnerCeiling_MarksSkipped_OtherSurvives()
+    {
+        var comp = new CompositeAgentEvaluator(
+            [("fast", Fast("fast"), null), ("slow", Slow("slow", 2000), TimeSpan.FromMilliseconds(50))]);
+
+        await comp.EvaluateAsync(Items(1), "t", CancellationToken.None);
+
+        Assert.NotNull(comp.CapturedPerSource.Single(s => s.Source == "slow").Result.Error);   // timed out -> skipped
+        Assert.Null(comp.CapturedPerSource.Single(s => s.Source == "fast").Result.Error);      // survived
+    }
+
+    [Fact]
+    public async Task CallerCancellation_Propagates()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var comp = new CompositeAgentEvaluator([("slow", Slow("slow", 200), null)]);
+
+        // Genuine caller cancellation must bubble, NOT be swallowed as a skipped branch.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => comp.EvaluateAsync(Items(1), "t", cts.Token));
+    }
+
+    [Fact]
+    public async Task Merge_PrefixesKeys_NoCollision()
+    {
+        // Both sources emit a metric named "relevance"; the source prefix keeps them distinct.
+        var comp = new CompositeAgentEvaluator([("local", Fast("local"), null), ("foundry", Fast("foundry"), null)]);
+
+        var merged = await comp.EvaluateAsync(Items(1), "t", CancellationToken.None);
+
+        Assert.Contains("local:relevance", merged.Items[0].Metrics.Keys);
+        Assert.Contains("foundry:relevance", merged.Items[0].Metrics.Keys);
+    }
+
+    [Fact]
+    public async Task Breaker_OpensAfterThreshold_SkipsFast_ThenReopensAfterCooldown()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var breaker = new CircuitBreaker(threshold: 2, cooldown: TimeSpan.FromMinutes(1), now: () => now);
+        var foundry = Throws("foundry");
+        var comp = new CompositeAgentEvaluator([("foundry", foundry, null)], breaker: breaker);
+
+        await comp.EvaluateAsync(Items(1), "t");   // 1: invoke -> fail  (failures=1)
+        await comp.EvaluateAsync(Items(1), "t");   // 2: invoke -> fail  (failures=2 -> open)
+        await comp.EvaluateAsync(Items(1), "t");   // 3: breaker OPEN -> skip fast (no invoke)
+        Assert.Equal(2, foundry.Calls);
+
+        now = now.AddMinutes(2);                    // cooldown elapsed
+        await comp.EvaluateAsync(Items(1), "t");   // 4: breaker closed -> invoke again
+        Assert.Equal(3, foundry.Calls);
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/HybridEvalTestHelpers.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/HybridEvalTestHelpers.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI.Evaluation;
+using AgentEval.Evals;
+
+namespace AgentEval.Tests.MAF.Evaluators;
+
+/// <summary>
+/// Shared in-memory fakes for the hybrid-eval tests (<c>CompositeAgentEvaluator</c> /
+/// <c>UnifiedEvalReport</c>) — no LLM, no network, so the whole suite runs in milliseconds.
+/// </summary>
+internal static class HybridEvalTestHelpers
+{
+    /// <summary>Builds <paramref name="n"/> minimal <see cref="EvalItem"/>s (query/response only).</summary>
+    public static IReadOnlyList<EvalItem> Items(int n) =>
+        Enumerable.Range(0, n).Select(i => new EvalItem($"q{i}", $"r{i}")).ToList();
+
+    /// <summary>A passing <see cref="AgentEvaluationResults"/> with one numeric metric per item.</summary>
+    public static AgentEvaluationResults Pass(IReadOnlyList<EvalItem> items, string source, string metric = "relevance")
+    {
+        var results = items.Select(_ =>
+        {
+            var r = new EvaluationResult();
+            r.Metrics[metric] = new NumericMetric(metric, 5.0, "ok")
+            { Interpretation = new EvaluationMetricInterpretation(EvaluationRating.Good, failed: false, reason: "ok") };
+            return r;
+        }).ToList();
+        return new AgentEvaluationResults(source, results, inputItems: items);
+    }
+
+    /// <summary>Fake <see cref="IAgentEvaluator"/> whose behaviour is a lambda; counts invocations.</summary>
+    public sealed class FakeEvaluator(
+        string name,
+        Func<IReadOnlyList<EvalItem>, CancellationToken, Task<AgentEvaluationResults>> body) : IAgentEvaluator
+    {
+        private int _calls;
+        public string Name { get; } = name;
+        public int Calls => Volatile.Read(ref _calls);
+        public Task<AgentEvaluationResults> EvaluateAsync(IReadOnlyList<EvalItem> items, string evalName, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _calls);
+            return body(items, ct);
+        }
+    }
+
+    public static FakeEvaluator Fast(string s) => new(s, (items, _) => Task.FromResult(Pass(items, s)));
+    public static FakeEvaluator Slow(string s, int ms) => new(s, async (items, ct) => { await Task.Delay(ms, ct); return Pass(items, s); });
+    public static FakeEvaluator Throws(string s) => new(s, (_, _) => throw new InvalidOperationException($"{s} boom"));
+
+    /// <summary>An <see cref="IEval"/> that returns a fixed tree (no LLM) — populates CapturedResults cheaply.</summary>
+    public sealed class StubComposite(EvalResult tree) : IEval
+    {
+        public string Key => "stub";
+        public string Name => "StubComposite";
+        public string Category => "agentic";
+        public string Version => "1.0.0";
+        public Task<EvalResult> EvaluateAsync(EvalInput input, CancellationToken ct = default) => Task.FromResult(tree);
+    }
+
+    public static EvalResult Leaf(string name, double value) => new(
+        new EvalMetadata(name, name, "quality", "1.0.0"),
+        new EvalScore(value, null, value >= 0.7 ? "pass" : "fail", value >= 0.7, 0.7, value >= 0.7 ? "none" : "high", null),
+        new EvalDetails(null, null, null, null, null),
+        new EvalProvenance("atomic-llm", null, null, null, null, 0, false),
+        DateTimeOffset.UtcNow);
+
+    public static EvalResult Tree(params EvalResult[] subs) => new(
+        new EvalMetadata("root", "StubComposite", "agentic", "1.0.0"),
+        new EvalScore(subs.Length == 0 ? 0 : subs.Average(s => s.Score.Value), null, "pass", true, 0.7, "none", null),
+        new EvalDetails(null, null, null, subs, "mean"),
+        new EvalProvenance("composite", null, null, null, null, 0, false),
+        DateTimeOffset.UtcNow);
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/UnifiedEvalReportTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/UnifiedEvalReportTests.cs
@@ -37,6 +37,21 @@ public class UnifiedEvalReportTests
     }
 
     [Fact]
+    public void Build_EmptyResultSet_IsNeutralErrorBranch_DoesNotSinkTheRoot()
+    {
+        var items = Items(1);
+        var empty = new AgentEvaluationResults(
+            "foundry", new List<Microsoft.Extensions.AI.Evaluation.EvaluationResult>(), inputItems: items);   // no Error, zero items
+
+        var report = UnifiedEvalReport.Build([("agenteval-local", Pass(items, "agenteval-local")), ("foundry", empty)]);
+
+        var foundryBranch = report.Details.SubResults!.Single(b => b.Metric.Name == "foundry");
+        Assert.Equal("error", foundryBranch.Score.Label);      // neutral, not a confirmed fail
+        Assert.Equal("none", foundryBranch.Score.Severity);
+        Assert.Equal("pass", report.Score.Label);              // the neutral branch must NOT sink the passing local branch
+    }
+
+    [Fact]
     public async Task Build_WithComposite_KeepsRichLocalHierarchy()
     {
         // A depth-2 composite tree, captured by running the AgentEvalCompositeEvaluator once.

--- a/tests/AgentEval.Tests/MAF/Evaluators/UnifiedEvalReportTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/UnifiedEvalReportTests.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using AgentEval.MAF.Evaluators;
+using Xunit;
+using static AgentEval.Tests.MAF.Evaluators.HybridEvalTestHelpers;
+
+namespace AgentEval.Tests.MAF.Evaluators;
+
+/// <summary>
+/// Unit coverage for <see cref="UnifiedEvalReport"/>: one source-tagged branch per source, the Foundry
+/// portal link surfaced as evidence, and the AgentEval-local branch preserving its full composite hierarchy.
+/// </summary>
+public class UnifiedEvalReportTests
+{
+    [Fact]
+    public void Build_OneBranchPerSource_AndFoundryReportUrlEvidence()
+    {
+        var items = Items(2);
+        var local = Pass(items, "agenteval-local");
+        var foundry = new AgentEvaluationResults("foundry", Pass(items, "foundry").Items, inputItems: items)
+        {
+            ReportUrl = new Uri("https://foundry.example/report/123"),
+        };
+
+        var report = UnifiedEvalReport.Build([("agenteval-local", local), ("foundry", foundry)]);
+
+        Assert.NotNull(report.Details.SubResults);
+        Assert.Equal(2, report.Details.SubResults!.Count);
+
+        var foundryBranch = report.Details.SubResults!.Single(b => b.Metric.Name == "foundry");
+        Assert.NotNull(foundryBranch.Details.Evidence);
+        Assert.Contains(foundryBranch.Details.Evidence!, e => e.Reference == "report_url");
+    }
+
+    [Fact]
+    public async Task Build_WithComposite_KeepsRichLocalHierarchy()
+    {
+        // A depth-2 composite tree, captured by running the AgentEvalCompositeEvaluator once.
+        var tree = Tree(Leaf("goal", 0.9), Leaf("rule", 0.8));
+        var composite = new AgentEvalCompositeEvaluator(new StubComposite(tree));
+        await composite.EvaluateAsync(
+            [new ChatMessage(ChatRole.User, "q")],
+            new ChatResponse(new ChatMessage(ChatRole.Assistant, "r")));   // populates CapturedResults
+
+        var items = Items(1);
+        var report = UnifiedEvalReport.Build([("agenteval-local", Pass(items, "agenteval-local"))], composite);
+
+        var branch = Assert.Single(report.Details.SubResults!);
+        // The spliced composite tree keeps its own children -> hierarchy depth > 1 (not flattened).
+        Assert.NotNull(branch.Details.SubResults);
+        Assert.All(branch.Details.SubResults!, node => Assert.NotEmpty(node.Details.SubResults!));
+    }
+}


### PR DESCRIPTION
## What

Enables **Azure AI Foundry evals to run alongside — and inside — AgentEval evals**, plus the MAF **1.12.0** bump that unlocks the Foundry package. Two integration directions, both provider-agnostic in the core:

1. **Foundry *alongside* local** (batched) — `CompositeAgentEvaluator` runs several `IAgentEvaluator`s over one agent run concurrently, isolates each (a failing/slow source becomes a visible "skipped" branch), bounds the cloud call with a per-source timeout, and merges into one source-tagged report via `UnifiedEvalReport`.
2. **Foundry *inside* a composite hierarchy** — `IAgentEvaluator.AsEvalLeaf()` wraps a Foundry eval as an AgentEval `IEval`, so it's a **weighted leaf inside a `CompositeEval`**, next to AgentEval leaves, under the same weighting/thresholding/aggregation.

## Core (in `AgentEval.MAF`, no Foundry reference — provider-agnostic)
- `CompositeAgentEvaluator` — concurrent fan-out + per-source isolation + timeout + optional `CircuitBreaker`.
- `UnifiedEvalReport` — one source-tagged `EvalResult` tree (a branch per source); splices an AgentEval composite's full hierarchy; surfaces a provider report URL as evidence.
- `CircuitBreaker` — consecutive-failure breaker (injectable clock).
- `AgentEvaluatorEvalLeaf` / `AsEvalLeaf()` — the inverse of `AsAgentEvaluator`; a MAF evaluator as an AgentEval `IEval` leaf.

## Samples
- `samples/AgentEval.MafEvalFoundryAlongsideLocal` — standalone end-to-end hybrid (Pattern A native mix, Pattern B `CompositeAgentEvaluator`).
- `AgentEval.Samples` → Benchmarks → **Foundry Hybrid** (H12, alongside/batched) and **Foundry Hierarchy** (H13, Foundry evals as weighted leaves in a composite tree). Both gated on `FOUNDRY_PROJECT_ENDPOINT`.

## Versions
- MAF core (`Microsoft.Agents.AI` + `.OpenAI` + `.Workflows` + `.Workflows.Generators`) **1.11.1 → 1.12.0 (stable)** across the solution — **no breaking changes** for AgentEval.
- `Microsoft.Agents.AI.Foundry` has no stable 1.12.0 yet, so it's pinned to its `1.12.0-preview` + `Azure.AI.Projects 2.1.0-beta.3`, referenced **only** by the samples. Core libraries stay provider-agnostic.
- `extern alias` on Azure.Identity in the samples to disambiguate `DefaultAzureCredential` (also declared in Azure.Core 1.57 via the Foundry beta).

## Testing
- Full suite green: **net8 6653/0**, **net10 6856/0** (+1 pre-existing skip). Solution builds clean net8/9/10.
- 17 new hybrid unit tests (in-memory fakes, no network): composer concurrency/isolation/timeout/cancel/merge, circuit breaker, unified report, and `AsEvalLeaf` (passing / isolated-failure / composed-in-a-`CompositeEval`).
- maf-doctor grade unchanged pre→post bump (C / 289 findings — no new findings from 1.12).

## Not covered
The samples **build** but haven't been run end-to-end against a **live** Foundry project (needs a Foundry endpoint + Azure creds). Everything short of a live run is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGXTUkPBGWXgR7HqfSDsPX