### PR TITLE
feat(glassbox): Part 2 foundations + workflow trace fidelity (A1/A2/B1/B2/B3)

### DIFF
--- a/src/AgentEval.Abstractions/Evals/EvalInput.cs
+++ b/src/AgentEval.Abstractions/Evals/EvalInput.cs
@@ -39,4 +39,14 @@ public sealed record EvalInput(
     IReadOnlyList<ToolDefinition>? ToolDefinitions = null,
     IReadOnlyList<ExpectedAction>? ExpectedActions = null,
     string? SystemMessage = null,
-    IReadOnlyDictionary<string, object>? Metadata = null);
+    IReadOnlyDictionary<string, object>? Metadata = null)
+{
+    /// <summary>
+    /// Canonical <see cref="Metadata"/> key under which a Glass Box <c>AgentTrace</c> may be stashed so
+    /// trace-aware evaluators (Glass Box Part 2) can read what actually happened at the chat/tool boundary.
+    /// Kept as a string-keyed <see cref="Metadata"/> entry — not a typed field — because this Abstractions
+    /// assembly cannot reference the Core trace type. Set via <c>WithTrace</c> and read via <c>GetTrace</c>
+    /// (both in <c>AgentEval.Core</c>, namespace <c>AgentEval.Evals</c>).
+    /// </summary>
+    public const string TraceMetadataKey = "__agentTrace__";
+}

--- a/src/AgentEval.Abstractions/Models/WorkflowExecutionResult.cs
+++ b/src/AgentEval.Abstractions/Models/WorkflowExecutionResult.cs
@@ -192,6 +192,13 @@ public record ExecutorStep
     public Core.TokenUsage? TokenUsage { get; init; }
 
     /// <summary>
+    /// Finish reason reported for this executor's agent response (e.g. "stop", "length", "content_filter"),
+    /// when available. Populated (Glass Box Part 2, P2.B1) from the per-executor ledger built off MAF's
+    /// <c>ExecutorAgentResponseEvent</c>; <c>null</c> when the executor emitted no complete agent response.
+    /// </summary>
+    public string? FinishReason { get; init; }
+
+    /// <summary>
     /// The input this executor received (may be from previous executor).
     /// </summary>
     public string? Input { get; init; }

--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -51,8 +51,24 @@ public sealed record WorkflowExecutorFidelity(
 /// <summary>The whole-workflow reconciliation result.</summary>
 public sealed record WorkflowTraceFidelityReport(IReadOnlyList<WorkflowExecutorFidelity> Executors)
 {
-    /// <summary>Mean of the per-executor fidelity scores (1.0 when there are no executors).</summary>
-    public double OverallScore => Executors.Count == 0 ? 1.0 : Executors.Average(e => e.Score);
+    /// <summary>
+    /// Mean fidelity over executors that HAVE chat-boundary truth (<see cref="WorkflowFidelityDiff"/> !=
+    /// <see cref="WorkflowFidelityDiff.NoTruth"/>); 1.0 when none is verifiable. NoTruth executors are
+    /// deliberately EXCLUDED from the aggregate — otherwise, in a partial-truth workflow, a genuine deception
+    /// on one traced executor would be averaged away by many untraced (NoTruth = 1.0) executors and pass the
+    /// gate. Coverage is reported separately via <see cref="VerifiedCount"/> / <see cref="Executors"/>.Count.
+    /// </summary>
+    public double OverallScore
+    {
+        get
+        {
+            var verified = Executors.Where(e => e.DiffKind != WorkflowFidelityDiff.NoTruth).ToList();
+            return verified.Count == 0 ? 1.0 : verified.Average(e => e.Score);
+        }
+    }
+
+    /// <summary>Number of executors that had chat-boundary truth to reconcile against (not NoTruth).</summary>
+    public int VerifiedCount => Executors.Count(e => e.DiffKind != WorkflowFidelityDiff.NoTruth);
 }
 
 /// <summary>
@@ -66,6 +82,16 @@ public sealed record WorkflowTraceFidelityReport(IReadOnlyList<WorkflowExecutorF
 /// chat trace per executor for the whole run, so a loop workflow that produces multiple
 /// <see cref="ExecutorStep"/>s for one executor must have their framework tokens SUMMED before comparison
 /// — otherwise every looped executor falsely reports a TokenMismatch (fix C5).
+/// <para>
+/// <b>Chat-truth availability caveat.</b> The <paramref name="chatTraces"/> dict must contain per-executor
+/// traces that carry <see cref="TraceEntryScope.ChatTurn"/> <b>Response</b> entries. Inside a <i>live</i> MAF
+/// <c>InProcessExecution</c> workflow those are NOT available today — <c>WorkflowChatRecording</c> documents
+/// that executor responses are not routed back through the instrumented client, so per-executor traces come
+/// back without Response entries (the Glass Box Path-2 upstream-MAF-hook gap). Until that hook lands, every
+/// executor in a live run is <see cref="WorkflowFidelityDiff.NoTruth"/> (ledger-only, score 1.0); the
+/// reconciler produces real reconciliation only for <b>direct-agent / pre-wired / hand-built</b> traces.
+/// This is a library primitive: it has no registered benchmark family or CLI wiring yet (follow-up P2.B4).
+/// </para>
 /// </remarks>
 public sealed class WorkflowTraceFidelityReconciler
 {
@@ -183,7 +209,12 @@ public sealed class WorkflowTraceFidelityReconciler
                 Passed: report.OverallScore >= 0.8, Threshold: 0.8,
                 Severity: report.OverallScore >= 0.8 ? "low" : report.OverallScore >= 0.5 ? "medium" : "high", Confidence: null),
             Details: new EvalDetails(
-                Dimensions: new Dictionary<string, double> { ["score100"] = report.OverallScore * 100, ["executors"] = report.Executors.Count },
+                Dimensions: new Dictionary<string, double>
+                {
+                    ["score100"] = report.OverallScore * 100,
+                    ["executors"] = report.Executors.Count,
+                    ["verified"] = report.VerifiedCount, // executors with chat-boundary truth; the rest are NoTruth
+                },
                 Evidence: null, Recommendations: null, SubResults: subResults, AggregationStrategy: "per-executor"),
             Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
             EvaluatedAt: DateTimeOffset.UtcNow);

--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Evals;
+using AgentEval.Models;
+using AgentEval.Tracing;
+
+namespace AgentEval.Benchmarks;
+
+/// <summary>How an executor's framework-reported ledger compares to chat-boundary truth.</summary>
+public enum WorkflowFidelityDiff
+{
+    /// <summary>Framework tokens and finish reason match chat-boundary truth.</summary>
+    Agree,
+
+    /// <summary>Only the summed token total diverges.</summary>
+    TokenMismatch,
+
+    /// <summary>Only the finish reason diverges.</summary>
+    FinishMismatch,
+
+    /// <summary>Both tokens and finish reason diverge.</summary>
+    Both,
+
+    /// <summary>No chat-boundary trace was supplied for this executor (live-workflow Path-4 / ledger-only).</summary>
+    NoTruth,
+}
+
+/// <summary>Per-executor reconciliation record.</summary>
+public sealed record WorkflowExecutorFidelity(
+    string ExecutorId,
+    int TokensFramework,
+    int? TokensChatTruth,
+    string? FinishFramework,
+    string? FinishChatTruth,
+    WorkflowFidelityDiff DiffKind)
+{
+    /// <summary>0–1 fidelity: Agree/NoTruth = 1.0; a single-axis mismatch = 0.5; both = 0.0.</summary>
+    public double Score => DiffKind switch
+    {
+        WorkflowFidelityDiff.Agree => 1.0,
+        WorkflowFidelityDiff.NoTruth => 1.0,
+        WorkflowFidelityDiff.TokenMismatch => 0.5,
+        WorkflowFidelityDiff.FinishMismatch => 0.5,
+        WorkflowFidelityDiff.Both => 0.0,
+        _ => 1.0,
+    };
+}
+
+/// <summary>The whole-workflow reconciliation result.</summary>
+public sealed record WorkflowTraceFidelityReport(IReadOnlyList<WorkflowExecutorFidelity> Executors)
+{
+    /// <summary>Mean of the per-executor fidelity scores (1.0 when there are no executors).</summary>
+    public double OverallScore => Executors.Count == 0 ? 1.0 : Executors.Average(e => e.Score);
+}
+
+/// <summary>
+/// Glass Box Part 2 (P2.B3): the workflow analogue of <see cref="TraceFidelityRunner"/>. Reconciles each
+/// executor's framework-reported per-executor ledger (tokens + finish reason, from P2.B1) against
+/// chat-boundary truth when pre-wired traces are available, and reports the ledger itself otherwise
+/// (the live-workflow Path-4 case). Pure code — no LLM tokens (CostTier.Free).
+/// </summary>
+/// <remarks>
+/// Reconciliation is at EXECUTOR granularity, not per-step: <c>WorkflowChatRecording</c> collects one
+/// chat trace per executor for the whole run, so a loop workflow that produces multiple
+/// <see cref="ExecutorStep"/>s for one executor must have their framework tokens SUMMED before comparison
+/// — otherwise every looped executor falsely reports a TokenMismatch (fix C5).
+/// </remarks>
+public sealed class WorkflowTraceFidelityReconciler
+{
+    private readonly SamplePreset _preset;
+
+    /// <summary>Creates a reconciler. The preset is informational (it does not change scoring).</summary>
+    public WorkflowTraceFidelityReconciler(SamplePreset preset = SamplePreset.Standard) => _preset = preset;
+
+    /// <summary>The capture preset this reconciler was configured with.</summary>
+    public SamplePreset Preset => _preset;
+
+    /// <summary>Reconciles a workflow result against optional per-executor chat-boundary traces.</summary>
+    public WorkflowTraceFidelityReport Reconcile(
+        WorkflowExecutionResult result,
+        IReadOnlyDictionary<string, AgentTrace>? chatTraces = null)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        var records = new List<WorkflowExecutorFidelity>();
+
+        foreach (var group in result.Steps.GroupBy(s => s.ExecutorId, StringComparer.Ordinal))
+        {
+            var executorId = group.Key;
+            var tokensFramework = group.Sum(s => s.TokenUsage?.TotalTokens ?? 0);
+            var finishFramework = group.Select(s => s.FinishReason).LastOrDefault(f => f is not null);
+
+            if (chatTraces is not null && chatTraces.TryGetValue(executorId, out var chatTrace) && chatTrace is not null)
+            {
+                var responses = chatTrace.Entries
+                    .Where(e => e.EffectiveScope == TraceEntryScope.ChatTurn && e.Type == TraceEntryType.Response)
+                    .ToList();
+                var tokensChatTruth = responses.Sum(e => e.TokenUsage?.TotalTokens ?? 0);
+                var finishChatTruth = responses.Select(e => e.FinishReason).LastOrDefault(f => f is not null);
+
+                var tokenMismatch = tokensFramework != tokensChatTruth;
+                var finishMismatch = finishChatTruth is not null && finishFramework is not null
+                    && !string.Equals(finishFramework, finishChatTruth, StringComparison.Ordinal);
+
+                var diff = (tokenMismatch, finishMismatch) switch
+                {
+                    (true, true) => WorkflowFidelityDiff.Both,
+                    (true, false) => WorkflowFidelityDiff.TokenMismatch,
+                    (false, true) => WorkflowFidelityDiff.FinishMismatch,
+                    _ => WorkflowFidelityDiff.Agree,
+                };
+
+                records.Add(new WorkflowExecutorFidelity(
+                    executorId, tokensFramework, tokensChatTruth, finishFramework, finishChatTruth, diff));
+            }
+            else
+            {
+                records.Add(new WorkflowExecutorFidelity(
+                    executorId, tokensFramework, null, finishFramework, null, WorkflowFidelityDiff.NoTruth));
+            }
+        }
+
+        return new WorkflowTraceFidelityReport(records);
+    }
+
+    /// <summary>
+    /// Reconciles and projects onto the unified <see cref="EvalResult"/> tree — one leaf per executor,
+    /// root score = mean of the leaves. Mirrors <see cref="TraceFidelityRunner.ReconcileToEvalResult"/>.
+    /// </summary>
+    public EvalResult ReconcileToEvalResult(
+        WorkflowExecutionResult result,
+        IReadOnlyDictionary<string, AgentTrace>? chatTraces = null)
+    {
+        var report = Reconcile(result, chatTraces);
+
+        var subResults = report.Executors.Select(e => new EvalResult(
+            Metric: new EvalMetadata(Key: $"workflow_trace_fidelity.executor.{e.ExecutorId}", Name: e.ExecutorId, Category: "TraceFidelity", Version: "1.0"),
+            Score: new EvalScore(
+                Value: e.Score, Ordinal: null,
+                Label: e.Score >= 0.99 ? "pass" : e.Score >= 0.8 ? "warn" : "fail",
+                Passed: e.Score >= 0.8, Threshold: 0.8,
+                Severity: e.Score >= 0.8 ? "Low" : e.Score >= 0.5 ? "Medium" : "High", Confidence: null),
+            Details: new EvalDetails(
+                Dimensions: new Dictionary<string, double>
+                {
+                    ["frameworkTokens"] = e.TokensFramework,
+                    ["chatTruthTokens"] = e.TokensChatTruth ?? -1,
+                    ["delta"] = e.TokensChatTruth is null ? 0 : e.TokensFramework - e.TokensChatTruth.Value,
+                    ["score100"] = e.Score * 100,
+                },
+                Evidence: new List<EvalEvidence>
+                {
+                    new(Source: "workflow-ledger-vs-chat", Reference: e.DiffKind.ToString(),
+                        Message: $"executor '{e.ExecutorId}': framework={e.TokensFramework} tokens / '{e.FinishFramework}', "
+                            + (e.TokensChatTruth is null
+                                ? "no chat truth (ledger-only)"
+                                : $"chat-truth={e.TokensChatTruth} tokens / '{e.FinishChatTruth}'")),
+                },
+                Recommendations: null, SubResults: null, AggregationStrategy: null),
+            Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
+            EvaluatedAt: DateTimeOffset.UtcNow)).ToList();
+
+        return new EvalResult(
+            Metric: new EvalMetadata(Key: "workflow_trace_fidelity", Name: "Workflow Trace Fidelity", Category: "TraceFidelity", Version: "1.0"),
+            Score: new EvalScore(
+                Value: report.OverallScore, Ordinal: null,
+                Label: report.OverallScore >= 0.99 ? "pass" : report.OverallScore >= 0.8 ? "warn" : "fail",
+                Passed: report.OverallScore >= 0.8, Threshold: 0.8,
+                Severity: report.OverallScore >= 0.8 ? "Low" : report.OverallScore >= 0.5 ? "Medium" : "High", Confidence: null),
+            Details: new EvalDetails(
+                Dimensions: new Dictionary<string, double> { ["score100"] = report.OverallScore * 100, ["executors"] = report.Executors.Count },
+                Evidence: null, Recommendations: null, SubResults: subResults, AggregationStrategy: "per-executor"),
+            Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
+            EvaluatedAt: DateTimeOffset.UtcNow);
+    }
+}

--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -92,16 +92,28 @@ public sealed class WorkflowTraceFidelityReconciler
             var tokensFramework = group.Sum(s => s.TokenUsage?.TotalTokens ?? 0);
             var finishFramework = group.Select(s => s.FinishReason).LastOrDefault(f => f is not null);
 
-            if (chatTraces is not null && chatTraces.TryGetValue(executorId, out var chatTrace) && chatTrace is not null)
-            {
-                var responses = chatTrace.Entries
+            var responses = chatTraces is not null
+                && chatTraces.TryGetValue(executorId, out var chatTrace) && chatTrace is not null
+                ? chatTrace.Entries
                     .Where(e => e.EffectiveScope == TraceEntryScope.ChatTurn && e.Type == TraceEntryType.Response)
-                    .ToList();
+                    .ToList()
+                : null;
+
+            // Only reconcile when there is actual chat-boundary truth (≥1 ChatTurn response). A supplied
+            // trace with no responses (tool-only executor, or a partial/failed capture) is NoTruth, not a
+            // comparison against a zero total (which would raise a spurious TokenMismatch).
+            if (responses is { Count: > 0 })
+            {
                 var tokensChatTruth = responses.Sum(e => e.TokenUsage?.TotalTokens ?? 0);
                 var finishChatTruth = responses.Select(e => e.FinishReason).LastOrDefault(f => f is not null);
 
                 var tokenMismatch = tokensFramework != tokensChatTruth;
-                var finishMismatch = finishChatTruth is not null && finishFramework is not null
+
+                // Suppressed finish reason is the headline deception: chat truth reports a terminal reason
+                // (e.g. content_filter / length) while the framework ledger reports null. So a mismatch fires
+                // whenever chat truth HAS a finish reason and the framework's differs — INCLUDING when the
+                // framework's is null (suppression). Mirrors TraceFidelityRunner.SuppressedFinishReason.
+                var finishMismatch = finishChatTruth is not null
                     && !string.Equals(finishFramework, finishChatTruth, StringComparison.Ordinal);
 
                 var diff = (tokenMismatch, finishMismatch) switch
@@ -143,13 +155,7 @@ public sealed class WorkflowTraceFidelityReconciler
                 Passed: e.Score >= 0.8, Threshold: 0.8,
                 Severity: e.Score >= 0.8 ? "Low" : e.Score >= 0.5 ? "Medium" : "High", Confidence: null),
             Details: new EvalDetails(
-                Dimensions: new Dictionary<string, double>
-                {
-                    ["frameworkTokens"] = e.TokensFramework,
-                    ["chatTruthTokens"] = e.TokensChatTruth ?? -1,
-                    ["delta"] = e.TokensChatTruth is null ? 0 : e.TokensFramework - e.TokensChatTruth.Value,
-                    ["score100"] = e.Score * 100,
-                },
+                Dimensions: BuildLeafDimensions(e),
                 Evidence: new List<EvalEvidence>
                 {
                     new(Source: "workflow-ledger-vs-chat", Reference: e.DiffKind.ToString(),
@@ -174,5 +180,23 @@ public sealed class WorkflowTraceFidelityReconciler
                 Evidence: null, Recommendations: null, SubResults: subResults, AggregationStrategy: "per-executor"),
             Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
             EvaluatedAt: DateTimeOffset.UtcNow);
+    }
+
+    // Per-executor leaf dimensions. chatTruthTokens/delta are OMITTED (not encoded as a -1/0 sentinel in the
+    // numeric map) when there is no chat truth, so a downstream aggregator can't mistake absence for a value.
+    private static Dictionary<string, double> BuildLeafDimensions(WorkflowExecutorFidelity e)
+    {
+        var dimensions = new Dictionary<string, double>
+        {
+            ["frameworkTokens"] = e.TokensFramework,
+            ["score100"] = e.Score * 100,
+        };
+        if (e.TokensChatTruth is int chatTruth)
+        {
+            dimensions["chatTruthTokens"] = chatTruth;
+            dimensions["delta"] = e.TokensFramework - chatTruth;
+        }
+
+        return dimensions;
     }
 }

--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -107,7 +107,12 @@ public sealed class WorkflowTraceFidelityReconciler
                 var tokensChatTruth = responses.Sum(e => e.TokenUsage?.TotalTokens ?? 0);
                 var finishChatTruth = responses.Select(e => e.FinishReason).LastOrDefault(f => f is not null);
 
-                var tokenMismatch = tokensFramework != tokensChatTruth;
+                // Flag only meaningful UNDER-reporting (framework hides tokens the model actually consumed),
+                // with a tolerance — mirrors TraceFidelityRunner.TokenUnderReporting. The framework ledger
+                // (MAF's aggregate AgentResponse.Usage) and chat-boundary truth (summed per-turn) are distinct
+                // capture points, so exact equality would false-positive on rounding or benign over-reporting.
+                var shortfall = (tokensChatTruth - tokensFramework) / (double)Math.Max(tokensChatTruth, 1);
+                var tokenMismatch = shortfall > TraceFidelityRubric.TokenToleranceFraction;
 
                 // Suppressed finish reason is the headline deception: chat truth reports a terminal reason
                 // (e.g. content_filter / length) while the framework ledger reports null. So a mismatch fires

--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -153,16 +153,18 @@ public sealed class WorkflowTraceFidelityReconciler
                 Value: e.Score, Ordinal: null,
                 Label: e.Score >= 0.99 ? "pass" : e.Score >= 0.8 ? "warn" : "fail",
                 Passed: e.Score >= 0.8, Threshold: 0.8,
-                Severity: e.Score >= 0.8 ? "Low" : e.Score >= 0.5 ? "Medium" : "High", Confidence: null),
+                Severity: e.Score >= 0.8 ? "low" : e.Score >= 0.5 ? "medium" : "high", Confidence: null),
             Details: new EvalDetails(
                 Dimensions: BuildLeafDimensions(e),
                 Evidence: new List<EvalEvidence>
                 {
                     new(Source: "workflow-ledger-vs-chat", Reference: e.DiffKind.ToString(),
-                        Message: $"executor '{e.ExecutorId}': framework={e.TokensFramework} tokens / '{e.FinishFramework}', "
+                        // Render a null finish reason explicitly as <null> (not '') — a suppressed/null finish
+                        // is a key fidelity signal, so null must not read as an empty string to consumers.
+                        Message: $"executor '{e.ExecutorId}': framework={e.TokensFramework} tokens / {FinishLabel(e.FinishFramework)}, "
                             + (e.TokensChatTruth is null
                                 ? "no chat truth (ledger-only)"
-                                : $"chat-truth={e.TokensChatTruth} tokens / '{e.FinishChatTruth}'")),
+                                : $"chat-truth={e.TokensChatTruth} tokens / {FinishLabel(e.FinishChatTruth)}")),
                 },
                 Recommendations: null, SubResults: null, AggregationStrategy: null),
             Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
@@ -174,13 +176,18 @@ public sealed class WorkflowTraceFidelityReconciler
                 Value: report.OverallScore, Ordinal: null,
                 Label: report.OverallScore >= 0.99 ? "pass" : report.OverallScore >= 0.8 ? "warn" : "fail",
                 Passed: report.OverallScore >= 0.8, Threshold: 0.8,
-                Severity: report.OverallScore >= 0.8 ? "Low" : report.OverallScore >= 0.5 ? "Medium" : "High", Confidence: null),
+                Severity: report.OverallScore >= 0.8 ? "low" : report.OverallScore >= 0.5 ? "medium" : "high", Confidence: null),
             Details: new EvalDetails(
                 Dimensions: new Dictionary<string, double> { ["score100"] = report.OverallScore * 100, ["executors"] = report.Executors.Count },
                 Evidence: null, Recommendations: null, SubResults: subResults, AggregationStrategy: "per-executor"),
             Provenance: new EvalProvenance(Type: "code", JudgeModel: null, PromptId: null, PromptHash: null, TokensUsed: null, EstimatedCost: 0.0, CacheHit: false),
             EvaluatedAt: DateTimeOffset.UtcNow);
     }
+
+    // Renders a finish reason for evidence, distinguishing a genuinely absent (null/suppressed) reason from
+    // an empty string — the null case is a load-bearing fidelity signal.
+    private static string FinishLabel(string? finishReason) =>
+        finishReason is null ? "<null>" : $"'{finishReason}'";
 
     // Per-executor leaf dimensions. chatTruthTokens/delta are OMITTED (not encoded as a -1/0 sentinel in the
     // numeric map) when there is no chat truth, so a downstream aggregator can't mistake absence for a value.

--- a/src/AgentEval.Core/Core/ToolUsageExtractor.cs
+++ b/src/AgentEval.Core/Core/ToolUsageExtractor.cs
@@ -94,12 +94,15 @@ public static class ToolUsageExtractor
     /// carried timing only in streaming mode, so <c>WithDurationUnder</c> / <c>HaveAverageToolTimeUnder</c> /
     /// <c>HaveTotalToolTimeUnder</c> silently skipped.
     /// <para>
-    /// Correlation is by tool <b>name + order</b>: the report has no CallId link to executions, so the Nth
-    /// recorded execution of a tool is matched to the Nth report call of that tool (both are in invocation
-    /// order). A call that already has timing (streaming path) is never overwritten. Uses a deterministic
-    /// UnixEpoch anchor because only <see cref="ToolCallRecord.Duration"/> is load-bearing for the assertions,
-    /// and a fixed anchor keeps enrichment deterministic (a hand-built <c>ForToolExecution</c> entry has a
-    /// default <c>Timestamp</c>). Correlation mismatches are skipped, never thrown.
+    /// Correlation is by tool <b>name + order</b> among <b>executed</b> calls: only calls that actually ran
+    /// (<see cref="ToolCallRecord.WasExecuted"/>) have a matching <see cref="TraceEntryScope.ToolExecution"/>
+    /// entry, so emitted-but-not-executed calls are skipped and never consume an execution slot. Each executed
+    /// call dequeues its tool's next recorded duration to stay aligned even if it is skipped for being already
+    /// timed — so a mix of streaming-timed and untimed executed calls of the same tool never cross-attributes.
+    /// A call that already has timing (streaming path) is never overwritten. Uses a deterministic UnixEpoch
+    /// anchor because only <see cref="ToolCallRecord.Duration"/> is load-bearing for the assertions, and a
+    /// fixed anchor keeps enrichment deterministic (a hand-built <c>ForToolExecution</c> entry has a default
+    /// <c>Timestamp</c>). Correlation mismatches are skipped, never thrown.
     /// </para>
     /// </summary>
     /// <param name="report">The report to enrich in place.</param>
@@ -132,15 +135,22 @@ public static class ToolUsageExtractor
 
         foreach (var call in report.Calls)
         {
-            if (call.HasTiming)
-                continue; // streaming path already timed this call — do not overwrite
+            // Only executed calls have a ToolExecution entry; skipping emitted-only calls keeps the
+            // per-name queues aligned to real executions (never attribute a duration to a non-executed emit).
+            if (!call.WasExecuted)
+                continue;
 
-            if (durationsByName.TryGetValue(call.Name, out var queue) && queue.Count > 0)
-            {
-                var durationMs = queue.Dequeue();
-                call.StartTime = DateTimeOffset.UnixEpoch;
-                call.EndTime = DateTimeOffset.UnixEpoch + TimeSpan.FromMilliseconds(durationMs);
-            }
+            if (!durationsByName.TryGetValue(call.Name, out var queue) || queue.Count == 0)
+                continue;
+
+            // Consume this execution's slot regardless of whether we set timing, so a later executed call
+            // of the same tool maps to its OWN execution (not this one's).
+            var durationMs = queue.Dequeue();
+            if (call.HasTiming)
+                continue; // streaming path already timed this call — keep it, but the slot is consumed
+
+            call.StartTime = DateTimeOffset.UnixEpoch;
+            call.EndTime = DateTimeOffset.UnixEpoch + TimeSpan.FromMilliseconds(durationMs);
         }
     }
 }

--- a/src/AgentEval.Core/Core/ToolUsageExtractor.cs
+++ b/src/AgentEval.Core/Core/ToolUsageExtractor.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Extensions.AI;
 using AgentEval.Models;
+using AgentEval.Tracing;
 
 namespace AgentEval.Core;
 
@@ -84,5 +85,62 @@ public static class ToolUsageExtractor
     {
         _ = response ?? throw new ArgumentNullException(nameof(response));
         return Extract(response.RawMessages);
+    }
+
+    /// <summary>
+    /// Glass Box Part 2 (P2.A2): back-fills real per-tool execution timing onto an already-extracted
+    /// <see cref="ToolUsageReport"/> from the <see cref="TraceEntryScope.ToolExecution"/> entries a Glass Box
+    /// trace captured at the actual invocation site (<c>EvaluatingAIFunction</c>). Before this, the report
+    /// carried timing only in streaming mode, so <c>WithDurationUnder</c> / <c>HaveAverageToolTimeUnder</c> /
+    /// <c>HaveTotalToolTimeUnder</c> silently skipped.
+    /// <para>
+    /// Correlation is by tool <b>name + order</b>: the report has no CallId link to executions, so the Nth
+    /// recorded execution of a tool is matched to the Nth report call of that tool (both are in invocation
+    /// order). A call that already has timing (streaming path) is never overwritten. Uses a deterministic
+    /// UnixEpoch anchor because only <see cref="ToolCallRecord.Duration"/> is load-bearing for the assertions,
+    /// and a fixed anchor keeps enrichment deterministic (a hand-built <c>ForToolExecution</c> entry has a
+    /// default <c>Timestamp</c>). Correlation mismatches are skipped, never thrown.
+    /// </para>
+    /// </summary>
+    /// <param name="report">The report to enrich in place.</param>
+    /// <param name="trace">The Glass Box trace whose <see cref="TraceEntryScope.ToolExecution"/> entries carry timing.</param>
+    public static void EnrichFromTrace(ToolUsageReport report, AgentTrace trace)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentNullException.ThrowIfNull(trace);
+
+        // Per-name FIFO queue of execution durations (ms), in trace order.
+        var durationsByName = new Dictionary<string, Queue<long>>(StringComparer.Ordinal);
+        foreach (var entry in trace.Entries)
+        {
+            if (entry.EffectiveScope != TraceEntryScope.ToolExecution)
+                continue;
+
+            var toolCall = entry.ToolCalls is { Count: > 0 } ? entry.ToolCalls[0] : null;
+            var name = toolCall?.Name;
+            if (string.IsNullOrEmpty(name))
+                continue;
+
+            var durationMs = entry.DurationMs ?? toolCall?.DurationMs ?? 0;
+            if (!durationsByName.TryGetValue(name, out var queue))
+                durationsByName[name] = queue = new Queue<long>();
+            queue.Enqueue(durationMs);
+        }
+
+        if (durationsByName.Count == 0)
+            return;
+
+        foreach (var call in report.Calls)
+        {
+            if (call.HasTiming)
+                continue; // streaming path already timed this call — do not overwrite
+
+            if (durationsByName.TryGetValue(call.Name, out var queue) && queue.Count > 0)
+            {
+                var durationMs = queue.Dequeue();
+                call.StartTime = DateTimeOffset.UnixEpoch;
+                call.EndTime = DateTimeOffset.UnixEpoch + TimeSpan.FromMilliseconds(durationMs);
+            }
+        }
     }
 }

--- a/src/AgentEval.Core/Core/ToolUsageExtractor.cs
+++ b/src/AgentEval.Core/Core/ToolUsageExtractor.cs
@@ -90,9 +90,15 @@ public static class ToolUsageExtractor
     /// <summary>
     /// Glass Box Part 2 (P2.A2): back-fills real per-tool execution timing onto an already-extracted
     /// <see cref="ToolUsageReport"/> from the <see cref="TraceEntryScope.ToolExecution"/> entries a Glass Box
-    /// trace captured at the actual invocation site (<c>EvaluatingAIFunction</c>). Before this, the report
-    /// carried timing only in streaming mode, so <c>WithDurationUnder</c> / <c>HaveAverageToolTimeUnder</c> /
-    /// <c>HaveTotalToolTimeUnder</c> silently skipped.
+    /// trace captured at the actual invocation site (<c>EvaluatingAIFunction</c>). Non-streaming reports carry
+    /// timing only when this runs, so <c>WithDurationUnder</c> / <c>HaveAverageToolTimeUnder</c> /
+    /// <c>HaveTotalToolTimeUnder</c> stay inert until it is called.
+    /// <para>
+    /// <b>Not yet auto-wired.</b> This is a library primitive — no harness calls it automatically today, so in
+    /// the default <c>MAFEvaluationHarness</c> flow the duration assertions are still inert. Wiring it in
+    /// (call it on <c>result.ToolUsage</c> with the captured trace before <c>PerformanceMetrics.TotalToolTime</c>
+    /// is read) is the follow-up. Call it explicitly to activate the assertions in the meantime.
+    /// </para>
     /// <para>
     /// Correlation is by tool <b>name + order</b> among <b>executed</b> calls: only calls that actually ran
     /// (<see cref="ToolCallRecord.WasExecuted"/>) have a matching <see cref="TraceEntryScope.ToolExecution"/>

--- a/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
+++ b/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.Evals;
+
+/// <summary>
+/// Glass Box Part 2 (P2.A1): the bridge that lets a Glass Box <see cref="AgentTrace"/> ride along on an
+/// <see cref="EvalInput"/> so trace-aware evaluators can read what actually happened at the chat/tool boundary.
+/// <para>
+/// The trace is carried as an <see cref="EvalInput.Metadata"/> entry under
+/// <see cref="EvalInput.TraceMetadataKey"/> (a string key, because the Abstractions assembly that owns
+/// <see cref="EvalInput"/> cannot reference the Core <see cref="AgentTrace"/> type). These extensions live in
+/// <c>AgentEval.Core</c> — the assembly that owns the trace type — and share <see cref="EvalInput"/>'s
+/// namespace so any code already using <see cref="EvalInput"/> gets them without an extra <c>using</c>.
+/// </para>
+/// <para>
+/// NOTE: qualify <c>AgentEval.Tracing.AgentTrace</c> explicitly — a second, unrelated
+/// <c>AgentEval.Abstractions.Output.AgentTrace</c> record exists (the output-store artifact shape).
+/// </para>
+/// </summary>
+public static class EvalInputTraceAccessor
+{
+    /// <summary>
+    /// Reads the Glass Box trace previously attached via <see cref="WithTrace"/>, or <c>null</c> when no
+    /// trace is present (or a value of a different type was stored under the key).
+    /// </summary>
+    public static AgentTrace? GetTrace(this EvalInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (input.Metadata is not null
+            && input.Metadata.TryGetValue(EvalInput.TraceMetadataKey, out var value))
+        {
+            return value as AgentTrace;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns a copy of <paramref name="input"/> with <paramref name="trace"/> attached under
+    /// <see cref="EvalInput.TraceMetadataKey"/>. Copy-on-write: the original <see cref="EvalInput.Metadata"/>
+    /// dictionary is never mutated (records are values); an existing trace under the key is replaced.
+    /// This is the canonical write site — no framework path constructs an <see cref="EvalInput"/> with a
+    /// trace already in scope, so callers (Phase-A evaluator harnesses, samples, traced test runs) attach it here.
+    /// </summary>
+    public static EvalInput WithTrace(this EvalInput input, AgentTrace trace)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(trace);
+
+        var metadata = input.Metadata is null
+            ? new Dictionary<string, object>()
+            : new Dictionary<string, object>(input.Metadata);
+        metadata[EvalInput.TraceMetadataKey] = trace;
+
+        return input with { Metadata = metadata };
+    }
+}

--- a/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
+++ b/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
@@ -20,6 +20,11 @@ namespace AgentEval.Evals;
 /// NOTE: qualify <c>AgentEval.Tracing.AgentTrace</c> explicitly — a second, unrelated
 /// <c>AgentEval.Abstractions.Output.AgentTrace</c> record exists (the output-store artifact shape).
 /// </para>
+/// <para>
+/// <b>Not yet auto-wired.</b> This is the bridge; no harness attaches a trace via <see cref="WithTrace"/>
+/// and no evaluator reads it via <see cref="GetTrace"/> yet (it unblocks the Phase-A trace-aware evaluators,
+/// which are the follow-up). Callers attach explicitly at the write site until then.
+/// </para>
 /// </summary>
 public static class EvalInputTraceAccessor
 {

--- a/src/AgentEval.Core/Tracing/WorkflowTrace.cs
+++ b/src/AgentEval.Core/Tracing/WorkflowTrace.cs
@@ -152,6 +152,14 @@ public class WorkflowTraceStep
     public TraceTokenUsage? TokenUsage { get; set; }
 
     /// <summary>
+    /// Finish reason for this step's agent response (e.g. "stop", "length", "content_filter"), when available.
+    /// Additive Glass Box Part 2 field; omitted from JSON when null (serializer uses WhenWritingNull), so
+    /// existing v1.x workflow-trace files round-trip byte-identically.
+    /// </summary>
+    [JsonPropertyName("finishReason")]
+    public string? FinishReason { get; set; }
+
+    /// <summary>
     /// The edge that led to this step.
     /// </summary>
     [JsonPropertyName("incomingEdge")]

--- a/src/AgentEval.Core/Tracing/WorkflowTraceRecorder.cs
+++ b/src/AgentEval.Core/Tracing/WorkflowTraceRecorder.cs
@@ -138,7 +138,8 @@ public sealed class WorkflowTraceRecorder : IWorkflowEvaluableAgent, IAsyncDispo
                 Output = SanitizeText(step.Output),
                 StartOffsetMs = (long)step.StartOffset.TotalMilliseconds,
                 DurationMs = (long)step.Duration.TotalMilliseconds,
-                ParallelBranchId = step.ParallelBranchId
+                ParallelBranchId = step.ParallelBranchId,
+                FinishReason = step.FinishReason
             };
 
             // Record tool calls

--- a/src/AgentEval.Core/Tracing/WorkflowTraceReplayingAgent.cs
+++ b/src/AgentEval.Core/Tracing/WorkflowTraceReplayingAgent.cs
@@ -142,6 +142,7 @@ public sealed class WorkflowTraceReplayingAgent : IWorkflowEvaluableAgent
             StartOffset = TimeSpan.FromMilliseconds(s.StartOffsetMs),
             Duration = TimeSpan.FromMilliseconds(s.DurationMs),
             ParallelBranchId = s.ParallelBranchId,
+            FinishReason = s.FinishReason,
             ToolCalls = s.ToolCalls?.Select(tc => new ToolCallRecord
             {
                 Name = tc.Name,

--- a/src/AgentEval.MAF/MAF/MAFWorkflowAdapter.cs
+++ b/src/AgentEval.MAF/MAF/MAFWorkflowAdapter.cs
@@ -99,6 +99,68 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
         string? currentBranchId = null;
         string? stepBranchId = null; // Branch ID captured when step started
 
+        // Glass Box Part 2 (P2.B1): per-executor ledger of the token usage + finish reason MAF only
+        // surfaces on a complete AgentResponse (ExecutorAgentResponseEvent). Keyed by executor id;
+        // consumed (and removed) when that executor's step is flushed, so a loop workflow that revisits
+        // an executor does NOT re-report an earlier iteration's usage on a later step.
+        var ledger = new Dictionary<string, (TokenUsage? Usage, string? FinishReason)>(StringComparer.Ordinal);
+
+        // Look up and REMOVE an executor's ledger entry (consume-on-flush). Returns (null, null) if absent.
+        (TokenUsage? Usage, string? FinishReason) TakeLedger(string executorId)
+        {
+            if (ledger.TryGetValue(executorId, out var value))
+            {
+                ledger.Remove(executorId);
+                return value;
+            }
+
+            return (null, null);
+        }
+
+        // The output-accumulation + executor-switch bookkeeping shared by ExecutorOutputEvent and its
+        // ExecutorAgentResponseEvent subclass. Flushes the previous executor's step (with its ledger
+        // values) when the executor changes, then begins tracking the new one.
+        void HandleExecutorOutput(ExecutorOutputEvent e)
+        {
+            if (currentExecutorId != e.ExecutorId && currentExecutorId != null)
+            {
+                var (usage, finishReason) = TakeLedger(currentExecutorId);
+                steps.Add(CreateStep(
+                    currentExecutorId,
+                    currentOutput.ToString(),
+                    stepStartOffset,
+                    executorStopwatch.Elapsed,
+                    stepIndex++,
+                    currentToolCalls,
+                    stepIncomingEdge,
+                    currentOutgoingEdges,
+                    stepBranchId,
+                    usage,
+                    finishReason));
+
+                currentToolCalls = [];
+                currentOutgoingEdges = [];
+            }
+
+            if (currentExecutorId != e.ExecutorId)
+            {
+                currentExecutorId = e.ExecutorId;
+                currentOutput.Clear();
+                stepStartOffset = overallStopwatch.Elapsed;
+                executorStopwatch.Restart();
+                stepBranchId = currentBranchId;
+                stepIncomingEdge = pendingIncomingEdge;
+                pendingIncomingEdge = null;
+
+                if (!_executorIds.Contains(currentExecutorId))
+                {
+                    _executorIds.Add(currentExecutorId);
+                }
+            }
+
+            currentOutput.Append(e.Output ?? string.Empty);
+        }
+
         try
         {
             var workflowComplete = false;
@@ -106,44 +168,28 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
             {
                 switch (evt)
                 {
+                    // Derived case MUST precede the ExecutorOutputEvent case (C# first-match): capture the
+                    // per-executor token usage + finish reason MAF only surfaces on a complete AgentResponse,
+                    // then run the identical output bookkeeping. The event always arrives while this executor's
+                    // step is still open (before any flush), so the ledger is populated before it is consumed.
+                    case ExecutorAgentResponseEvent responseEvent:
+                        HandleExecutorOutput(responseEvent);
+                        if (ledger.TryGetValue(responseEvent.ExecutorId, out var prior))
+                        {
+                            // Repeat event for the same open step (retry / streamed-then-completed): SUM the
+                            // tokens, keep the FIRST non-null finish reason.
+                            ledger[responseEvent.ExecutorId] = (
+                                SumUsage(prior.Usage, responseEvent.Usage),
+                                prior.FinishReason ?? responseEvent.FinishReason);
+                        }
+                        else
+                        {
+                            ledger[responseEvent.ExecutorId] = (responseEvent.Usage, responseEvent.FinishReason);
+                        }
+                        break;
+
                     case ExecutorOutputEvent outputEvent:
-                        // When executor changes, save previous step
-                        if (currentExecutorId != outputEvent.ExecutorId && currentExecutorId != null)
-                        {
-                            steps.Add(CreateStep(
-                                currentExecutorId,
-                                currentOutput.ToString(),
-                                stepStartOffset,
-                                executorStopwatch.Elapsed,
-                                stepIndex++,
-                                currentToolCalls,
-                                stepIncomingEdge,
-                                currentOutgoingEdges,
-                                stepBranchId));
-                            
-                            currentToolCalls = [];
-                            currentOutgoingEdges = [];
-                        }
-
-                        if (currentExecutorId != outputEvent.ExecutorId)
-                        {
-                            // Start tracking new executor
-                            currentExecutorId = outputEvent.ExecutorId;
-                            currentOutput.Clear();
-                            stepStartOffset = overallStopwatch.Elapsed;
-                            executorStopwatch.Restart();
-                            stepBranchId = currentBranchId; // Capture branch at step start
-                            stepIncomingEdge = pendingIncomingEdge; // Use pending edge as incoming
-                            pendingIncomingEdge = null; // Reset pending
-
-                            // Track executor ID if not already known
-                            if (!_executorIds.Contains(currentExecutorId))
-                            {
-                                _executorIds.Add(currentExecutorId);
-                            }
-                        }
-
-                        currentOutput.Append(outputEvent.Output ?? string.Empty);
+                        HandleExecutorOutput(outputEvent);
                         break;
 
                     case EdgeTraversedEvent edgeEvent:
@@ -171,6 +217,7 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
                         // the source executor's step (the original off-by-one attribution bug).
                         if (currentExecutorId != null)
                         {
+                            var (edgeUsage, edgeFinishReason) = TakeLedger(currentExecutorId);
                             steps.Add(CreateStep(
                                 currentExecutorId,
                                 currentOutput.ToString(),
@@ -180,7 +227,9 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
                                 currentToolCalls,
                                 stepIncomingEdge,
                                 currentOutgoingEdges,
-                                stepBranchId));
+                                stepBranchId,
+                                edgeUsage,
+                                edgeFinishReason));
 
                             currentToolCalls = [];
                             currentOutgoingEdges = [];
@@ -258,9 +307,12 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
                         break;
 
                     case WorkflowCompleteEvent:
-                        // Workflow complete - save final step
+                        // Workflow complete - save final step. This is the MOST COMMON terminal flush
+                        // (the bridge always yields WorkflowCompleteEvent), so it MUST take the ledger too,
+                        // or the final executor of every workflow loses its tokens/finish reason.
                         if (currentExecutorId != null)
                         {
+                            var (completeUsage, completeFinishReason) = TakeLedger(currentExecutorId);
                             steps.Add(CreateStep(
                                 currentExecutorId,
                                 currentOutput.ToString(),
@@ -270,7 +322,9 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
                                 currentToolCalls,
                                 stepIncomingEdge,
                                 currentOutgoingEdges,
-                                stepBranchId));
+                                stepBranchId,
+                                completeUsage,
+                                completeFinishReason));
                         }
                         workflowComplete = true;
                         break;
@@ -283,6 +337,7 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
             // If no WorkflowCompleteEvent was received, save final step
             if (currentExecutorId != null && !steps.Any(s => s.ExecutorId == currentExecutorId && s.StepIndex == stepIndex))
             {
+                var (finalUsage, finalFinishReason) = TakeLedger(currentExecutorId);
                 steps.Add(CreateStep(
                     currentExecutorId,
                     currentOutput.ToString(),
@@ -292,7 +347,9 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
                     currentToolCalls,
                     stepIncomingEdge,
                     currentOutgoingEdges,
-                    stepBranchId));
+                    stepBranchId,
+                    finalUsage,
+                    finalFinishReason));
             }
 
             overallStopwatch.Stop();
@@ -406,7 +463,9 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
         List<ToolCallRecord> toolCalls,
         EdgeExecution? incomingEdge = null,
         List<EdgeExecution>? outgoingEdges = null,
-        string? branchId = null)
+        string? branchId = null,
+        TokenUsage? tokenUsage = null,
+        string? finishReason = null)
     {
         return new ExecutorStep
         {
@@ -418,7 +477,24 @@ public class MAFWorkflowAdapter : IWorkflowEvaluableAgent
             ToolCalls = toolCalls.Count > 0 ? toolCalls.ToList() : null,
             IncomingEdge = incomingEdge,
             OutgoingEdges = outgoingEdges?.Count > 0 ? outgoingEdges.ToList() : null,
-            ParallelBranchId = branchId
+            ParallelBranchId = branchId,
+            TokenUsage = tokenUsage,
+            FinishReason = finishReason
+        };
+    }
+
+    /// <summary>
+    /// Sums two per-executor token-usage snapshots (Glass Box Part 2, P2.B1). Null-tolerant: a null operand
+    /// is treated as the identity. <see cref="TokenUsage"/> is init-only, so summing constructs a new instance.
+    /// </summary>
+    private static TokenUsage? SumUsage(TokenUsage? a, TokenUsage? b)
+    {
+        if (a is null) return b;
+        if (b is null) return a;
+        return new TokenUsage
+        {
+            PromptTokens = a.PromptTokens + b.PromptTokens,
+            CompletionTokens = a.CompletionTokens + b.CompletionTokens,
         };
     }
 

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -94,6 +94,40 @@ public class WorkflowTraceFidelityReconcilerTests
     }
 
     [Fact]
+    public void Reconcile_TokenUnderReportAndSuppressedFinish_IsBoth_ScoresZero()
+    {
+        // Both axes diverge at once: framework hides ~13% of tokens AND suppresses the finish reason.
+        var result = Result(Step("a", 0, 520, 350, finish: null));       // framework 870, no finish
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(1000, "content_filter") };
+
+        var rec = Assert.Single(new WorkflowTraceFidelityReconciler().Reconcile(result, chat).Executors);
+
+        Assert.Equal(WorkflowFidelityDiff.Both, rec.DiffKind);
+        Assert.Equal(0.0, rec.Score);
+    }
+
+    [Fact]
+    public void OverallScore_ExcludesNoTruthExecutors_SoDeceptionIsNotDilutedAway()
+    {
+        // One traced executor is a full deception (Both, 0.0); three others are untraced (NoTruth, 1.0).
+        // A plain mean would give 0.75 (Passed). Excluding NoTruth, the deception must dominate → 0.0.
+        var result = Result(
+            Step("a", 0, 520, 350, finish: null),
+            Step("b", 1, 10, 5, "stop"),
+            Step("c", 2, 10, 5, "stop"),
+            Step("d", 3, 10, 5, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(1000, "content_filter") };
+
+        var report = new WorkflowTraceFidelityReconciler().Reconcile(result, chat);
+
+        Assert.Equal(0.0, report.OverallScore);
+        Assert.Equal(1, report.VerifiedCount);
+
+        var root = new WorkflowTraceFidelityReconciler().ReconcileToEvalResult(result, chat);
+        Assert.False(root.Score.Passed); // the deception is NOT averaged past the 0.8 gate
+    }
+
+    [Fact]
     public void Reconcile_SuppressedFinishReason_IsFinishMismatch()
     {
         // The headline deception: chat truth hit a content filter, but the framework ledger reports no

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Benchmarks;
+using AgentEval.Models;
+using AgentEval.Tracing;
+using CoreTokenUsage = AgentEval.Core.TokenUsage;
+
+namespace AgentEval.Tests.Benchmarks;
+
+/// <summary>
+/// Glass Box Part 2 — WF-SAMPLE-T4: <see cref="WorkflowTraceFidelityReconciler"/>. Confirms per-executor
+/// reconciliation (grouping steps by executor and summing framework tokens), the four diff kinds, the
+/// EvalResult tree shape, and the loop-workflow regression guard (fix C5).
+/// </summary>
+public class WorkflowTraceFidelityReconcilerTests
+{
+    private static ExecutorStep Step(string executorId, int stepIndex, int prompt, int completion, string? finish) =>
+        new()
+        {
+            ExecutorId = executorId,
+            Output = $"{executorId}#{stepIndex}",
+            StepIndex = stepIndex,
+            TokenUsage = new CoreTokenUsage { PromptTokens = prompt, CompletionTokens = completion },
+            FinishReason = finish,
+        };
+
+    private static WorkflowExecutionResult Result(params ExecutorStep[] steps) =>
+        new() { FinalOutput = "done", Steps = steps };
+
+    private static AgentTrace ChatTrace(int totalTokens, string? finish)
+    {
+        var trace = new AgentTrace();
+        trace.Entries.Add(AgentEval.Tracing.TraceEntry.ForChatResponse(
+            index: 0, correlationId: null, text: "r", durationMs: 1,
+            usage: new TraceTokenUsage { PromptTokens = totalTokens, CompletionTokens = 0 },
+            toolCalls: null, finishReason: finish, providerMetadata: null));
+        return trace;
+    }
+
+    [Fact]
+    public void Reconcile_MatchingTokens_Agree()
+    {
+        var result = Result(Step("a", 0, 10, 5, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(15, "stop") };
+
+        var report = new WorkflowTraceFidelityReconciler().Reconcile(result, chat);
+
+        var rec = Assert.Single(report.Executors);
+        Assert.Equal(WorkflowFidelityDiff.Agree, rec.DiffKind);
+        Assert.Equal(1.0, rec.Score);
+        Assert.Equal(1.0, report.OverallScore);
+    }
+
+    [Fact]
+    public void Reconcile_TokenDivergence_TokenMismatch()
+    {
+        var result = Result(Step("a", 0, 10, 5, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(99, "stop") };
+
+        var rec = Assert.Single(new WorkflowTraceFidelityReconciler().Reconcile(result, chat).Executors);
+
+        Assert.Equal(WorkflowFidelityDiff.TokenMismatch, rec.DiffKind);
+        Assert.Equal(0.5, rec.Score);
+        Assert.Equal(15, rec.TokensFramework);
+        Assert.Equal(99, rec.TokensChatTruth);
+    }
+
+    [Fact]
+    public void Reconcile_NoChatTrace_NoTruth_ScoresOne()
+    {
+        var report = new WorkflowTraceFidelityReconciler().Reconcile(Result(Step("a", 0, 10, 5, "stop")), chatTraces: null);
+
+        var rec = Assert.Single(report.Executors);
+        Assert.Equal(WorkflowFidelityDiff.NoTruth, rec.DiffKind);
+        Assert.Equal(1.0, rec.Score);
+        Assert.Null(rec.TokensChatTruth);
+    }
+
+    [Fact]
+    public void Reconcile_LoopWorkflow_GroupsByExecutor_SumsFrameworkTokens_Agree()
+    {
+        // A runs twice (A -> B -> A): two steps for A totaling 10+5 + 1+1 = 17 tokens, against A's single
+        // whole-run chat trace of 17. WITHOUT per-executor grouping this would be a false TokenMismatch (C5).
+        var result = Result(
+            Step("a", 0, 10, 5, "stop"),
+            Step("b", 1, 20, 8, "stop"),
+            Step("a", 2, 1, 1, "stop"));
+        var chat = new Dictionary<string, AgentTrace>
+        {
+            ["a"] = ChatTrace(17, "stop"),
+            ["b"] = ChatTrace(28, "stop"),
+        };
+
+        var report = new WorkflowTraceFidelityReconciler().Reconcile(result, chat);
+
+        Assert.Equal(2, report.Executors.Count); // one record per EXECUTOR, not per step
+        var a = report.Executors.Single(e => e.ExecutorId == "a");
+        Assert.Equal(17, a.TokensFramework);
+        Assert.Equal(WorkflowFidelityDiff.Agree, a.DiffKind);
+    }
+
+    [Fact]
+    public void ReconcileToEvalResult_ProducesRootWithPerExecutorLeaves()
+    {
+        var result = Result(Step("a", 0, 10, 5, "stop"), Step("b", 1, 20, 8, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(15, "stop"), ["b"] = ChatTrace(99, "stop") };
+
+        var root = new WorkflowTraceFidelityReconciler().ReconcileToEvalResult(result, chat);
+
+        Assert.Equal("workflow_trace_fidelity", root.Metric.Key);
+        Assert.NotNull(root.Details.SubResults);
+        Assert.Equal(2, root.Details.SubResults!.Count);
+        // a agrees (1.0), b token-mismatches (0.5) => mean 0.75
+        Assert.Equal(0.75, root.Score.Value, precision: 5);
+        Assert.All(root.Details.SubResults, leaf => Assert.StartsWith("workflow_trace_fidelity.executor.", leaf.Metric.Key));
+    }
+}

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -145,5 +145,13 @@ public class WorkflowTraceFidelityReconcilerTests
         // a agrees (1.0), b token-mismatches (0.5) => mean 0.75
         Assert.Equal(0.75, root.Score.Value, precision: 5);
         Assert.All(root.Details.SubResults, leaf => Assert.StartsWith("workflow_trace_fidelity.executor.", leaf.Metric.Key));
+
+        // Severity must use the normalized lowercase vocabulary SeverityRollup recognizes, or a real
+        // mismatch (b, score 0.5) would roll up as "none" and hide the warning.
+        var recognized = new[] { "none", "low", "medium", "high", "critical" };
+        Assert.Contains(root.Score.Severity, recognized);
+        Assert.All(root.Details.SubResults, leaf => Assert.Contains(leaf.Score.Severity, recognized));
+        var bLeaf = root.Details.SubResults.Single(l => l.Metric.Key.EndsWith(".b"));
+        Assert.Equal("medium", bLeaf.Score.Severity); // score 0.5 => medium, not "Medium"
     }
 }

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -68,6 +68,36 @@ public class WorkflowTraceFidelityReconcilerTests
     }
 
     [Fact]
+    public void Reconcile_SuppressedFinishReason_IsFinishMismatch()
+    {
+        // The headline deception: chat truth hit a content filter, but the framework ledger reports no
+        // finish reason (null). This MUST be flagged, not scored as Agree.
+        var result = Result(Step("a", 0, 10, 5, finish: null));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(15, "content_filter") };
+
+        var rec = Assert.Single(new WorkflowTraceFidelityReconciler().Reconcile(result, chat).Executors);
+
+        Assert.Equal(WorkflowFidelityDiff.FinishMismatch, rec.DiffKind);
+        Assert.Equal(0.5, rec.Score);
+        Assert.Null(rec.FinishFramework);
+        Assert.Equal("content_filter", rec.FinishChatTruth);
+    }
+
+    [Fact]
+    public void Reconcile_ChatTraceWithNoResponses_IsNoTruth_NotTokenMismatch()
+    {
+        // A supplied trace with zero ChatTurn responses is not "truth" — comparing framework tokens against a
+        // zero total would raise a spurious TokenMismatch.
+        var result = Result(Step("a", 0, 10, 5, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = new AgentTrace() };
+
+        var rec = Assert.Single(new WorkflowTraceFidelityReconciler().Reconcile(result, chat).Executors);
+
+        Assert.Equal(WorkflowFidelityDiff.NoTruth, rec.DiffKind);
+        Assert.Equal(1.0, rec.Score);
+    }
+
+    [Fact]
     public void Reconcile_NoChatTrace_NoTruth_ScoresOne()
     {
         var report = new WorkflowTraceFidelityReconciler().Reconcile(Result(Step("a", 0, 10, 5, "stop")), chatTraces: null);

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -68,6 +68,32 @@ public class WorkflowTraceFidelityReconcilerTests
     }
 
     [Fact]
+    public void Reconcile_FrameworkOverReportsOrRoundingDiff_IsNotTokenMismatch()
+    {
+        // Over-reporting (framework > chat truth) and a sub-tolerance (<2%) difference are NOT deceptions —
+        // only meaningful UNDER-reporting is flagged (mirrors TraceFidelityRunner).
+        var overReport = new WorkflowTraceFidelityReconciler().Reconcile(
+            Result(Step("a", 0, 60, 40, "stop")),                       // framework 100
+            new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(99, "stop") }); // chat 99
+        Assert.Equal(WorkflowFidelityDiff.Agree, Assert.Single(overReport.Executors).DiffKind);
+
+        var rounding = new WorkflowTraceFidelityReconciler().Reconcile(
+            Result(Step("a", 0, 600, 400, "stop")),                     // framework 1000
+            new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(1005, "stop") }); // chat 1005 (0.5% short)
+        Assert.Equal(WorkflowFidelityDiff.Agree, Assert.Single(rounding.Executors).DiffKind);
+    }
+
+    [Fact]
+    public void Reconcile_FrameworkUnderReportsBeyondTolerance_IsTokenMismatch()
+    {
+        // Framework hides ~13% of the tokens the model actually consumed → a real fidelity discrepancy.
+        var rec = Assert.Single(new WorkflowTraceFidelityReconciler().Reconcile(
+            Result(Step("a", 0, 520, 350, "stop")),                      // framework 870
+            new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(1000, "stop") }).Executors); // chat 1000
+        Assert.Equal(WorkflowFidelityDiff.TokenMismatch, rec.DiffKind);
+    }
+
+    [Fact]
     public void Reconcile_SuppressedFinishReason_IsFinishMismatch()
     {
         // The headline deception: chat truth hit a content filter, but the framework ledger reports no

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -154,4 +154,20 @@ public class WorkflowTraceFidelityReconcilerTests
         var bLeaf = root.Details.SubResults.Single(l => l.Metric.Key.EndsWith(".b"));
         Assert.Equal("medium", bLeaf.Score.Severity); // score 0.5 => medium, not "Medium"
     }
+
+    [Fact]
+    public void ReconcileToEvalResult_NullFinishReason_RendersAsAngleBracketNull_NotEmptyString()
+    {
+        // A suppressed/null finish reason is a key fidelity signal.  The evidence message must render null
+        // explicitly as "<null>" so consumers can distinguish "framework reported nothing" from an empty string.
+        var result = Result(Step("a", 0, 10, 5, finish: null));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(15, finish: null) };
+
+        var root = new WorkflowTraceFidelityReconciler().ReconcileToEvalResult(result, chat);
+
+        var leaf = Assert.Single(root.Details.SubResults!);
+        var evidenceMsg = Assert.Single(leaf.Details.Evidence!).Message;
+        Assert.Contains("<null>", evidenceMsg);
+        Assert.DoesNotContain("/ ''", evidenceMsg); // must not render as empty-quoted string
+    }
 }

--- a/tests/AgentEval.Tests/Core/ToolUsageEnrichFromTraceTests.cs
+++ b/tests/AgentEval.Tests/Core/ToolUsageEnrichFromTraceTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Core;
+using AgentEval.Models;
+using AgentEval.Tracing;
+
+namespace AgentEval.Tests.Core;
+
+/// <summary>
+/// Glass Box Part 2 (P2.A2): <see cref="ToolUsageExtractor.EnrichFromTrace"/> back-fills real per-tool
+/// execution timing from a trace's <see cref="TraceEntryScope.ToolExecution"/> entries, fixing the
+/// long-inert duration assertions.
+/// </summary>
+public class ToolUsageEnrichFromTraceTests
+{
+    private static ToolCallRecord Call(string name, int order) =>
+        new() { Name = name, CallId = $"c{order}", Order = order };
+
+    private static AgentTrace TraceWithExecutions(params (string name, long durationMs)[] executions)
+    {
+        var trace = new AgentTrace();
+        var i = 0;
+        foreach (var (name, durationMs) in executions)
+        {
+            trace.Entries.Add(TraceEntry.ForToolExecution(
+                index: i++, correlationId: null, toolName: name, arguments: null,
+                result: "ok", durationMs: durationMs, succeeded: true, error: null));
+        }
+
+        return trace;
+    }
+
+    [Fact]
+    public void EnrichFromTrace_PopulatesTimingAndTotalToolTime()
+    {
+        var report = new ToolUsageReport();
+        report.AddCall(Call("search", 1));
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("search", 250)));
+
+        var call = report.Calls[0];
+        Assert.True(call.HasTiming);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), call.Duration);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), report.TotalToolTime);
+    }
+
+    [Fact]
+    public void EnrichFromTrace_SameToolMultipleCalls_MatchesInFifoOrder()
+    {
+        var report = new ToolUsageReport();
+        report.AddCall(Call("search", 1));
+        report.AddCall(Call("search", 2));
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("search", 100), ("search", 400)));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(100), report.Calls[0].Duration);
+        Assert.Equal(TimeSpan.FromMilliseconds(400), report.Calls[1].Duration);
+        Assert.Equal(TimeSpan.FromMilliseconds(500), report.TotalToolTime);
+    }
+
+    [Fact]
+    public void EnrichFromTrace_DoesNotOverwriteExistingTiming()
+    {
+        var start = DateTimeOffset.UtcNow;
+        var report = new ToolUsageReport();
+        report.AddCall(new ToolCallRecord
+        {
+            Name = "search", CallId = "c1", Order = 1,
+            StartTime = start, EndTime = start + TimeSpan.FromMilliseconds(999),
+        });
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("search", 100)));
+
+        // Streaming-path timing (999ms) is preserved, not replaced by the trace's 100ms.
+        Assert.Equal(TimeSpan.FromMilliseconds(999), report.Calls[0].Duration);
+    }
+
+    [Fact]
+    public void EnrichFromTrace_NoToolExecutionEntries_IsNoOp()
+    {
+        var report = new ToolUsageReport();
+        report.AddCall(Call("search", 1));
+
+        ToolUsageExtractor.EnrichFromTrace(report, new AgentTrace());
+
+        Assert.False(report.Calls[0].HasTiming);
+    }
+
+    [Fact]
+    public void EnrichFromTrace_UnmatchedName_LeavesCallUntimed()
+    {
+        var report = new ToolUsageReport();
+        report.AddCall(Call("search", 1));
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("other_tool", 100)));
+
+        Assert.False(report.Calls[0].HasTiming);
+    }
+}

--- a/tests/AgentEval.Tests/Core/ToolUsageEnrichFromTraceTests.cs
+++ b/tests/AgentEval.Tests/Core/ToolUsageEnrichFromTraceTests.cs
@@ -15,8 +15,9 @@ namespace AgentEval.Tests.Core;
 /// </summary>
 public class ToolUsageEnrichFromTraceTests
 {
+    // An EXECUTED call (has a paired result), which is what carries a matching ToolExecution trace entry.
     private static ToolCallRecord Call(string name, int order) =>
-        new() { Name = name, CallId = $"c{order}", Order = order };
+        new() { Name = name, CallId = $"c{order}", Order = order, WasExecuted = true };
 
     private static AgentTrace TraceWithExecutions(params (string name, long durationMs)[] executions)
     {
@@ -67,7 +68,7 @@ public class ToolUsageEnrichFromTraceTests
         var report = new ToolUsageReport();
         report.AddCall(new ToolCallRecord
         {
-            Name = "search", CallId = "c1", Order = 1,
+            Name = "search", CallId = "c1", Order = 1, WasExecuted = true,
             StartTime = start, EndTime = start + TimeSpan.FromMilliseconds(999),
         });
 
@@ -75,6 +76,41 @@ public class ToolUsageEnrichFromTraceTests
 
         // Streaming-path timing (999ms) is preserved, not replaced by the trace's 100ms.
         Assert.Equal(TimeSpan.FromMilliseconds(999), report.Calls[0].Duration);
+    }
+
+    [Fact]
+    public void EnrichFromTrace_EmittedNotExecutedCall_DoesNotConsumeSlot()
+    {
+        // 'foo' emitted-but-not-executed at order 1, then executed at order 2 (both untimed). The single
+        // recorded execution (30ms) must attach to the EXECUTED call, not the emit.
+        var report = new ToolUsageReport();
+        report.AddCall(new ToolCallRecord { Name = "foo", CallId = "a", Order = 1, WasExecuted = false });
+        report.AddCall(new ToolCallRecord { Name = "foo", CallId = "b", Order = 2, WasExecuted = true });
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("foo", 30)));
+
+        Assert.False(report.Calls[0].HasTiming);                              // emit: no timing
+        Assert.Equal(TimeSpan.FromMilliseconds(30), report.Calls[1].Duration); // executed call gets it
+    }
+
+    [Fact]
+    public void EnrichFromTrace_StreamingTimedThenUntimed_SameTool_StaysAligned()
+    {
+        // Executed 'search' #1 already streaming-timed (50ms real), executed 'search' #2 untimed. Trace queue
+        // is [50, 300] in execution order. #1 consumes slot 50 (kept at 50), #2 must get 300 — not 50.
+        var start = DateTimeOffset.UtcNow;
+        var report = new ToolUsageReport();
+        report.AddCall(new ToolCallRecord
+        {
+            Name = "search", CallId = "c1", Order = 1, WasExecuted = true,
+            StartTime = start, EndTime = start + TimeSpan.FromMilliseconds(50),
+        });
+        report.AddCall(new ToolCallRecord { Name = "search", CallId = "c2", Order = 2, WasExecuted = true });
+
+        ToolUsageExtractor.EnrichFromTrace(report, TraceWithExecutions(("search", 50), ("search", 300)));
+
+        Assert.Equal(TimeSpan.FromMilliseconds(50), report.Calls[0].Duration);
+        Assert.Equal(TimeSpan.FromMilliseconds(300), report.Calls[1].Duration);
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
+++ b/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Evals;
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.Tests.Evals;
+
+/// <summary>
+/// Glass Box Part 2 (P2.A1): <see cref="EvalInputTraceAccessor"/> — the metadata bridge that carries a
+/// Glass Box trace on an <see cref="EvalInput"/> for trace-aware evaluators.
+/// </summary>
+public class EvalInputTraceAccessorTests
+{
+    [Fact]
+    public void GetTrace_NoMetadata_ReturnsNull()
+    {
+        var input = new EvalInput(Query: "q");
+
+        Assert.Null(input.GetTrace());
+    }
+
+    [Fact]
+    public void GetTrace_MetadataWithoutTraceKey_ReturnsNull()
+    {
+        var input = new EvalInput(Query: "q", Metadata: new Dictionary<string, object> { ["other"] = 1 });
+
+        Assert.Null(input.GetTrace());
+    }
+
+    [Fact]
+    public void GetTrace_WrongTypeUnderKey_ReturnsNull()
+    {
+        var input = new EvalInput(
+            Query: "q",
+            Metadata: new Dictionary<string, object> { [EvalInput.TraceMetadataKey] = "not a trace" });
+
+        Assert.Null(input.GetTrace());
+    }
+
+    [Fact]
+    public void WithTrace_ThenGetTrace_RoundTripsSameInstance()
+    {
+        var trace = new AgentTrace { AgentName = "planner" };
+        var input = new EvalInput(Query: "q");
+
+        var withTrace = input.WithTrace(trace);
+
+        Assert.Same(trace, withTrace.GetTrace());
+    }
+
+    [Fact]
+    public void WithTrace_DoesNotMutateOriginalInputOrItsMetadata()
+    {
+        var original = new EvalInput(Query: "q", Metadata: new Dictionary<string, object> { ["keep"] = 1 });
+
+        var withTrace = original.WithTrace(new AgentTrace());
+
+        // Original is untouched (copy-on-write); the new input carries both the old key and the trace.
+        Assert.Null(original.GetTrace());
+        Assert.False(original.Metadata!.ContainsKey(EvalInput.TraceMetadataKey));
+        Assert.NotNull(withTrace.GetTrace());
+        Assert.Equal(1, withTrace.Metadata!["keep"]);
+    }
+
+    [Fact]
+    public void WithTrace_ReplacesExistingTrace()
+    {
+        var first = new AgentTrace { AgentName = "first" };
+        var second = new AgentTrace { AgentName = "second" };
+
+        var input = new EvalInput(Query: "q").WithTrace(first).WithTrace(second);
+
+        Assert.Same(second, input.GetTrace());
+    }
+}

--- a/tests/AgentEval.Tests/MAF/MAFWorkflowLedgerTests.cs
+++ b/tests/AgentEval.Tests/MAF/MAFWorkflowLedgerTests.cs
@@ -111,6 +111,52 @@ public class MAFWorkflowLedgerTests
     }
 
     [Fact]
+    public async Task DoubleResponse_WithNullThenNonNullUsage_SumsViaIdentity()
+    {
+        // Exercises SumUsage's null-identity branches: a null-usage response followed by a real one must
+        // yield the real usage (null treated as identity), not throw or zero it out.
+        var adapter = new MAFWorkflowAdapter("ledger-nullusage", NullThenRealUsage);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal(7, step.TokenUsage!.PromptTokens);
+        Assert.Equal(3, step.TokenUsage.CompletionTokens);
+        Assert.Equal("stop", step.FinishReason); // first non-null finish (the null-usage event carried it)
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> NullThenRealUsage(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorAgentResponseEvent("a", "part 1", Usage: null, FinishReason: "stop");
+        yield return new ExecutorAgentResponseEvent("a", "part 2", new CoreTokenUsage { PromptTokens = 7, CompletionTokens = 3 }, "length");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ParallelBranches_EachBranchExecutorCarriesItsOwnUsage()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-parallel", ParallelExecutor);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        var b1 = result.Steps.Single(s => s.ExecutorId == "branch1");
+        var b2 = result.Steps.Single(s => s.ExecutorId == "branch2");
+        Assert.Equal(11, b1.TokenUsage!.PromptTokens);
+        Assert.Equal(22, b2.TokenUsage!.PromptTokens); // no cross-branch contamination
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> ParallelExecutor(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ParallelBranchStartEvent("fan", ["branch1", "branch2"]);
+        yield return new ExecutorAgentResponseEvent("branch1", "b1", new CoreTokenUsage { PromptTokens = 11, CompletionTokens = 1 }, "stop");
+        yield return new EdgeTraversedEvent("branch1", "branch2");
+        yield return new ExecutorAgentResponseEvent("branch2", "b2", new CoreTokenUsage { PromptTokens = 22, CompletionTokens = 2 }, "stop");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
     public async Task NoResponseEvent_LeavesTokenUsageAndFinishReasonNull_BackCompat()
     {
         var adapter = new MAFWorkflowAdapter("ledger-plain", PlainOutputOnly);

--- a/tests/AgentEval.Tests/MAF/MAFWorkflowLedgerTests.cs
+++ b/tests/AgentEval.Tests/MAF/MAFWorkflowLedgerTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using AgentEval.MAF;
+using CoreTokenUsage = AgentEval.Core.TokenUsage;
+
+namespace AgentEval.Tests.MAF;
+
+/// <summary>
+/// Glass Box Part 2 — WF-SAMPLE-T3: the per-executor ledger (P2.B1) + the additive FinishReason carrier
+/// (P2.B2). Drives <see cref="MAFWorkflowAdapter"/> with scripted event streams and asserts that each
+/// <c>ExecutorStep</c> is populated from its executor's <c>ExecutorAgentResponseEvent</c>, including the
+/// dedup-SUM rule, consume-on-flush across a loop, the WorkflowCompleteEvent terminal-flush path, and
+/// back-compat when no response event is emitted.
+/// </summary>
+public class MAFWorkflowLedgerTests
+{
+    [Fact]
+    public async Task LinearRun_PopulatesTokenUsageAndFinishReason_ViaCompleteFlush()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-linear", LinearWithResponse);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal("a", step.ExecutorId);
+        Assert.NotNull(step.TokenUsage);
+        Assert.Equal(10, step.TokenUsage!.PromptTokens);
+        Assert.Equal(5, step.TokenUsage.CompletionTokens);
+        Assert.Equal("stop", step.FinishReason);
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> LinearWithResponse(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorAgentResponseEvent("a", "output A", new CoreTokenUsage { PromptTokens = 10, CompletionTokens = 5 }, "stop");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task MultiExecutor_PopulatesEachStep_ViaEdgeAndCompleteFlush()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-multi", TwoExecutorsWithResponses);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        Assert.Equal(2, result.Steps.Count);
+        var a = result.Steps.Single(s => s.ExecutorId == "a");
+        var b = result.Steps.Single(s => s.ExecutorId == "b");
+        Assert.Equal(10, a.TokenUsage!.PromptTokens);
+        Assert.Equal("stop", a.FinishReason);
+        Assert.Equal(20, b.TokenUsage!.PromptTokens);
+        Assert.Equal("length", b.FinishReason);
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> TwoExecutorsWithResponses(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorAgentResponseEvent("a", "output A", new CoreTokenUsage { PromptTokens = 10, CompletionTokens = 5 }, "stop");
+        yield return new EdgeTraversedEvent("a", "b");
+        yield return new ExecutorAgentResponseEvent("b", "output B", new CoreTokenUsage { PromptTokens = 20, CompletionTokens = 8 }, "length");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task RepeatResponseForSameOpenStep_SumsTokens_KeepsFirstFinishReason()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-dedup", DoubleResponse);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Equal(13, step.TokenUsage!.PromptTokens);   // 10 + 3
+        Assert.Equal(7, step.TokenUsage.CompletionTokens); // 5 + 2
+        Assert.Equal("stop", step.FinishReason);           // first non-null wins
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> DoubleResponse(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorAgentResponseEvent("a", "part 1", new CoreTokenUsage { PromptTokens = 10, CompletionTokens = 5 }, "stop");
+        yield return new ExecutorAgentResponseEvent("a", "part 2", new CoreTokenUsage { PromptTokens = 3, CompletionTokens = 2 }, "length");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task LoopWorkflow_ConsumesLedgerPerFlush_DoesNotReReportEarlierUsage()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-loop", LoopExecutor);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        // A runs twice (A -> B -> A). Each A step must carry ONLY its own iteration's usage.
+        var aSteps = result.Steps.Where(s => s.ExecutorId == "a").OrderBy(s => s.StepIndex).ToList();
+        Assert.Equal(2, aSteps.Count);
+        Assert.Equal(10, aSteps[0].TokenUsage!.PromptTokens); // first A
+        Assert.Equal(1, aSteps[1].TokenUsage!.PromptTokens);  // second A — NOT 11 (consume-on-flush)
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> LoopExecutor(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorAgentResponseEvent("a", "A#1", new CoreTokenUsage { PromptTokens = 10, CompletionTokens = 5 }, "stop");
+        yield return new EdgeTraversedEvent("a", "b");
+        yield return new ExecutorAgentResponseEvent("b", "B", new CoreTokenUsage { PromptTokens = 20, CompletionTokens = 8 }, "stop");
+        yield return new EdgeTraversedEvent("b", "a");
+        yield return new ExecutorAgentResponseEvent("a", "A#2", new CoreTokenUsage { PromptTokens = 1, CompletionTokens = 1 }, "stop");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task NoResponseEvent_LeavesTokenUsageAndFinishReasonNull_BackCompat()
+    {
+        var adapter = new MAFWorkflowAdapter("ledger-plain", PlainOutputOnly);
+
+        var result = await adapter.ExecuteWorkflowAsync("go");
+
+        var step = Assert.Single(result.Steps);
+        Assert.Null(step.TokenUsage);
+        Assert.Null(step.FinishReason);
+    }
+
+    private static async IAsyncEnumerable<WorkflowEvent> PlainOutputOnly(string prompt, [EnumeratorCancellation] CancellationToken ct)
+    {
+        yield return new ExecutorOutputEvent("a", "plain output");
+        yield return new WorkflowCompleteEvent();
+        await Task.CompletedTask;
+    }
+}

--- a/tests/AgentEval.Tests/Tracing/WorkflowTraceFinishReasonTests.cs
+++ b/tests/AgentEval.Tests/Tracing/WorkflowTraceFinishReasonTests.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Tracing;
+
+namespace AgentEval.Tests.Tracing;
+
+/// <summary>
+/// Glass Box Part 2 (P2.B2) — the additive <c>FinishReason</c> field survives serialization (WhenWritingNull
+/// so null omits the key) AND the record → save → load → replay round trip (WorkflowTraceReplayingAgent).
+/// </summary>
+public class WorkflowTraceFinishReasonTests
+{
+    private static WorkflowTrace TraceWithStep(string? finishReason)
+    {
+        var trace = new WorkflowTrace { TraceName = "t", WorkflowType = "Sequential", OriginalPrompt = "go" };
+        trace.Steps.Add(new WorkflowTraceStep
+        {
+            ExecutorId = "a", StepIndex = 0, Output = "out",
+            FinishReason = finishReason,
+        });
+        return trace;
+    }
+
+    [Fact]
+    public async Task FinishReason_SerializesAsCamelCase_AndSurvivesRoundTrip()
+    {
+        var json = await WorkflowTraceSerializer.SerializeToStringAsync(TraceWithStep("content_filter"));
+
+        Assert.Contains("\"finishReason\": \"content_filter\"", json);
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        var reloaded = await WorkflowTraceSerializer.DeserializeAsync(stream);
+        Assert.Equal("content_filter", reloaded.Steps[0].FinishReason);
+    }
+
+    [Fact]
+    public async Task FinishReason_Null_OmitsKey_ForByteIdenticalBackCompat()
+    {
+        var json = await WorkflowTraceSerializer.SerializeToStringAsync(TraceWithStep(null));
+
+        Assert.DoesNotContain("finishReason", json);
+    }
+
+    [Fact]
+    public async Task FinishReason_SurvivesReplayReconstruction()
+    {
+        // Record→save→load leaves FinishReason in the WorkflowTrace; replay must project it back onto ExecutorStep.
+        var replay = new WorkflowTraceReplayingAgent(TraceWithStep("length"));
+
+        var result = await replay.ExecuteWorkflowAsync("go");
+
+        Assert.Equal("length", result.Steps[0].FinishReason);
+    }
+}


### PR DESCRIPTION
## Glass Box Part 2 — Foundations + Workflow Trace Fidelity

Advances Glass Box **Part 2** (turning captured signals into *evaluation*) by shipping the foundation layer plus the workflow framework-honesty reconciler — the complete **"per-executor cost ledger → workflow trace fidelity"** story, end-to-end and tested.

### What's in this PR (5 tasks)

| Task | Change |
|---|---|
| **P2.A1** | `EvalInput.TraceMetadataKey` + `EvalInputTraceAccessor` (`GetTrace`/`WithTrace`) — the metadata bridge that lets trace-aware evaluators read a Glass Box `AgentTrace` off an `EvalInput`. Copy-on-write; qualifies `AgentEval.Tracing.AgentTrace` (a second `AgentTrace` exists in `Abstractions.Output`). Unblocks all Phase-A evaluators. |
| **P2.A2** | `ToolUsageExtractor.EnrichFromTrace` — back-fills **real per-tool execution timing** from `ToolExecution` trace entries, fixing the long-inert `WithDurationUnder` / `Have*ToolTimeUnder` assertions (they silently skipped without timing). Correlates by name+order among *executed* calls; deterministic anchor. |
| **P2.B1** | `MAFWorkflowAdapter` now **consumes `ExecutorAgentResponseEvent`** (previously silently dropped) into a per-executor ledger — SUM tokens / first-non-null finish — threaded into **all four** `CreateStep` flush sites (executor-switch, edge, **WorkflowCompleteEvent**, post-loop) with **consume-on-flush** so loop workflows don't re-report an earlier iteration's usage. Recovers "what did this workflow cost, per agent" with **zero MAF change**. |
| **P2.B2** | Additive `FinishReason` on `ExecutorStep` + `WorkflowTraceStep` (`WhenWritingNull` → existing traces round-trip byte-identically). |
| **P2.B3** | `WorkflowTraceFidelityReconciler` — the workflow analogue of `TraceFidelityRunner`. Reconciles each executor's framework-reported ledger against chat-boundary truth; **groups steps by executor and sums framework tokens** so loop workflows don't false-positive `TokenMismatch`. Detects **suppressed finish reasons** (framework null vs chat-truth `content_filter`). Projects onto the `EvalResult` tree. |

### Testing
- **+29 tests** across the five tasks (ledger dedup/loop/complete-flush/back-compat; enrich correlation edge cases; accessor round-trip; reconciler agree/mismatch/no-truth/suppressed-finish/loop-C5-guard/eval-tree).
- **net8.0 / net9.0 / net10.0** all build; net8.0 affected-namespace sweep **648 green**, all new tests green on net8 + net10, **0 regressions** in the existing workflow suite (72 tests).

### Quality
- An adversarial 4-agent review (verify-refute pass) ran against the diff: the risky B1 hot-path state-machine refactor came back **clean**; a **major reconciler bug** (suppressed finish reason never flagged) + minors were **found and fixed** in this branch, with regression tests added.
- Additive-only, calibration-frozen (ADR-018) — no compliance scorer is touched.

### Not in this PR (tracked follow-up, all unblocked)
Phase-A evaluator families (P2.A3–A7), workflow-fidelity family registration / assertions / persistence (P2.B4–B7), the `04_RealVsFramework_Workflow` sample (P2.C), and docs (P2.D). Each is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyCZ6Em2Rc5aYdaMHuwtuy
