### PR TITLE
docs(maf): document all SkippedResults params (silence DocFX warnings)

### DIFF
--- a/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
+++ b/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
@@ -16,6 +16,9 @@ internal static class HybridEvalInterop
     /// source is VISIBLE in the merged output (not a silently lost run) WITHOUT masquerading as a real
     /// low-scoring failure.
     /// </summary>
+    /// <param name="items">The eval items being scored — one status result is produced per item.</param>
+    /// <param name="source">The source label for this branch (e.g. "foundry", "agenteval-local").</param>
+    /// <param name="reason">Human-readable reason for the skip/error (timeout, exception message, breaker open).</param>
     /// <param name="label">
     /// <c>"error"</c> for an infrastructure failure (timeout/exception — the default), or <c>"skipped"</c>
     /// for an intentional skip (e.g. circuit breaker open). Renders neutral (severity none) either way; the


### PR DESCRIPTION
## What

#68 added a `label` parameter to `HybridEvalInterop.SkippedResults` and documented only `<param name="label">`. DocFX warns when *some but not all* parameters are documented, so `items` / `source` / `reason` were flagged as "no matching param tag (but other parameters do)" in the `Documentation` build.

This adds the three missing `<param>` tags so all four parameters are documented.

- **Doc-comment only** — no behavior change, no tests affected.
- Silences the three DocFX annotations introduced in #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGXTUkPBGWXgR7HqfSDsPX