### PR TITLE
fix(glassbox): address Copilot round-2 findings on #72 (post-merge)

### DIFF
--- a/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
+++ b/src/AgentEval.Core/Benchmarks/TraceFidelity/WorkflowTraceFidelityReconciler.cs
@@ -184,7 +184,7 @@ public sealed class WorkflowTraceFidelityReconciler
                 Value: e.Score, Ordinal: null,
                 Label: e.Score >= 0.99 ? "pass" : e.Score >= 0.8 ? "warn" : "fail",
                 Passed: e.Score >= 0.8, Threshold: 0.8,
-                Severity: e.Score >= 0.8 ? "low" : e.Score >= 0.5 ? "medium" : "high", Confidence: null),
+                Severity: e.Score >= 0.99 ? "none" : e.Score >= 0.8 ? "low" : e.Score >= 0.5 ? "medium" : "high", Confidence: null),
             Details: new EvalDetails(
                 Dimensions: BuildLeafDimensions(e),
                 Evidence: new List<EvalEvidence>
@@ -207,7 +207,7 @@ public sealed class WorkflowTraceFidelityReconciler
                 Value: report.OverallScore, Ordinal: null,
                 Label: report.OverallScore >= 0.99 ? "pass" : report.OverallScore >= 0.8 ? "warn" : "fail",
                 Passed: report.OverallScore >= 0.8, Threshold: 0.8,
-                Severity: report.OverallScore >= 0.8 ? "low" : report.OverallScore >= 0.5 ? "medium" : "high", Confidence: null),
+                Severity: report.OverallScore >= 0.99 ? "none" : report.OverallScore >= 0.8 ? "low" : report.OverallScore >= 0.5 ? "medium" : "high", Confidence: null),
             Details: new EvalDetails(
                 Dimensions: new Dictionary<string, double>
                 {

--- a/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
+++ b/src/AgentEval.Core/Evals/EvalInputTraceAccessor.cs
@@ -56,9 +56,14 @@ public static class EvalInputTraceAccessor
         ArgumentNullException.ThrowIfNull(input);
         ArgumentNullException.ThrowIfNull(trace);
 
-        var metadata = input.Metadata is null
-            ? new Dictionary<string, object>()
-            : new Dictionary<string, object>(input.Metadata);
+        // Preserve the source dictionary's key comparer when copying — a caller may use a case-insensitive
+        // Metadata dictionary, and dropping the comparer would silently change key-lookup semantics on the copy.
+        var metadata = input.Metadata switch
+        {
+            null => new Dictionary<string, object>(),
+            Dictionary<string, object> dict => new Dictionary<string, object>(dict, dict.Comparer),
+            _ => new Dictionary<string, object>(input.Metadata),
+        };
         metadata[EvalInput.TraceMetadataKey] = trace;
 
         return input with { Metadata = metadata };

--- a/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/WorkflowTraceFidelityReconcilerTests.cs
@@ -230,4 +230,18 @@ public class WorkflowTraceFidelityReconcilerTests
         Assert.Contains("<null>", evidenceMsg);
         Assert.DoesNotContain("/ ''", evidenceMsg); // must not render as empty-quoted string
     }
+
+    [Fact]
+    public void ReconcileToEvalResult_FullPass_SeverityIsNone_NotLow()
+    {
+        // A fully-agreeing workflow must roll up severity "none" — "low" on a clean pass would surface a
+        // spurious low-severity signal in aggregations (Copilot follow-up on #72).
+        var result = Result(Step("a", 0, 10, 5, "stop"));
+        var chat = new Dictionary<string, AgentTrace> { ["a"] = ChatTrace(15, "stop") };
+
+        var root = new WorkflowTraceFidelityReconciler().ReconcileToEvalResult(result, chat);
+
+        Assert.Equal("none", root.Score.Severity);
+        Assert.All(root.Details.SubResults!, leaf => Assert.Equal("none", leaf.Score.Severity));
+    }
 }

--- a/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
+++ b/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
@@ -76,7 +76,7 @@ public class EvalInputTraceAccessorTests
     }
 
     [Fact]
-    public void WithTrace_PreservesSourceKeyComparer()
+    public void WithTrace_CaseInsensitiveMetadata_PreservesComparer()
     {
         // A case-insensitive Metadata dictionary must stay case-insensitive after WithTrace copies it
         // (Copilot follow-up on #72 — dropping the comparer would silently change key-lookup semantics).

--- a/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
+++ b/tests/AgentEval.Tests/Evals/EvalInputTraceAccessorTests.cs
@@ -74,4 +74,17 @@ public class EvalInputTraceAccessorTests
 
         Assert.Same(second, input.GetTrace());
     }
+
+    [Fact]
+    public void WithTrace_PreservesSourceKeyComparer()
+    {
+        // A case-insensitive Metadata dictionary must stay case-insensitive after WithTrace copies it
+        // (Copilot follow-up on #72 — dropping the comparer would silently change key-lookup semantics).
+        var metadata = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase) { ["Key"] = 1 };
+        var input = new EvalInput(Query: "q", Metadata: metadata);
+
+        var withTrace = input.WithTrace(new AgentTrace());
+
+        Assert.True(withTrace.Metadata!.ContainsKey("KEY")); // case-insensitive lookup survives the copy
+    }
 }


### PR DESCRIPTION
A **second Copilot review round** on #72 posted 3 findings that landed after the earlier fixes and were **not addressed before the squash-merge**. This corrects them in `main`.

| Finding | Fix |
|---|---|
| `EvalInputTraceAccessor.WithTrace` copies `Metadata` without preserving the source key comparer → a case-insensitive dict silently becomes ordinal on the copy | Preserve the comparer when the source is a `Dictionary<string,object>` |
| `WorkflowTraceFidelityReconciler` leaf Severity is `"low"` even on a full pass (≥ 0.99) → a clean run surfaces a spurious low-severity signal | Emit `"none"` on a full pass (leaf) |
| Root Severity same issue | Emit `"none"` on a full pass (root) |

Both severity findings are **minor** (SeverityRollup noise, not a correctness break); the comparer one is an edge case. +2 regression tests; net8/9/10 green.

Note: the sibling `TraceFidelityRunner` shares the same severity-on-pass pattern (pre-existing, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyCZ6Em2Rc5aYdaMHuwtuy