### PR TITLE
feat(gatekeeper): CompositeJudgeGate — the Tribunal primitive (single-axis judge as a runtime gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ a block). See [`docs/gatekeeper/introduction.md`](docs/gatekeeper/introduction.m
   affirms the call is routine (a throwing gate, an unserializable-args or parameterless call all escalate). Tools
   opt in via `.RequiresApproval()`. Marked `[Experimental("AEGK001")]` as it rides MAF's evaluation-only approval
   API (`MAAI001`).
+- **`CompositeJudgeGate<TRubric>`** (`AgentEval.Guardrails.Judges`) — the Tribunal primitive: a single-axis
+  `IJudgeRubric` (prefilter + one-question prompt + parser) becomes a runtime `IChatGate` backed by a fast model.
+  Prefilter short-circuit (most turns cost 0 tokens) → model under a hard timeout → decisive `JudgeVerdict`
+  (Allowed / Blocked-with-confidence-and-evidence-spans / Inconclusive). Blocked≥threshold blocks (spans →
+  `GateVerdict.Matches`); an inconclusive verdict (timeout / model error / unparseable) fails closed by default.
+  Provider-agnostic (caller supplies the `IChatClient`). Calibrate against a per-axis gold set before going inline.
 - **`agenteval doctor`** double-gating check + `GateMetadataReader.StageFromKey`.
 - **`agenteval redteam --sut gatekeeper-demo`** — a credential-free, deterministic gated demo agent to run the
   attack suite against (the attack-the-gate closed loop), composing with the `--baseline`/`--fail-on regression`

--- a/docs/gatekeeper/gate-reference.md
+++ b/docs/gatekeeper/gate-reference.md
@@ -122,11 +122,13 @@ The same pattern applies to **`SafetyMetricGate`‑style checks on both input an
 data‑exfiltration intent): a cheap deterministic version can run inline, while an LLM‑judge version belongs in a
 fast run‑pre / run‑post gate or the shadow judge.
 
-> **You can build this today with the existing seams.** For example, a **PI‑detection Composite Judge** built for
-> speed (small model, single‑axis rubric) plugs into the run‑pre seam as a custom `IChatGate`; and because a
-> judge‑as‑a‑gate is itself a detection task, you can score that same judge against a labelled corpus of injection
-> vs. benign prompts — running it *in parallel* — to calibrate its accuracy before trusting it inline. Both
-> evaluate an **incoming prompt**, not an agent response, so they fit the run‑pre gate cleanly.
+> **The primitive ships: `CompositeJudgeGate<TRubric>`.** Write a single‑axis `IJudgeRubric` — a cheap prefilter
+> (so most turns cost 0 tokens) + a one‑question prompt + a parser — and wrap it in a `CompositeJudgeGate` backed
+> by a fast (*mini*/*nano*) model; it plugs into the run‑pre seam as an `IChatGate`. It runs the model under a
+> hard timeout and **fails closed** on an inconclusive verdict (timeout / model error / unparseable reply), citing
+> evidence spans in the gate verdict. **Calibrate before you trust it inline:** because a judge‑as‑a‑gate is
+> itself a detection task, score the same rubric against a labelled corpus of injection vs. benign prompts to
+> confirm it beats the deterministic baseline before it blocks live traffic (the calibration harness).
 
 ## `agenteval doctor` — a double‑gating check
 

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>
+/// Turns a single-axis <see cref="IJudgeRubric"/> into a runtime <see cref="IChatGate"/> backed by a fast model —
+/// the core primitive of "The Tribunal". It slots into the run-pre / run-post seam (which accepts LLM cost,
+/// unlike the inline tool gate).
+/// <para>Flow: <b>prefilter</b> (skip the model, allow — most turns cost 0 tokens) → <b>fast model</b> under a
+/// hard <see cref="JudgeGateOptions.Timeout"/> → <b>parse</b> into a decisive <see cref="JudgeVerdict"/>. A
+/// <see cref="JudgeDecision.Blocked"/> at or above the confidence threshold blocks (citing evidence spans in
+/// <see cref="GateVerdict.Matches"/>); an <see cref="JudgeDecision.Inconclusive"/> (timeout / model error /
+/// unparseable reply) is <b>fail-closed</b> by default. Never stalls the hot path; never throws out of the gate
+/// except to honor the caller's own cancellation.</para>
+/// <para><b>Trust before deployment.</b> A judge should be calibrated against a per-axis gold set (the
+/// calibration harness) before it goes inline — an uncalibrated inline judge is a fabrication risk.</para>
+/// </summary>
+public sealed class CompositeJudgeGate<TRubric> : IChatGate
+    where TRubric : IJudgeRubric
+{
+    private readonly TRubric _rubric;
+    private readonly IChatClient _fastModel;
+    private readonly JudgeGateOptions _options;
+
+    /// <inheritdoc/>
+    public string PolicyName { get; }
+
+    /// <summary>Creates the gate from a single-axis rubric and the fast model that answers it.</summary>
+    public CompositeJudgeGate(TRubric rubric, IChatClient fastModel, JudgeGateOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(rubric);
+        ArgumentNullException.ThrowIfNull(fastModel);
+        if (string.IsNullOrWhiteSpace(rubric.Axis))
+        {
+            throw new ArgumentException("rubric.Axis must be non-empty.", nameof(rubric));
+        }
+
+        _rubric = rubric;
+        _fastModel = fastModel;
+        _options = options ?? new JudgeGateOptions();
+        PolicyName = $"judge:{rubric.Axis}";
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<GateVerdict> InspectAsync(string text, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(text) || !SafePrefilter(text))
+        {
+            return GateVerdict.Allow(PolicyName);   // cheap short-circuit — most turns never reach the model
+        }
+
+        var verdict = await JudgeAsync(text, cancellationToken).ConfigureAwait(false);
+
+        return verdict.Decision switch
+        {
+            JudgeDecision.Blocked when verdict.Confidence >= _options.BlockThreshold =>
+                GateVerdict.Block(PolicyName, verdict.Rationale ?? $"{_rubric.Axis} detected", verdict.Spans),
+            JudgeDecision.Inconclusive when _options.FailClosedOnInconclusive =>
+                GateVerdict.Block(PolicyName, verdict.Rationale ?? $"{_rubric.Axis} judge inconclusive (fail-closed)"),
+            _ => GateVerdict.Allow(PolicyName),   // Allowed, low-confidence Blocked, or fail-open Inconclusive
+        };
+    }
+
+    private bool SafePrefilter(string text)
+    {
+        try
+        {
+            return _rubric.Prefilter(text);
+        }
+        catch
+        {
+            return true;   // a broken prefilter must not silently skip the judge — fail toward inspecting
+        }
+    }
+
+    private async ValueTask<JudgeVerdict> JudgeAsync(string text, CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_options.Timeout);
+
+        try
+        {
+            var messages = new List<ChatMessage> { new(ChatRole.User, _rubric.BuildPrompt(text)) };
+            var options = new ChatOptions { MaxOutputTokens = _options.MaxOutputTokens, Temperature = 0f };
+            var response = await _fastModel.GetResponseAsync(messages, options, cts.Token).ConfigureAwait(false);
+            return _rubric.Parse(response.Text ?? string.Empty) ?? JudgeVerdict.Inconclusive($"{_rubric.Axis} rubric returned null");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;   // the CALLER cancelled — honor it (don't swallow into a verdict)
+        }
+        catch (OperationCanceledException)
+        {
+            return JudgeVerdict.Inconclusive($"{_rubric.Axis} judge timed out after {_options.Timeout.TotalMilliseconds:0}ms");
+        }
+        catch (Exception ex)
+        {
+            return JudgeVerdict.Inconclusive($"{_rubric.Axis} judge error: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/AgentEval.Core/Guardrails/Judges/IJudgeRubric.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/IJudgeRubric.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>
+/// A <b>single-axis</b> judge rubric — one question, asked of a fast model, parsed into a decisive
+/// <see cref="JudgeVerdict"/>. The unit of "The Tribunal": a rubric is cheap to write (a prefilter + a prompt +
+/// a parser) and a <c>CompositeJudgeGate&lt;TRubric&gt;</c> turns it into a runtime <see cref="IChatGate"/>.
+/// <para><b>Invariant — one axis only.</b> A rubric asks exactly one question (e.g. "does this content instruct
+/// the agent?"). A multi-criteria mega-judge collapses toward the noise floor — the repo's grading work proved
+/// task-specific single-axis decomposition is the active ingredient. Compose many rubrics with a fan-out, don't
+/// widen one.</para>
+/// </summary>
+public interface IJudgeRubric
+{
+    /// <summary>Stable axis id, e.g. <c>"indirect-injection"</c>. Becomes the gate's policy name (<c>judge:{Axis}</c>).</summary>
+    string Axis { get; }
+
+    /// <summary>
+    /// Cheap deterministic pre-screen. Return <c>false</c> to skip the model entirely (the gate allows) — so most
+    /// turns cost zero tokens. Must be conservative: return <c>true</c> whenever the model <i>might</i> be needed.
+    /// </summary>
+    bool Prefilter(string text);
+
+    /// <summary>Builds the single-axis question sent to the fast model.</summary>
+    string BuildPrompt(string text);
+
+    /// <summary>Parses the model's reply into a decisive verdict. Return <see cref="JudgeVerdict.Inconclusive"/> on an unparseable reply.</summary>
+    JudgeVerdict Parse(string modelReply);
+}

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>Options for a <see cref="CompositeJudgeGate{TRubric}"/>.</summary>
+public sealed class JudgeGateOptions
+{
+    /// <summary>
+    /// Max wall-clock for one judge call. On timeout the verdict is <see cref="JudgeDecision.Inconclusive"/>
+    /// (never stalls the hot path). Default 5s.
+    /// </summary>
+    public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Minimum <see cref="JudgeVerdict.Confidence"/> to act on a <see cref="JudgeDecision.Blocked"/> verdict. Default 0.5.</summary>
+    public double BlockThreshold { get; init; } = 0.5;
+
+    /// <summary>Cap on the judge's output tokens (a judge answers briefly). Default 256.</summary>
+    public int MaxOutputTokens { get; init; } = 256;
+
+    /// <summary>
+    /// When the judge is <see cref="JudgeDecision.Inconclusive"/> (timeout / model error / unparseable reply),
+    /// whether to block (fail-closed) or allow (fail-open, observe-only). Default <c>true</c> (fail-closed) — a
+    /// gate that cannot prove a turn safe should not pass it under a blocking policy. Enforcement is still gated
+    /// by the run gate's <see cref="EvalGatePolicy"/> (a block only stops the run under a blocking policy).
+    /// </summary>
+    public bool FailClosedOnInconclusive { get; init; } = true;
+}

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeVerdict.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeVerdict.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>What a single-axis judge rubric decided about one turn.</summary>
+public enum JudgeDecision
+{
+    /// <summary>The axis was not present — allow.</summary>
+    Allowed,
+
+    /// <summary>The axis was present — block.</summary>
+    Blocked,
+
+    /// <summary>The judge could not decide (timeout, model error, unparseable reply) — an abstention.</summary>
+    Inconclusive,
+}
+
+/// <summary>
+/// A single-axis judge rubric's decision, with a confidence and the cited evidence spans. Deliberately decisive
+/// (<see cref="JudgeDecision"/>) rather than a bare score — a runtime gate must act, and an abstention
+/// (<see cref="JudgeDecision.Inconclusive"/>) is a first-class outcome (a timeout / model error / unparseable
+/// reply), handled fail-closed by the gate under a blocking policy.
+/// </summary>
+/// <param name="Decision">The decisive outcome.</param>
+/// <param name="Confidence">0..1 confidence in the decision (used against the gate's block threshold).</param>
+/// <param name="Spans">The offending text spans cited as evidence (recorded into the gate verdict's matches).</param>
+/// <param name="Rationale">A short human-readable reason.</param>
+public sealed record JudgeVerdict(
+    JudgeDecision Decision,
+    double Confidence = 1.0,
+    IReadOnlyList<string>? Spans = null,
+    string? Rationale = null)
+{
+    /// <summary>The axis was not present.</summary>
+    public static JudgeVerdict Allowed(double confidence = 1.0) => new(JudgeDecision.Allowed, confidence);
+
+    /// <summary>The axis was present — block, citing the evidence spans.</summary>
+    public static JudgeVerdict Blocked(string? rationale = null, IReadOnlyList<string>? spans = null, double confidence = 1.0)
+        => new(JudgeDecision.Blocked, confidence, spans, rationale);
+
+    /// <summary>The judge could not decide — an abstention (handled fail-closed by the gate under a blocking policy).</summary>
+    public static JudgeVerdict Inconclusive(string? rationale = null)
+        => new(JudgeDecision.Inconclusive, 0.0, null, rationale);
+}

--- a/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+using AgentEval.Guardrails.Judges;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Guardrails;
+
+/// <summary>The Tribunal primitive: a single-axis rubric + fast model → runtime IChatGate, fail-closed on abstention.</summary>
+public class CompositeJudgeGateTests
+{
+    // A trivial single-axis rubric: prefilter on "scan"; the model answers BLOCK / ALLOW; anything else is unparseable.
+    private sealed class KeywordRubric : IJudgeRubric
+    {
+        public string Axis => "test-axis";
+        public bool Prefilter(string text) => text.Contains("scan", StringComparison.OrdinalIgnoreCase);
+        public string BuildPrompt(string text) => $"Is this bad? {text}";
+        public JudgeVerdict Parse(string reply)
+            => reply.Contains("BLOCK", StringComparison.OrdinalIgnoreCase) ? JudgeVerdict.Blocked("axis present", ["the-evidence"], 0.9)
+             : reply.Contains("ALLOW", StringComparison.OrdinalIgnoreCase) ? JudgeVerdict.Allowed()
+             : JudgeVerdict.Inconclusive("unparseable reply");
+    }
+
+    private static CompositeJudgeGate<KeywordRubric> Gate(IChatClient model, JudgeGateOptions? opts = null)
+        => new(new KeywordRubric(), model, opts);
+
+    [Fact]
+    public async Task BlockedVerdict_Blocks_WithEvidenceSpans()
+    {
+        var v = await Gate(new ScriptedChatClient().AddText("BLOCK")).InspectAsync("please scan this input");
+
+        Assert.Equal(GateAction.Block, v.Action);
+        Assert.Equal("judge:test-axis", v.PolicyName);
+        Assert.Contains("the-evidence", v.Matches!);
+    }
+
+    [Fact]
+    public async Task AllowedVerdict_Allows()
+    {
+        var v = await Gate(new ScriptedChatClient().AddText("ALLOW")).InspectAsync("please scan this input");
+        Assert.Equal(GateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task PrefilterFalse_ShortCircuits_ModelNeverCalled()
+    {
+        var model = new ScriptedChatClient().AddText("BLOCK");   // would block IF called
+        var v = await Gate(model).InspectAsync("nothing interesting here");   // no "scan" ⇒ prefilter false
+
+        Assert.Equal(GateAction.Allow, v.Action);
+        Assert.Empty(model.ReceivedMessages);   // proves the fast model was never invoked (0 tokens)
+    }
+
+    [Fact]
+    public async Task ModelError_IsInconclusive_FailClosed_Blocks()
+    {
+        var v = await Gate(new ScriptedChatClient().AddThrow()).InspectAsync("please scan this");
+
+        Assert.Equal(GateAction.Block, v.Action);
+        Assert.Contains("error", v.Reason!, StringComparison.OrdinalIgnoreCase);   // "…judge error: InvalidOperationException"
+    }
+
+    [Fact]
+    public async Task ModelError_FailOpenOption_Allows()
+    {
+        var opts = new JudgeGateOptions { FailClosedOnInconclusive = false };
+        var v = await Gate(new ScriptedChatClient().AddThrow(), opts).InspectAsync("please scan this");
+        Assert.Equal(GateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task UnparseableReply_IsInconclusive_FailClosed_Blocks()
+    {
+        var v = await Gate(new ScriptedChatClient().AddText("I'm not sure, maybe?")).InspectAsync("please scan this");
+        Assert.Equal(GateAction.Block, v.Action);
+    }
+
+    [Fact]
+    public async Task Timeout_IsInconclusive_FailClosed_Blocks()
+    {
+        var slow = new DelayingChatClient(TimeSpan.FromSeconds(30));   // far longer than the gate timeout
+        var opts = new JudgeGateOptions { Timeout = TimeSpan.FromMilliseconds(50) };
+
+        var v = await Gate(slow, opts).InspectAsync("please scan this");
+
+        Assert.Equal(GateAction.Block, v.Action);
+        Assert.Contains("timed out", v.Reason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task LowConfidenceBlock_BelowThreshold_Allows()
+    {
+        // Threshold 0.95 > the rubric's 0.9 confidence ⇒ not decisive enough to act.
+        var opts = new JudgeGateOptions { BlockThreshold = 0.95 };
+        var v = await Gate(new ScriptedChatClient().AddText("BLOCK"), opts).InspectAsync("please scan this");
+        Assert.Equal(GateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsHonored_NotSwallowed()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await Gate(new DelayingChatClient(TimeSpan.FromSeconds(30))).InspectAsync("please scan this", cts.Token));
+    }
+
+    [Fact]
+    public void NullRubric_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new CompositeJudgeGate<KeywordRubric>(null!, new ScriptedChatClient()));
+
+    [Fact]
+    public void NullModel_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new CompositeJudgeGate<KeywordRubric>(new KeywordRubric(), null!));
+
+    // A fast model that respects cancellation but otherwise never returns in time (for the timeout path).
+    private sealed class DelayingChatClient : IChatClient
+    {
+        private readonly TimeSpan _delay;
+        public DelayingChatClient(TimeSpan delay) => _delay = delay;
+
+        public async Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(_delay, cancellationToken);
+            return new ChatResponse(new ChatMessage(ChatRole.Assistant, "BLOCK"));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
The foundation of **The Tribunal** — a single-axis LLM judge as a runtime gate. This is the *primitive*; concrete
rubrics (`IndirectInjectionJudge`) and the **calibration harness** (the trust step) build on it next.

- **`IJudgeRubric`** — `Axis` / `Prefilter` / `BuildPrompt` / `Parse`. One axis only (compose with a fan-out, don't
  widen one — the repo's grading work proved single-axis decomposition is the active ingredient).
- **`JudgeVerdict`** — decisive `Allowed` / `Blocked` (confidence + evidence spans) / `Inconclusive`. Abstention is
  a first-class outcome.
- **`CompositeJudgeGate<TRubric>` : `IChatGate`** — prefilter short-circuit (most turns cost **0 tokens**) → fast
  model under a **hard timeout** → parse. `Blocked` ≥ threshold blocks (spans → `GateVerdict.Matches`); an
  `Inconclusive` verdict (timeout / model error / unparseable) is **fail-closed** by default (configurable). Never
  stalls the hot path; only throws to honor the caller's own cancellation. Provider-agnostic.

**11 tests** (block+spans, allow, prefilter-short-circuit proving the model is never called, model-error
fail-closed/fail-open, unparseable, timeout, sub-threshold, caller-cancel, guards). net8/10 green.

Docs: the gate reference's *Extending — LLM-backed detection* section now points at the shipped primitive, with the
**calibrate-before-inline** discipline.

Next in the plan: **The Bar** (`GateCalibrationHarness`) → **`IndirectInjectionJudge`** (calibrated → promoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyCZ6Em2Rc5aYdaMHuwtuy