### PR TITLE
docs(gatekeeper): CHANGELOG + README + ADR-025 for the merged Gatekeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,6 @@ a block). See [`docs/gatekeeper.md`](docs/gatekeeper.md) and [ADR-025](docs/adr/
   checks the inline gates reject, off the hot path, over an immutable snapshot; an adverse verdict arms
   quarantine for a *later* run instead of blocking the one it observed.
 - **`agenteval doctor`** double-gating check + `GateMetadataReader.StageFromKey`.
-- **`agenteval redteam --sut gatekeeper-demo`** — a credential-free, deterministic gated demo agent to run the
-  attack suite against (the attack-the-gate closed loop), composing with the `--baseline`/`--fail-on regression`
-  gate.
 - **Docs + sample** — `docs/gatekeeper.md` and the credential-free `SafetyAndSecurity/04_GatekeeperEnforcement`
   sample.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Gatekeeper — runtime fail-closed enforcement
+
+**Glass Box tells you what your agent *did*; Gatekeeper stops it from doing the wrong thing** — at runtime,
+fail-closed. It puts the same checks you red-team with into the request path so a forbidden tool call, a
+poisoned argument, or a compromised conversation is blocked *before* it happens. Every gate is fail-closed
+(cannot-inspect ⇒ deny) and records honest `gate.*` evidence into the `AgentTrace` (a warn is never counted as
+a block). See [`docs/gatekeeper.md`](docs/gatekeeper.md) and [ADR-025](docs/adr/025-gatekeeper-runtime-fail-closed-enforcement.md).
+
+#### Added
+- **Tool gates** (`AgentEval.MAF.Gatekeeper`) — `UseAgentEvalToolGate` over the MAF function-invocation seam:
+  Allow / Block / Mutate a live tool call, enforced by `ToolGatePolicy` (WarnOnly / ReplaceResult / Terminate).
+  Built-ins: `ForbiddenToolGate`, `ArgumentPatternGate` (bounded regex), `SequenceGate` (ordered combination,
+  per-run scoped). A gate can declare a `MinimumPolicy` enforcement floor so a honeypot can't be silently
+  downgraded to observe-only. Network/LLM-cost gates are rejected inline (`GateCost`).
+- **Run gate** — `UseAgentEvalGate` inspects the run's input (incoming-attack detection) and output text,
+  reusing the shipped `IChatGate`/`EvalGatePolicy`; establishes an `AgentRunScope` (stable across streaming
+  segments) so inner gates can read the run context.
+- **Session gates** — fail-closed `OperatorAuthGate` (allow-list), `RateLimitGate` (race-safe in-process
+  counter, injectable clock), and `QuarantineGate`.
+- **The moat** (`AgentEval.RedTeam.Gatekeeper`, a bridge assembly) — `ProbeEvaluatorGate` runs a deterministic
+  red-team oracle as a runtime gate (fail-closed: only *Resisted* allows; *Succeeded*+*Inconclusive* block),
+  and `CanaryToolGate` + `CanaryLure` graduate a red-team canary into a production honeypot.
+- **Shadow judge** — `UseAgentEvalShadowJudge` + an owned `ShadowJudgePump`: runs the expensive LLM/network
+  checks the inline gates reject, off the hot path, over an immutable snapshot; an adverse verdict arms
+  quarantine for a *later* run instead of blocking the one it observed.
+- **`agenteval doctor`** double-gating check + `GateMetadataReader.StageFromKey`.
+- **`agenteval redteam --sut gatekeeper-demo`** — a credential-free, deterministic gated demo agent to run the
+  attack suite against (the attack-the-gate closed loop), composing with the `--baseline`/`--fail-on regression`
+  gate.
+- **Docs + sample** — `docs/gatekeeper.md` and the credential-free `SafetyAndSecurity/04_GatekeeperEnforcement`
+  sample.
+
 ### Microsoft Agent Framework: hybrid evaluation (several evaluators, one report)
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ await result.ExportHtmlReportAsync("memory-report.html");
 | "What's the latency/cost?" | **Performance metrics** - TTFT, tokens, estimated cost |
 | "How do I debug failures?" | **Trace recording** - capture executions for step-by-step analysis |
 | "Is my agent secure?" | **Red Team evaluation** - 258 probes, full OWASP LLM Top 10 2025 coverage |
-| "Can I STOP a bad action at runtime?" | **Gatekeeper** - fail-closed runtime enforcement: block forbidden tool calls before they run, quarantine compromised sessions |
+| "Can I stop a bad action at runtime?" | **Gatekeeper** - fail-closed runtime enforcement: block forbidden tool calls before they run, quarantine compromised sessions |
 | "Is content safe and unbiased?" | **ResponsibleAI metrics** - toxicity, bias, misinformation |
 | "Does my agent actually remember?" | **Memory evaluation** - retention, reach-back, temporal, LongMemEval (ICLR 2025) |
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ await result.ExportHtmlReportAsync("memory-report.html");
 | "What's the latency/cost?" | **Performance metrics** - TTFT, tokens, estimated cost |
 | "How do I debug failures?" | **Trace recording** - capture executions for step-by-step analysis |
 | "Is my agent secure?" | **Red Team evaluation** - 258 probes, full OWASP LLM Top 10 2025 coverage |
+| "Can I STOP a bad action at runtime?" | **Gatekeeper** - fail-closed runtime enforcement: block forbidden tool calls before they run, quarantine compromised sessions |
 | "Is content safe and unbiased?" | **ResponsibleAI metrics** - toxicity, bias, misinformation |
 | "Does my agent actually remember?" | **Memory evaluation** - retention, reach-back, temporal, LongMemEval (ICLR 2025) |
 
@@ -450,6 +451,7 @@ await result.ExportHtmlReportAsync("memory-report.html");
 
 ### Evaluation Coverage
 - Red Team security - 258 probes, full OWASP LLM Top 10 2025, MITRE ATLAS coverage
+- Gatekeeper runtime enforcement - fail-closed gates that block forbidden tool calls before they run, red-team probes as runtime guards, and an async shadow judge that quarantines compromised sessions ([docs](docs/gatekeeper.md))
 - Responsible AI - toxicity, bias, misinformation detection
 - **Memory evaluation** - retention, reach-back, temporal, cross-session, HTML pentagon reports, LongMemEval (ICLR 2025)
 - Multi-turn conversations - full conversation flow evaluation

--- a/docs/adr/025-gatekeeper-runtime-fail-closed-enforcement.md
+++ b/docs/adr/025-gatekeeper-runtime-fail-closed-enforcement.md
@@ -1,6 +1,6 @@
 # ADR-025 — Gatekeeper: runtime fail-closed enforcement middleware
 
-- **Status:** Accepted (2026-07-05). Implemented (M0–M5) in `src/AgentEval.MAF/Gatekeeper/` + `src/AgentEval.RedTeam.Gatekeeper/`.
+- **Status:** Accepted (2026-07-05). Implemented in `src/AgentEval.MAF/Gatekeeper/` + `src/AgentEval.RedTeam.Gatekeeper/`.
 - **Relates to:** ADR-019/020 (Glass Box dual-boundary trace — Gatekeeper records its evidence there), the shipped chat-gate primitives (`IChatGate` / `EvalGatePolicy`), ADR-021→024 (the red-team oracles the "moat" gates reuse).
 - **One-line:** evaluation and red-teaming find problems *after the fact*; Gatekeeper puts the same checks **in the request path** so a forbidden tool call, poisoned argument, or compromised conversation is **blocked before it happens** — and it is **fail-closed by construction**, with the expensive checks moved off the hot path.
 
@@ -38,6 +38,6 @@ Inline gates **reject** `GateCost.Network`/`Llm` at construction (`GateCost` dri
 ## Consequences
 
 - Enforcement is composable and independent per layer; adding a gate under the default `WarnOnly` never changes an agent's behavior (opt into `ReplaceResult`/`Terminate` for prod).
-- The closed loop is demonstrable end-to-end: `agenteval redteam --sut gatekeeper-demo` runs the attack suite against a gated agent, credential-free, and composes with the shipped `--baseline`/`--fail-on regression` gate (attack-the-gate CI).
-- **Deferred:** workflow middleware (M6) is blocked upstream on `microsoft/agent-framework#3075` — no MAF seam exists yet.
+- The closed loop is demonstrable end-to-end: the shipped red-team attack suite runs against a Gatekeeper-gated agent (wrapped as an evaluable SUT) and composes with the `--baseline`/`--fail-on regression` gate — a probe that gets *through* a gate becomes a new conclusive failure (attack-the-gate CI).
+- Workflow-level enforcement is not covered: MAF exposes no workflow-middleware seam to hook (tracked upstream at `microsoft/agent-framework#3075`).
 - Each milestone was reviewed adversarially to convergence and through the Copilot review loop before merge; the fail-closed posture caught real defects (a JSON-escape fail-open, a streaming bypass, a composed-LLM-grader gap) that a contract/test alone would have missed.

--- a/docs/adr/025-gatekeeper-runtime-fail-closed-enforcement.md
+++ b/docs/adr/025-gatekeeper-runtime-fail-closed-enforcement.md
@@ -1,0 +1,43 @@
+# ADR-025 — Gatekeeper: runtime fail-closed enforcement middleware
+
+- **Status:** Accepted (2026-07-05). Implemented (M0–M5) in `src/AgentEval.MAF/Gatekeeper/` + `src/AgentEval.RedTeam.Gatekeeper/`.
+- **Relates to:** ADR-019/020 (Glass Box dual-boundary trace — Gatekeeper records its evidence there), the shipped chat-gate primitives (`IChatGate` / `EvalGatePolicy`), ADR-021→024 (the red-team oracles the "moat" gates reuse).
+- **One-line:** evaluation and red-teaming find problems *after the fact*; Gatekeeper puts the same checks **in the request path** so a forbidden tool call, poisoned argument, or compromised conversation is **blocked before it happens** — and it is **fail-closed by construction**, with the expensive checks moved off the hot path.
+
+## Context
+
+AgentEval could *measure* an agent (Glass Box, red-team) but not *stop* it. Runtime enforcement is a different problem with two failure modes that a naïve middleware gets wrong:
+
+1. **Fail-open.** A gate that throws, times out, or can't read its context, and then lets the action through, is worse than no gate — it gives false assurance. MAF's `FunctionInvokingChatClient` (FICC) makes this easy to get wrong: a thrown callback is swallowed into a tool-error result and the loop proceeds; a null return is fabricated into `"Success: Function completed."`.
+2. **Cost on the hot path.** The most useful checks (an LLM-as-judge, a package-reputation lookup) are exactly the ones you cannot afford to run on *every* tool call — they stall the agent and, run inline, invite a fabricated verdict under time pressure.
+
+## Decision
+
+A layered, fail-closed middleware over the MAF agent pipeline, on two load-bearing principles.
+
+**1. Cannot-inspect ⇒ deny.** Every gate is fail-closed by construction: a gate that throws is caught and treated as a **Block** (never swallowed into a proceed); a session gate that can't read its context **Blocks**; a run-post gate that cannot inspect a stream under a blocking policy throws at stream start rather than let output through. A block always returns a non-null refusal, so it can never surface as MEAI's `"Success"` fabrication.
+
+**2. Honest evidence.** Every enforcement decision is recorded into the same [`AgentTrace`](../glass-box.md) the evaluators read, under `gate.*` keys. A gate that only *warns* records `action="Warn"` — it is **never** counted as a block, so `GlassBoxEvidence.GateBlockCount` can never claim it stopped a call that actually ran.
+
+**The layers, split by cost budget:**
+
+| Layer | Seam | Cost budget |
+|---|---|---|
+| Tool gate | each tool call, pre-execution | pure-code / bounded |
+| Run gate | run input (incoming-attack) + output | pure-code / bounded |
+| Session gates | before a run (auth / rate / quarantine) | pure-code |
+| The moat | a tool call (red-team probes / canaries as gates) | pure-code / bounded |
+| Shadow judge | *after* the run, async | **anything — LLM, network** |
+
+Inline gates **reject** `GateCost.Network`/`Llm` at construction (`GateCost` drives inline-vs-shadow). The **shadow judge** is the release valve: it runs after the run returns, on an owned bounded-queue pump, over an immutable snapshot — **never the live trace** (so it can't race the returning run's serialization) — and an adverse verdict **arms quarantine** so a *later* run fails closed, rather than blocking the run it observed.
+
+**The moat inverts the grading rule.** `ProbeEvaluatorGate` runs a deterministic red-team oracle as a runtime gate. Where grading must *never* punish honesty (ADR-021→024: abstention is not a failure), a runtime gate must do the **opposite** — only a clear *Resisted* verdict allows the call; *Succeeded* **and** *Inconclusive* both Block. A gate that cannot prove a call safe must not run it. LLM-backed evaluators are rejected (an `IChatClient` reachable anywhere in the evaluator tree), keeping the moat on the pure-code budget.
+
+**A separate bridge assembly.** The moat gates (`ProbeEvaluatorGate`, `CanaryToolGate`) live in `AgentEval.RedTeam.Gatekeeper`, referencing both `AgentEval.MAF` and `AgentEval.RedTeam` — so the core MAF package never takes a dependency on the (heavier) red-team assembly. No cycle: neither parent references the other.
+
+## Consequences
+
+- Enforcement is composable and independent per layer; adding a gate under the default `WarnOnly` never changes an agent's behavior (opt into `ReplaceResult`/`Terminate` for prod).
+- The closed loop is demonstrable end-to-end: `agenteval redteam --sut gatekeeper-demo` runs the attack suite against a gated agent, credential-free, and composes with the shipped `--baseline`/`--fail-on regression` gate (attack-the-gate CI).
+- **Deferred:** workflow middleware (M6) is blocked upstream on `microsoft/agent-framework#3075` — no MAF seam exists yet.
+- Each milestone was reviewed adversarially to convergence and through the Copilot review loop before merge; the fail-closed posture caught real defects (a JSON-escape fail-open, a streaming bypass, a composed-LLM-grader gap) that a contract/test alone would have missed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ Each ADR follows this structure:
 | [022](022-grading-by-decomposition-composite-sub-evaluators.md) | Grading by Decomposition (Composite Sub-Evaluators) — RedTeam Phase C | Accepted (extends 021; B.3 executed) | 2026-06-21 |
 | [023](023-decompose-misinformation-confabulation-vs-denial.md) | Decompose the Misinformation Oracle (Confabulation ⊕ Existence-Denial) | Accepted | 2026-06-22 |
 | [024](024-split-then-gate-decomposition-and-its-bounds.md) | Split-then-Gate Decomposition (Gated Trees) and Its Bounds | Accepted | 2026-06-23 |
+| [025](025-gatekeeper-runtime-fail-closed-enforcement.md) | Gatekeeper — Runtime Fail-Closed Enforcement Middleware | Accepted | 2026-07-05 |
 
 ---
 


### PR DESCRIPTION
The Gatekeeper (PR #76, M0–M5) is merged and working but was **undiscoverable** — no CHANGELOG, README, or ADR
entry. This is docs-only.

- **CHANGELOG.md** `[Unreleased]` — a Gatekeeper section (tool/run/session gates, the moat, shadow judge, the
  `doctor` double-gating check, `--sut gatekeeper-demo`, docs + sample).
- **README.md** — a *"Can I STOP a bad action at runtime?"* table row + an Evaluation Coverage line.
- **ADR-025** — the architecture decision: fail-closed (cannot-inspect ⇒ deny), honest Warn-vs-Block evidence,
  the cost model (inline gates reject LLM/network; the shadow judge is the release valve), the moat inverting
  the grading rule for the enforcement path, and the separate bridge assembly (no cycle). Indexed in
  `docs/adr/README.md`.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyCZ6Em2Rc5aYdaMHuwtuy