### PR TITLE
feat: Foundry integration — correct scores, diagnostics, source chips, and graceful bug bypass

### DIFF
--- a/samples/AgentEval.Samples/AIConfig.cs
+++ b/samples/AgentEval.Samples/AIConfig.cs
@@ -78,6 +78,25 @@ public static class AIConfig
     public static bool IsEmbeddingConfigured => 
         IsConfigured && !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDING_DEPLOYMENT"));
 
+    // ── Azure AI Foundry project (used by samples 12 / 13) ───────────────────────────────
+
+    /// <summary>
+    /// Azure AI Foundry project endpoint. Reads from <c>AZURE_FOUNDRY_ENDPOINT</c>.
+    /// Format: <c>https://&lt;hub&gt;.services.ai.azure.com/api/projects/&lt;project&gt;</c>
+    /// (copy from Azure AI Foundry portal → your project → Settings → Endpoint).
+    /// Authentication uses Azure AD (<c>DefaultAzureCredential</c>); the API key cannot
+    /// authenticate <c>AIProjectClient</c>.
+    /// </summary>
+    public static Uri? FoundryEndpoint =>
+        Environment.GetEnvironmentVariable("AZURE_FOUNDRY_ENDPOINT") is { } v && !string.IsNullOrWhiteSpace(v)
+            ? new Uri(v)
+            : null;
+
+    /// <summary>
+    /// Returns true when <c>AZURE_FOUNDRY_ENDPOINT</c> is set in addition to the core Azure OpenAI variables.
+    /// </summary>
+    public static bool IsFoundryConfigured => IsConfigured && FoundryEndpoint is not null;
+
     public static void PrintMissingCredentialsWarning()
     {
         Console.ForegroundColor = ConsoleColor.Yellow;

--- a/samples/AgentEval.Samples/AIConfig.cs
+++ b/samples/AgentEval.Samples/AIConfig.cs
@@ -89,8 +89,7 @@ public static class AIConfig
     /// </summary>
     public static Uri? FoundryEndpoint =>
         Environment.GetEnvironmentVariable("AZURE_FOUNDRY_ENDPOINT") is { } v && !string.IsNullOrWhiteSpace(v)
-            ? new Uri(v)
-            : null;
+            && Uri.TryCreate(v, UriKind.Absolute, out var uri) ? uri : null;
 
     /// <summary>
     /// Returns true when <c>AZURE_FOUNDRY_ENDPOINT</c> is set in addition to the core Azure OpenAI variables.

--- a/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
@@ -24,8 +24,11 @@ namespace AgentEval.Samples.Benchmarks;
 /// AgentEval Composite Eval and the Foundry eval, and renders both in one source-tagged HTML report.
 /// </summary>
 /// <remarks>
-/// Requires Azure OpenAI credentials (the judge + the fallback agent). The Foundry branch runs only when
-/// <c>FOUNDRY_PROJECT_ENDPOINT</c> is set; otherwise the sample runs AgentEval-local-only and says so.
+/// Requires Azure OpenAI credentials (the judge + fallback agent) and optionally an Azure AI Foundry
+/// project endpoint for the Foundry branch. Set <c>AZURE_FOUNDRY_ENDPOINT</c> to
+/// <c>https://&lt;hub&gt;.services.ai.azure.com/api/projects/&lt;project&gt;</c> (copy from the Foundry portal).
+/// Without it the sample runs AgentEval-local-only. The Foundry branch uses Azure AD
+/// (<c>DefaultAzureCredential</c>), so run <c>az login</c> first.
 /// </remarks>
 public static class FoundryHybridBenchmarkSample
 {
@@ -51,16 +54,19 @@ public static class FoundryHybridBenchmarkSample
             .AsMeaiEvaluator();
         IAgentEvaluator local = composite.AsAgentEvaluator(chatConfig);
 
-        // ── The Foundry eval — only when a Foundry project is configured ───────────────────────────
-        var foundryEndpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
-        var foundryModel = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? AIConfig.ModelDeployment;
-        bool foundryOn = !string.IsNullOrWhiteSpace(foundryEndpoint);
+        // ── The Foundry eval — only when AZURE_FOUNDRY_ENDPOINT is set ────────────────────────
+        // Endpoint comes from AIConfig.FoundryEndpoint (AZURE_FOUNDRY_ENDPOINT).
+        // Format: https://<hub>.services.ai.azure.com/api/projects/<project>
+        // AIProjectClient uses DefaultAzureCredential (Azure AD) — run `az login` first.
+        var foundryEndpoint = AIConfig.FoundryEndpoint;
+        var foundryModel = AIConfig.ModelDeployment;
+        bool foundryOn = foundryEndpoint is not null;
 
         AIProjectClient? projectClient = foundryOn
-            ? new AIProjectClient(new Uri(foundryEndpoint!), new azureidentity::Azure.Identity.DefaultAzureCredential())
+            ? new AIProjectClient(foundryEndpoint!, new azureidentity::Azure.Identity.DefaultAzureCredential())
             : null;
 
-        // System-under-test agent: Foundry-hosted when available, else Azure OpenAI.
+        // System-under-test agent: Foundry-hosted when available, else Azure OpenAI fallback.
         AIAgent agent = projectClient is not null
             ? projectClient.AsAIAgent(model: foundryModel, instructions: "You are a helpful travel advisor.", name: "TravelAdvisor")
             : judgeChat.AsAIAgent(name: "TravelAdvisor", instructions: "You are a helpful travel advisor.");
@@ -73,23 +79,57 @@ public static class FoundryHybridBenchmarkSample
         if (projectClient is not null)
         {
             inners.Add(("foundry",
-                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120,
-                                 FoundryEvals.TaskAdherence, FoundryEvals.Relevance),
+                new TracingAgentEvaluator(
+                    new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120,
+                                     FoundryEvals.TaskAdherence, FoundryEvals.Relevance)),
                 TimeSpan.FromSeconds(150)));
         }
 
         var hybrid = new CompositeAgentEvaluator(inners, name: "Foundry ⊕ AgentEval");
 
         Console.WriteLine($"   Sources: {string.Join(", ", inners.Select(i => i.Source))}"
-                          + (foundryOn ? "" : "   (set FOUNDRY_PROJECT_ENDPOINT to add the Foundry branch)"));
+                          + (foundryOn ? $"  (Foundry: {foundryEndpoint})" : "   (set AZURE_FOUNDRY_ENDPOINT to add the Foundry branch)"));
 
         string[] queries = { "Plan a 3-day trip to Kyoto for a family with two kids." };
 
         // One call: the agent runs once; the composite fans out to both evaluators concurrently.
         AgentEvaluationResults results = await agent.EvaluateAsync(queries, hybrid);
 
-        Console.WriteLine($"   Merged verdict: {results.Passed}/{results.Total} passed across "
-                          + $"{hybrid.CapturedPerSource.Count} source(s).");
+        // ── Per-source console summary ────────────────────────────────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine($"   Merged verdict: {results.Passed}/{results.Total} passed across {hybrid.CapturedPerSource.Count} source(s).");
+        Console.WriteLine();
+        foreach (var (src, r) in hybrid.CapturedPerSource)
+        {
+            var isFoundry = src.Contains("foundry", StringComparison.OrdinalIgnoreCase);
+            var icon = isFoundry ? "☁ " : "⚙ ";
+            if (!string.IsNullOrEmpty(r.Error) || r.Total == 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine($"   {icon} [{src}]  SKIPPED — {r.Error ?? "no results returned"}");
+                Console.ResetColor();
+            }
+            else
+            {
+                Console.ForegroundColor = r.Passed == r.Total ? ConsoleColor.Green : ConsoleColor.Red;
+                Console.WriteLine($"   {icon} [{src}]  {r.Passed}/{r.Total} passed" +
+                    (r.Status is not null ? $"  status={r.Status}" : ""));
+                Console.ResetColor();
+                if (r.ReportUrl is not null)
+                    Console.WriteLine($"               🔗 {r.ReportUrl}");
+                foreach (var meai in r.Items)
+                {
+                    foreach (var (metricName, metric) in meai.Metrics)
+                    {
+                        var score = metric is Microsoft.Extensions.AI.Evaluation.NumericMetric nm
+                            ? nm.Value?.ToString("F2", System.Globalization.CultureInfo.InvariantCulture) ?? "N/A"
+                            : metric?.ToString() ?? "N/A";
+                        Console.WriteLine($"               • {metricName}: {score}");
+                    }
+                }
+            }
+        }
+        Console.WriteLine();
 
         // One source-tagged report (a branch per source; the local branch keeps its full hierarchy).
         EvalResult tree = UnifiedEvalReport.Build(hybrid.CapturedPerSource, composite);

--- a/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/12_FoundryHybridBenchmark.cs
@@ -105,8 +105,10 @@ public static class FoundryHybridBenchmarkSample
             var icon = isFoundry ? "☁ " : "⚙ ";
             if (!string.IsNullOrEmpty(r.Error) || r.Total == 0)
             {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine($"   {icon} [{src}]  SKIPPED — {r.Error ?? "no results returned"}");
+                var isIntentional = string.Equals(r.Status, "skipped", StringComparison.OrdinalIgnoreCase);
+                Console.ForegroundColor = isIntentional ? ConsoleColor.Yellow : ConsoleColor.Red;
+                var verb = isIntentional ? "SKIPPED" : "ERROR";
+                Console.WriteLine($"   {icon} [{src}]  {verb} — {(!string.IsNullOrEmpty(r.Error) ? r.Error : "no results returned")}");
                 Console.ResetColor();
             }
             else

--- a/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
@@ -111,12 +111,14 @@ public static class FoundryHierarchyBenchmarkSample
         {
             var isFoundry = sub.Metric.Key.StartsWith("foundry.", StringComparison.OrdinalIgnoreCase);
             var icon = isFoundry ? "☁ " : "⚙ ";
-            var isSkipped = sub.Score.Label is "skipped" or "error";
-            if (isSkipped)
+            var isNeutral = sub.Score.Label is "skipped" or "error";
+            if (isNeutral)
             {
-                Console.ForegroundColor = ConsoleColor.Yellow;
+                var isIntentional = sub.Score.Label == "skipped";
+                Console.ForegroundColor = isIntentional ? ConsoleColor.Yellow : ConsoleColor.Red;
+                var verb = isIntentional ? "SKIPPED" : "ERROR";
                 var reason = sub.Details.Evidence?.FirstOrDefault()?.Message ?? "no result";
-                Console.WriteLine($"   {icon} [{sub.Metric.Name}]  SKIPPED — {reason}");
+                Console.WriteLine($"   {icon} [{sub.Metric.Name}]  {verb} — {reason}");
                 Console.ResetColor();
             }
             else

--- a/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
+++ b/samples/AgentEval.Samples/Benchmarks/13_FoundryHierarchyBenchmark.cs
@@ -24,10 +24,13 @@ namespace AgentEval.Samples.Benchmarks;
 /// The rendered report is a single benchmark hierarchy where <i>some of the leaves are Foundry evals</i>.
 /// </summary>
 /// <remarks>
-/// Requires Azure OpenAI (the judge + the SUT agent). The Foundry leaves are added only when
-/// <c>FOUNDRY_PROJECT_ENDPOINT</c> is set. NOTE: a composite evaluates once per input, so each Foundry leaf
-/// makes one cloud call per scenario — fine for a benchmark; for large runs prefer the batched
-/// "Foundry alongside local" path (Benchmarks H11 / the MafEvalFoundryAlongsideLocal sample).
+/// Requires Azure OpenAI credentials and optionally an Azure AI Foundry project endpoint for the
+/// Foundry leaves. Set <c>AZURE_FOUNDRY_ENDPOINT</c> to
+/// <c>https://&lt;hub&gt;.services.ai.azure.com/api/projects/&lt;project&gt;</c> (copy from the Foundry portal).
+/// Without it only the AgentEval sub-composite runs (weight=1.0). The Foundry leaves use Azure AD
+/// (<c>DefaultAzureCredential</c>), so run <c>az login</c> first. NOTE: a composite evaluates once
+/// per input, so each Foundry leaf makes one cloud call per scenario — fine for a benchmark; for
+/// large runs prefer the batched path (the MafEvalFoundryAlongsideLocal sample).
 /// </remarks>
 public static class FoundryHierarchyBenchmarkSample
 {
@@ -47,16 +50,20 @@ public static class FoundryHierarchyBenchmarkSample
         IChatClient judgeChat = azure.GetChatClient(AIConfig.ModelDeployment).AsIChatClient();
         var judge = new ChatClientEvaluator(judgeChat);
 
-        var foundryEndpoint = Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT");
-        var foundryModel = Environment.GetEnvironmentVariable("FOUNDRY_MODEL") ?? AIConfig.ModelDeployment;
-        bool foundryOn = !string.IsNullOrWhiteSpace(foundryEndpoint);
+        // Foundry leaves come from AZURE_FOUNDRY_ENDPOINT (see AIConfig.FoundryEndpoint).
+        // Format: https://<hub>.services.ai.azure.com/api/projects/<project>
+        // AIProjectClient uses DefaultAzureCredential (Azure AD) — run `az login` first.
+        var foundryEndpoint = AIConfig.FoundryEndpoint;
+        var foundryModel = AIConfig.ModelDeployment;
+        bool foundryOn = foundryEndpoint is not null;
 
         AIProjectClient? projectClient = foundryOn
-            ? new AIProjectClient(new Uri(foundryEndpoint!), new azureidentity::Azure.Identity.DefaultAzureCredential())
+            ? new AIProjectClient(foundryEndpoint!, new azureidentity::Azure.Identity.DefaultAzureCredential())
             : null;
 
         // ── Build the benchmark hierarchy: an AgentEval sub-composite + (optional) Foundry leaves ──────
         // ToolCallAccuracy is itself a 5-dimension composite — so this benchmark is genuinely multi-level.
+        // One FoundryEvals per evaluator → each becomes its own weighted leaf in the tree.
         var components = new List<EvalComponent>
         {
             new(AgenticBenchmark.ToolCallAccuracy(judge, foundryModel), foundryOn ? 0.5 : 1.0),
@@ -64,13 +71,14 @@ public static class FoundryHierarchyBenchmarkSample
 
         if (projectClient is not null)
         {
-            // One FoundryEvals per evaluator → each becomes its own weighted leaf in the tree.
             components.Add(new(
-                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.Relevance)
+                new TracingAgentEvaluator(
+                    new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.Relevance))
                     .AsEvalLeaf("foundry.relevance", "Foundry Relevance", judgeModel: foundryModel),
                 0.25));
             components.Add(new(
-                new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.TaskAdherence)
+                new TracingAgentEvaluator(
+                    new FoundryEvals(projectClient, foundryModel, splitter: null, pollIntervalSeconds: 5, timeoutSeconds: 120, FoundryEvals.TaskAdherence))
                     .AsEvalLeaf("foundry.task_adherence", "Foundry Task Adherence", judgeModel: foundryModel),
                 0.25));
         }
@@ -85,7 +93,7 @@ public static class FoundryHierarchyBenchmarkSample
             threshold: 0.75);
 
         Console.WriteLine($"   Components: {string.Join(", ", components.Select(c => $"{c.Eval.Name} (w={c.Weight})"))}");
-        Console.WriteLine(foundryOn ? "" : "   (set FOUNDRY_PROJECT_ENDPOINT to weave Foundry evals into the hierarchy)");
+        Console.WriteLine(foundryOn ? $"   Foundry endpoint: {foundryEndpoint}" : "   (set AZURE_FOUNDRY_ENDPOINT to weave Foundry evals into the hierarchy)");
 
         // ── Run the SUT agent once, then score its answer with the whole benchmark tree ───────────────
         AIAgent agent = judgeChat.AsAIAgent(name: "TravelAdvisor", instructions: "You are a helpful travel advisor.");
@@ -94,8 +102,36 @@ public static class FoundryHierarchyBenchmarkSample
 
         EvalResult result = await benchmark.EvaluateAsync(new EvalInput(query, runResponse.Text));
 
+        // ── Per-component console summary ───────────────────────────────────────────────────────────
+        Console.WriteLine();
         Console.WriteLine($"   Benchmark score: {result.Score.Value:P0} ({result.Score.Label}) across "
                           + $"{result.Details.SubResults?.Count ?? 0} top-level component(s).");
+        Console.WriteLine();
+        foreach (var sub in result.Details.SubResults ?? [])
+        {
+            var isFoundry = sub.Metric.Key.StartsWith("foundry.", StringComparison.OrdinalIgnoreCase);
+            var icon = isFoundry ? "☁ " : "⚙ ";
+            var isSkipped = sub.Score.Label is "skipped" or "error";
+            if (isSkipped)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                var reason = sub.Details.Evidence?.FirstOrDefault()?.Message ?? "no result";
+                Console.WriteLine($"   {icon} [{sub.Metric.Name}]  SKIPPED — {reason}");
+                Console.ResetColor();
+            }
+            else
+            {
+                Console.ForegroundColor = sub.Score.Passed ? ConsoleColor.Green : ConsoleColor.Red;
+                Console.WriteLine($"   {icon} [{sub.Metric.Name}]  {sub.Score.Value:P0} ({sub.Score.Label})");
+                Console.ResetColor();
+                if (sub.Details.Evidence is { } evs)
+                    foreach (var ev in evs.Where(e => string.Equals(e.Reference, "report_url", StringComparison.Ordinal)))
+                        Console.WriteLine($"               🔗 {ev.Message}");
+                if (!isFoundry && sub.Details.SubResults is { Count: > 0 } childSubs)
+                    Console.WriteLine($"               ({childSubs.Count} dimension(s))");
+            }
+        }
+        Console.WriteLine();
 
         var subject = new SubjectIdentity(SubjectKind.Agent, agent.Name ?? "agent", ModelId: foundryModel, Framework: "MAF");
         var html = await new HtmlEvalResultRenderer().RenderAsync(result, new EvalResultRenderOptions(

--- a/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
+++ b/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
@@ -1223,10 +1223,17 @@ internal static class BenchmarkSampleHelpers
 }
 
 /// <summary>
-/// Diagnostic wrapper around any MAF <see cref="IAgentEvaluator"/> that prints detailed console
-/// traces: the items sent, the scores returned, and the full exception chain on failure.
-/// Intended for debugging Foundry or other remote-eval integrations in sample code.
+/// Diagnostic wrapper for Foundry (and other remote) <see cref="IAgentEvaluator"/> instances used in
+/// samples 12 and 13. Prints <c>[Foundry ▶]</c> / <c>[Foundry ✔]</c> / <c>[Foundry ⚠]</c> /
+/// <c>[Foundry ✘]</c> console traces showing the items sent, scores received, and full exception chain.
 /// </summary>
+/// <remarks>
+/// The wrapper is intentionally Foundry-oriented: the console tags are hard-coded and it contains a
+/// targeted workaround for <see href="https://github.com/microsoft/agent-framework/issues/6991"/>
+/// (FoundryEvals sends <c>azure_ai_evaluator</c> criteria type rejected by current API). It is NOT a
+/// general-purpose tracing wrapper and should not be reused for non-Foundry evaluators without removing
+/// the Foundry-specific bypass logic.
+/// </remarks>
 internal sealed class TracingAgentEvaluator : IAgentEvaluator
 {
     private readonly IAgentEvaluator _inner;

--- a/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
+++ b/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Text.Json;
 using Azure.AI.OpenAI;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using AgentEval.Core;
 using AgentEval.Core.Evals.Rendering;
@@ -1219,4 +1220,136 @@ internal static class BenchmarkSampleHelpers
                 CacheHit: allCacheHits),
             EvaluatedAt: DateTimeOffset.UtcNow);
     }
+}
+
+/// <summary>
+/// Diagnostic wrapper around any MAF <see cref="IAgentEvaluator"/> that prints detailed console
+/// traces: the items sent, the scores returned, and the full exception chain on failure.
+/// Intended for debugging Foundry or other remote-eval integrations in sample code.
+/// </summary>
+internal sealed class TracingAgentEvaluator : IAgentEvaluator
+{
+    private readonly IAgentEvaluator _inner;
+
+    public TracingAgentEvaluator(IAgentEvaluator inner) => _inner = inner;
+
+    public string Name => _inner.Name;
+
+    public async Task<AgentEvaluationResults> EvaluateAsync(
+        IReadOnlyList<EvalItem> items,
+        string evalName = "Agent Framework Eval",
+        CancellationToken cancellationToken = default)
+    {
+        // ── BEFORE: print what we are sending ─────────────────────────────────
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine($"\n   [Foundry ▶] '{Name}'  evalName={evalName}  items={items.Count}");
+        Console.ResetColor();
+        for (var i = 0; i < items.Count; i++)
+        {
+            var it = items[i];
+            Console.WriteLine($"              item[{i}] query    : {Clip(it.Query, 120)}");
+            Console.WriteLine($"              item[{i}] response : {Clip(it.Response, 120)}");
+            if (!string.IsNullOrEmpty(it.Context))
+                Console.WriteLine($"              item[{i}] context  : {Clip(it.Context, 80)}");
+        }
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var result = await _inner.EvaluateAsync(items, evalName, cancellationToken);
+            sw.Stop();
+
+            // ── AFTER (success): print what we received ───────────────────────
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"   [Foundry ✔] '{Name}' completed in {sw.Elapsed.TotalSeconds:F1}s" +
+                              $"  passed={result.Passed}/{result.Total}" +
+                              (result.Status is { } st ? $"  status={st}" : ""));
+            Console.ResetColor();
+
+            if (result.PerEvaluator is { } pe)
+                foreach (var (ev, pr) in pe)
+                    Console.WriteLine($"              evaluator '{ev}' → passed={pr.Passed} failed={pr.Failed}");
+
+            if (result.DetailedItems is { } di)
+                foreach (var item in di)
+                    Console.WriteLine($"              item '{item.ItemId}' {item.Status}" +
+                        (item.Scores.Count > 0
+                            ? " | " + string.Join(", ", item.Scores.Select(s => $"{s.Name}={s.Score:F2} pass={s.Passed}"))
+                            : item.IsError ? $" ERROR: {item.ErrorCode} — {item.ErrorMessage}" : ""));
+
+            if (result.ReportUrl is { } url)
+                Console.WriteLine($"              Foundry report URL: {url}");
+
+            return result;
+        }
+        catch (Exception ex) when (IsKnownAzureAiEvaluatorBug(ex))
+        {
+            sw.Stop();
+            // ── WORKAROUND: microsoft/agent-framework#6991 ────────────────────
+            // FoundryEvals sends `"type": "azure_ai_evaluator"` in the testing-criteria
+            // JSON but the Foundry API at *.services.ai.azure.com no longer accepts that
+            // type (valid: label_model, text_similarity, string_check, score_model,
+            // python, endpoint).  The bug is in FoundryEvalWireModels.cs (main branch,
+            // nightly 1.12.0-preview.260629.1).  Track: https://github.com/microsoft/agent-framework/issues/6991
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"   [Foundry ⚠] '{Name}' SKIPPED — known package bug (microsoft/agent-framework#6991)");
+            Console.WriteLine($"              The FoundryEvals package sends 'azure_ai_evaluator' but the API");
+            Console.WriteLine($"              now requires 'score_model' or another supported criteria type.");
+            Console.WriteLine($"              Fix pending upstream. Local AgentEval results are unaffected.");
+            Console.ResetColor();
+
+            // Return an empty-but-valid result so the composite can continue cleanly.
+            return new AgentEvaluationResults(
+                Name,
+                [],           // no MEAI metric results
+                inputItems: items)
+            {
+                Status = "skipped",
+                Error = "Blocked by microsoft/agent-framework#6991 — azure_ai_evaluator type rejected by API",
+            };
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            // ── AFTER (unexpected failure): print the full exception chain ────
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"   [Foundry ✘] '{Name}' FAILED after {sw.Elapsed.TotalSeconds:F1}s");
+            Console.ResetColor();
+            PrintExceptionChain(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the exception is the HTTP 400 caused by the
+    /// <c>azure_ai_evaluator</c> criteria-type bug in <c>FoundryEvals</c>.
+    /// (microsoft/agent-framework#6991)
+    /// </summary>
+    private static bool IsKnownAzureAiEvaluatorBug(Exception ex)
+    {
+        // Walk the exception chain — the 400 detail may be wrapped.
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e.Message.Contains("azure_ai_evaluator", StringComparison.OrdinalIgnoreCase)
+                && e.Message.Contains("invalid_request_error", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static void PrintExceptionChain(Exception ex, int depth = 0)
+    {
+        var indent = "              " + new string(' ', depth * 2);
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine($"{indent}{ex.GetType().FullName}: {ex.Message}");
+        Console.ResetColor();
+        if (ex.InnerException is { } inner)
+        {
+            Console.WriteLine($"{indent}  └─ inner:");
+            PrintExceptionChain(inner, depth + 1);
+        }
+    }
+
+    private static string Clip(string? s, int max) =>
+        string.IsNullOrEmpty(s) ? "(empty)" : s.Length <= max ? s : s[..max] + "\u2026";
 }

--- a/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
+++ b/samples/AgentEval.Samples/Benchmarks/_BenchmarkSampleHelpers.cs
@@ -1299,8 +1299,10 @@ internal sealed class TracingAgentEvaluator : IAgentEvaluator
             Console.ResetColor();
 
             // Return an empty-but-valid result so the composite can continue cleanly.
+            // Append " (skipped)" to ProviderName — UnifiedEvalReport.Build checks for this suffix
+            // to render the branch as "skipped" (neutral, severity none) rather than "error".
             return new AgentEvaluationResults(
-                Name,
+                Name + " (skipped)",
                 [],           // no MEAI metric results
                 inputItems: items)
             {

--- a/src/AgentEval.Core/Evals/Aggregations/WeightedSumAggregation.cs
+++ b/src/AgentEval.Core/Evals/Aggregations/WeightedSumAggregation.cs
@@ -26,14 +26,21 @@ public sealed class WeightedSumAggregation : IAggregationStrategy
         double weightSum = 0, weightedScoreSum = 0;
         for (int i = 0; i < results.Count; i++)
         {
-            if (results[i].Score.Label == "skipped") continue;
+            // Exclude neutral infra leaves from weighted scoring:
+            //   "skipped" — evaluator intentionally not run (bypass, timeout, circuit-breaker)
+            //   "error"   — transient provider failure (network, quota, upstream bug)
+            // Neither represents a real quality signal; including them at 0.0 would incorrectly
+            // drag the composite below threshold (e.g. sample 13 uses threshold=0.75).
+            if (results[i].Score.Label is "skipped" or "error") continue;
             if (components[i].Weight <= 0) continue;
             weightSum        += components[i].Weight;
             weightedScoreSum += results[i].Score.Value * components[i].Weight;
         }
 
         var score = weightSum > 0 ? weightedScoreSum / weightSum : 0;
-        var severity = SeverityRollup.Max(results.Where(r => r.Score.Label != "skipped").Select(r => r.Score.Severity));
+        var severity = SeverityRollup.Max(results
+            .Where(r => r.Score.Label is not "skipped" and not "error")
+            .Select(r => r.Score.Severity));
         return (score, severity);
     }
 }

--- a/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
+++ b/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
@@ -159,6 +159,7 @@ public sealed class HtmlEvalResultRenderer : IEvalResultRenderer
                   .Append(chipText).Append("</span>\n");
         }
         sb.Append("<span class=\"key\">").Append(WebUtility.HtmlEncode(node.Metric.Key)).Append("</span>\n");
+        if (!isSkipped)
         {
             sb.Append("<span class=\"score-inline\">").Append(FormatPct(node.Score.Value)).Append("</span>\n");
         }

--- a/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
+++ b/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
@@ -134,7 +134,29 @@ public sealed class HtmlEvalResultRenderer : IEvalResultRenderer
         sb.Append(isSkipped ? "NOT TESTED" : WebUtility.HtmlEncode(node.Score.Label.ToUpperInvariant()));
         sb.Append("</span>\n");
         sb.Append("<span class=\"name\">").Append(WebUtility.HtmlEncode(node.Metric.Name)).Append("</span>\n");
-        sb.Append("<span class=\"key\">").Append(WebUtility.HtmlEncode(node.Metric.Key)).Append("</span>\n");
+        // Source chip — emitted for source-tagged nodes so Foundry and local branches/leaves are
+        // immediately distinguishable without opening the node body.
+        //   hybrid.*       → driven by the suffix  (sample 12: CompositeAgentEvaluator branches)
+        //   foundry.*      → always ☁ Foundry chip  (sample 13: AgentEvaluatorEvalLeaf leaves)
+        {
+            string? chipCss = null, chipText = null;
+            if (node.Metric.Key.StartsWith("foundry.", StringComparison.OrdinalIgnoreCase))
+            {
+                chipCss = "source-foundry"; chipText = "&#9729; Foundry";
+            }
+            else if (node.Metric.Key.StartsWith("hybrid.", StringComparison.Ordinal))
+            {
+                var srcPart = node.Metric.Key["hybrid.".Length..];
+                (chipCss, chipText) = srcPart.Contains("foundry", StringComparison.OrdinalIgnoreCase)
+                    ? ("source-foundry", "&#9729; Foundry")
+                    : srcPart.Contains("local", StringComparison.OrdinalIgnoreCase)
+                      || srcPart.Contains("agenteval", StringComparison.OrdinalIgnoreCase)
+                        ? ("source-local", "&#9881; AgentEval")
+                        : ("source-other", WebUtility.HtmlEncode(srcPart));
+            }
+            if (chipCss is not null)
+                sb.Append("<span class=\"source-chip \").Append(chipCss).Append(\"\">").Append(chipText).Append("</span>\n");
+        }
         if (!isSkipped)
         {
             sb.Append("<span class=\"score-inline\">").Append(FormatPct(node.Score.Value)).Append("</span>\n");
@@ -331,6 +353,10 @@ details[open] > summary::before { transform: rotate(90deg); }
 .badge.sev-medium  { background: var(--med-bg);  color: var(--med-fg);  border-color: var(--med-border);  }
 .badge.sev-high    { background: var(--high-bg); color: var(--high-fg); border-color: var(--high-border); }
 .badge.sev-skipped { background: var(--skip-bg); color: var(--skip-fg); border-color: var(--skip-border); }
+.source-chip { display: inline-block; padding: 1px 7px; border-radius: 4px; font-size: 10px; font-weight: 700; letter-spacing: 0.4px; border: 1px solid; vertical-align: middle; }
+.source-foundry { background: #ddf4ff; color: #0550ae; border-color: #54aeff; }
+.source-local   { background: #dafbe1; color: #1a7f37; border-color: #4ac26b; }
+.source-other   { background: #fff8c5; color: #9a6700; border-color: #d4a72c; }
 .name { font-weight: 600; flex: 1; }
 .key { color: var(--muted); font-family: ui-monospace, monospace; font-size: 12px; }
 .score-inline { font-family: ui-monospace, monospace; font-size: 13px; color: var(--muted); }

--- a/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
+++ b/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
@@ -144,7 +144,7 @@ public sealed class HtmlEvalResultRenderer : IEvalResultRenderer
             {
                 chipCss = "source-foundry"; chipText = "&#9729; Foundry";
             }
-            else if (node.Metric.Key.StartsWith("hybrid.", StringComparison.Ordinal))
+            else if (node.Metric.Key.StartsWith("hybrid.", StringComparison.OrdinalIgnoreCase))
             {
                 var srcPart = node.Metric.Key["hybrid.".Length..];
                 (chipCss, chipText) = srcPart.Contains("foundry", StringComparison.OrdinalIgnoreCase)

--- a/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
+++ b/src/AgentEval.Core/Evals/Rendering/HtmlEvalResultRenderer.cs
@@ -155,9 +155,10 @@ public sealed class HtmlEvalResultRenderer : IEvalResultRenderer
                         : ("source-other", WebUtility.HtmlEncode(srcPart));
             }
             if (chipCss is not null)
-                sb.Append("<span class=\"source-chip \").Append(chipCss).Append(\"\">").Append(chipText).Append("</span>\n");
+                sb.Append("<span class=\"source-chip ").Append(chipCss).Append("\">")
+                  .Append(chipText).Append("</span>\n");
         }
-        if (!isSkipped)
+        sb.Append("<span class=\"key\">").Append(WebUtility.HtmlEncode(node.Metric.Key)).Append("</span>\n");
         {
             sb.Append("<span class=\"score-inline\">").Append(FormatPct(node.Score.Value)).Append("</span>\n");
         }

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
@@ -98,8 +98,8 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
             // Return a neutral skipped leaf so it doesn't contribute a 0-score to CompositeEval
             // aggregation — it is excluded from weighted roll-ups, same as a timeout branch.
             if (string.Equals(results.Status, "skipped", StringComparison.OrdinalIgnoreCase))
-                return SkippedLeaf(results.Error ?? "skipped by provider");
-            return ErrorLeaf(results.Error ?? "no results returned");
+                return SkippedLeaf(!string.IsNullOrEmpty(results.Error) ? results.Error : "skipped by provider");
+            return ErrorLeaf(!string.IsNullOrEmpty(results.Error) ? results.Error : "no results returned");
         }
 
         // Reuse the existing MEAI -> EvalResult bridge for robust metric normalisation, then re-key its

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
@@ -91,13 +91,21 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
             return ErrorLeaf($"evaluator '{Name}' threw {ex.GetType().Name}: {ex.Message}");
         }
 
-        if (results.Error is not null || results.Items.Count == 0)
+        if (!string.IsNullOrEmpty(results.Error) || results.Items.Count == 0)
             return ErrorLeaf(results.Error ?? "no results returned");
 
         // Reuse the existing MEAI -> EvalResult bridge for robust metric normalisation, then re-key its
         // aggregate as THIS leaf so it participates (by weight) in the parent CompositeEval.
         EvalResult tree = MeaiToEvalResultBridge.Build(Name, new[] { input.Query }, results, _judgeModel);
         EvalScore agg = tree.Score;
+
+        // Build evidence: pass/fail summary + optional provider portal link (e.g. Foundry report URL).
+        var evidence = new System.Collections.Generic.List<EvalEvidence>
+        {
+            new EvalEvidence("provider", Key, $"{results.Passed}/{results.Total} metric(s) passed")
+        };
+        if (results.ReportUrl is not null)
+            evidence.Add(new EvalEvidence("provider", "report_url", results.ReportUrl.ToString()));
 
         return new EvalResult(
             Metric: new EvalMetadata(Key, Name, Category, Version),
@@ -106,7 +114,7 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
                 Threshold: _threshold, Severity: agg.Severity, Confidence: null),
             Details: new EvalDetails(
                 Dimensions: null,
-                Evidence: new[] { new EvalEvidence("provider", Key, $"{results.Passed}/{results.Total} metric(s) passed") },
+                Evidence: evidence.ToArray(),
                 Recommendations: null,
                 // Keep the provider's per-metric breakdown as a sub-tree so the hierarchy shows depth.
                 SubResults: tree.Details.SubResults,

--- a/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
+++ b/src/AgentEval.MAF/Evaluators/AgentEvaluatorEvalLeaf.cs
@@ -92,7 +92,15 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
         }
 
         if (!string.IsNullOrEmpty(results.Error) || results.Items.Count == 0)
+        {
+            // A provider bypass (e.g. TracingAgentEvaluator's graceful workaround for upstream bugs)
+            // sets Status="skipped" to signal that the evaluator was intentionally not run.
+            // Return a neutral skipped leaf so it doesn't contribute a 0-score to CompositeEval
+            // aggregation — it is excluded from weighted roll-ups, same as a timeout branch.
+            if (string.Equals(results.Status, "skipped", StringComparison.OrdinalIgnoreCase))
+                return SkippedLeaf(results.Error ?? "skipped by provider");
             return ErrorLeaf(results.Error ?? "no results returned");
+        }
 
         // Reuse the existing MEAI -> EvalResult bridge for robust metric normalisation, then re-key its
         // aggregate as THIS leaf so it participates (by weight) in the parent CompositeEval.
@@ -131,6 +139,15 @@ public sealed class AgentEvaluatorEvalLeaf : IEval
     private EvalResult ErrorLeaf(string reason) => new(
         Metric: new EvalMetadata(Key, Name, Category, Version),
         Score: new EvalScore(0.0, Ordinal: null, Label: "error", Passed: false, Threshold: _threshold, Severity: "none", Confidence: null),
+        Details: new EvalDetails(null, new[] { new EvalEvidence("provider", Key, reason) }, null, null, null),
+        Provenance: new EvalProvenance("atomic-llm", _judgeModel, null, null, null, 0, false),
+        EvaluatedAt: DateTimeOffset.UtcNow);
+
+    // A provider that was intentionally skipped (e.g. known-bug bypass) is surfaced as a neutral
+    // "skipped" leaf — severity none, excluded from CompositeEval weighted roll-ups.
+    private EvalResult SkippedLeaf(string reason) => new(
+        Metric: new EvalMetadata(Key, Name, Category, Version),
+        Score: new EvalScore(0.0, Ordinal: null, Label: "skipped", Passed: false, Threshold: _threshold, Severity: "none", Confidence: null),
         Details: new EvalDetails(null, new[] { new EvalEvidence("provider", Key, reason) }, null, null, null),
         Provenance: new EvalProvenance("atomic-llm", _judgeModel, null, null, null, 0, false),
         EvaluatedAt: DateTimeOffset.UtcNow);

--- a/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
+++ b/src/AgentEval.MAF/Evaluators/HybridEvalInterop.cs
@@ -42,7 +42,12 @@ internal static class HybridEvalInterop
             results.Add(r);
         }
         // ProviderName carries the neutral label so UnifiedEvalReport renders the matching neutral branch.
-        return new AgentEvaluationResults($"{source} ({label})", results, inputItems: items) { Error = reason };
+        // Status is set to the same label so callers can use result.Status instead of parsing ProviderName.
+        return new AgentEvaluationResults($"{source} ({label})", results, inputItems: items)
+        {
+            Error = reason,
+            Status = label,
+        };
     }
 
     /// <summary>Convenience overload for an exception — surfaced as a neutral <c>"error"</c> branch.</summary>

--- a/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
+++ b/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
@@ -89,12 +89,16 @@ public static class MeaiToEvalResultBridge
             //   0–1  for agent/binary evaluators (task_adherence, intent_resolution, …)
             //   1–5  for quality evaluators       (relevance, coherence, fluency, …)
             // AgentEval's own metrics always embed the score marker above, so they never reach here.
-            // Primary: v > 1.0 → must be 1–5 scale.
-            // Edge case: v == 1.0 is ambiguous (best on 0–1 OR worst on 1–5). ONLY for this exact
-            // value, consult Interpretation.Failed to disambiguate: Failed=true → 1–5 worst (0%);
-            // Failed=false/null → 0–1 best (100%). For all other v < 1.0 values (e.g. task_adherence
-            // returning 0.5 with Failed=true meaning partial failure), treat as 0–1 proportion.
-            score0To100 = (v > 1.0 || (v == 1.0 && metric.Interpretation?.Failed == true))
+            // Primary: v clearly above 1.0 → must be 1–5 scale.
+            // Edge case: v ≈ 1.0 is ambiguous (best on 0–1 OR worst on 1–5). Use Interpretation.Failed
+            // to disambiguate — Failed=true → 1–5 worst (0%); Failed=false/null → 0–1 best (100%).
+            // For all other v < 1.0 − ε (e.g. task_adherence=0.5 with Failed=true), treat as 0–1.
+            // Use an epsilon to handle floating-point imprecision in deserialized values (e.g. a
+            // JSON 1.0 that arrives as 0.9999999998 or 1.0000000002 must still hit the same branch).
+            const double nearOneEpsilon = 1e-9;
+            bool likelyAbove1 = v > 1.0 + nearOneEpsilon;
+            bool nearOne = !likelyAbove1 && Math.Abs(v - 1.0) <= nearOneEpsilon;
+            score0To100 = (likelyAbove1 || (nearOne && metric.Interpretation?.Failed == true))
                 ? Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100)
                 : Math.Clamp(v * 100.0, 0, 100);
         }

--- a/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
+++ b/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
@@ -90,10 +90,11 @@ public static class MeaiToEvalResultBridge
             //   1–5  for quality evaluators       (relevance, coherence, fluency, …)
             // AgentEval's own metrics always embed the score marker above, so they never reach here.
             // Primary: v > 1.0 → must be 1–5 scale.
-            // Edge case: v == 1.0 is ambiguous (best on 0–1 OR worst on 1–5). Consult
-            // Interpretation.Failed to disambiguate — a 1-5 metric scoring 1.0 (worst) has
-            // Failed=true, while a 0-1 metric scoring 1.0 (best) has Failed=false or null.
-            score0To100 = (v > 1.0 || metric.Interpretation?.Failed == true)
+            // Edge case: v == 1.0 is ambiguous (best on 0–1 OR worst on 1–5). ONLY for this exact
+            // value, consult Interpretation.Failed to disambiguate: Failed=true → 1–5 worst (0%);
+            // Failed=false/null → 0–1 best (100%). For all other v < 1.0 values (e.g. task_adherence
+            // returning 0.5 with Failed=true meaning partial failure), treat as 0–1 proportion.
+            score0To100 = (v > 1.0 || (v == 1.0 && metric.Interpretation?.Failed == true))
                 ? Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100)
                 : Math.Clamp(v * 100.0, 0, 100);
         }

--- a/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
+++ b/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
@@ -85,7 +85,15 @@ public static class MeaiToEvalResultBridge
         }
         else if (metric is NumericMetric { Value: { } v })
         {
-            score0To100 = Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100);
+            // Foundry uses mixed scales across evaluators:
+            //   0–1  for agent/binary evaluators (task_adherence, intent_resolution, …)
+            //   1–5  for quality evaluators       (relevance, coherence, fluency, …)
+            // AgentEval's own metrics always embed the score marker above, so they never reach here.
+            // Heuristic: v ≤ 1.0 → treat as a 0–1 proportion (multiply by 100);
+            //            v > 1.0 → treat as a 1–5 Likert scale (normalise via (v-1)/4).
+            score0To100 = v <= 1.0
+                ? Math.Clamp(v * 100.0, 0, 100)
+                : Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100);
         }
         else
         {

--- a/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
+++ b/src/AgentEval.MAF/Evaluators/MeaiToEvalResultBridge.cs
@@ -89,11 +89,13 @@ public static class MeaiToEvalResultBridge
             //   0–1  for agent/binary evaluators (task_adherence, intent_resolution, …)
             //   1–5  for quality evaluators       (relevance, coherence, fluency, …)
             // AgentEval's own metrics always embed the score marker above, so they never reach here.
-            // Heuristic: v ≤ 1.0 → treat as a 0–1 proportion (multiply by 100);
-            //            v > 1.0 → treat as a 1–5 Likert scale (normalise via (v-1)/4).
-            score0To100 = v <= 1.0
-                ? Math.Clamp(v * 100.0, 0, 100)
-                : Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100);
+            // Primary: v > 1.0 → must be 1–5 scale.
+            // Edge case: v == 1.0 is ambiguous (best on 0–1 OR worst on 1–5). Consult
+            // Interpretation.Failed to disambiguate — a 1-5 metric scoring 1.0 (worst) has
+            // Failed=true, while a 0-1 metric scoring 1.0 (best) has Failed=false or null.
+            score0To100 = (v > 1.0 || metric.Interpretation?.Failed == true)
+                ? Math.Clamp((v - 1) / 4.0 * 100.0, 0, 100)
+                : Math.Clamp(v * 100.0, 0, 100);
         }
         else
         {

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -35,7 +35,7 @@ public static class UnifiedEvalReport
                 : Enumerable.Range(0, result.Items.Count).Select(i => $"query[{i}]").ToList();
 
             EvalResult branch;
-            if (result.Error is not null || result.Items.Count == 0)
+            if (!string.IsNullOrEmpty(result.Error) || result.Items.Count == 0)
             {
                 // Neutral infra branch (timeout / exception / breaker-open / empty result set). Do NOT bridge:
                 // the bridge yields a fail/high composite (an empty composite is "not passed") that would
@@ -54,9 +54,28 @@ public static class UnifiedEvalReport
             }
             else
             {
-                // Flat branch: reuse the bridge (per-query -> per-metric leaves), re-tagged as this source.
+                // Flat branch: bridge the MAF results into an EvalResult tree, then flatten redundant
+                // wrapper levels so the report stays shallow and readable.
+                //
+                // MeaiToEvalResultBridge.Build produces:
+                //   maf.eval (source)
+                //     └─ maf.eval.query0  (query text)
+                //          └─ metric leaf …
+                //
+                // We want instead (single query → promote metrics directly; multi-query → keep per-query):
+                //   hybrid.<source>
+                //     └─ metric leaf …          (single query)
+                //  OR
+                //   hybrid.<source>
+                //     └─ maf.eval.query0 …      (multiple queries)
+                //          └─ metric leaf …
                 var bridged = MeaiToEvalResultBridge.Build(source, queries, result, judgeModel: null);
-                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", new[] { bridged }, source);
+                var querySubs = bridged.Details.SubResults ?? [];
+                IReadOnlyList<EvalResult> hybridChildren = querySubs.Count == 1
+                    && querySubs[0].Details.SubResults is { Count: > 0 } leafSubs
+                        ? leafSubs          // single query → expose metric leaves directly
+                        : querySubs;        // multiple queries → keep per-query level
+                branch = Node($"hybrid.{Sanitize(source)}", source, "agentic", hybridChildren, source);
             }
 
             // Attach the provider's portal link (when present) as evidence on the branch. Use the actual

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -40,7 +40,7 @@ public static class UnifiedEvalReport
                 // Neutral infra branch (timeout / exception / breaker-open / empty result set). Do NOT bridge:
                 // the bridge yields a fail/high composite (an empty composite is "not passed") that would
                 // sink the whole report. Render it neutral instead.
-                var reason = result.Error ?? "no results returned";
+                var reason = !string.IsNullOrEmpty(result.Error) ? result.Error : "no results returned";
                 var neutralLabel = result.ProviderName.EndsWith("(skipped)", StringComparison.Ordinal) ? "skipped" : "error";
                 branch = NeutralBranch($"hybrid.{Sanitize(source)}", source, neutralLabel, reason);
             }

--- a/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
+++ b/src/AgentEval.MAF/Evaluators/UnifiedEvalReport.cs
@@ -41,7 +41,12 @@ public static class UnifiedEvalReport
                 // the bridge yields a fail/high composite (an empty composite is "not passed") that would
                 // sink the whole report. Render it neutral instead.
                 var reason = !string.IsNullOrEmpty(result.Error) ? result.Error : "no results returned";
-                var neutralLabel = result.ProviderName.EndsWith("(skipped)", StringComparison.Ordinal) ? "skipped" : "error";
+                // Use result.Status as the primary discriminant (reliable, set by both TracingAgentEvaluator
+                // and HybridEvalInterop.SkippedResults). Fall back to the ProviderName suffix for results
+                // produced by older code paths that may not set Status.
+                var neutralLabel = string.Equals(result.Status, "skipped", StringComparison.OrdinalIgnoreCase)
+                    || result.ProviderName.EndsWith("(skipped)", StringComparison.Ordinal)
+                    ? "skipped" : "error";
                 branch = NeutralBranch($"hybrid.{Sanitize(source)}", source, neutralLabel, reason);
             }
             else if (composite is not null && IsLocalAgentEval(source) && composite.CapturedResults.Count > 0 && result.Items.Count > 0)

--- a/tests/AgentEval.Tests/Evals/WeightedSumAggregationTests.cs
+++ b/tests/AgentEval.Tests/Evals/WeightedSumAggregationTests.cs
@@ -125,4 +125,45 @@ public class WeightedSumAggregationTests
     {
         Assert.Equal("WeightedSum", _sut.Name);
     }
+
+    // ── "error" is neutral (same as "skipped") ────────────────────────────────────
+
+    private static EvalResult ErrorResult() => MakeResult(0.0, "none", "error");
+
+    [Fact]
+    public void Aggregate_OneError_ErrorContributionOmitted()
+    {
+        // An infra-failure leaf (score=0, label="error") must not drag the composite below threshold.
+        // Same semantics as "skipped": omit from weighted sum entirely.
+        var results = new[] { MakeResult(0.8), ErrorResult() };
+        var components = new[] { Comp(1), Comp(1) };
+
+        var (score, _) = _sut.Aggregate(results, components);
+
+        Assert.Equal(0.8, score, precision: 10);   // error leaf not included in denominator
+    }
+
+    [Fact]
+    public void Aggregate_AllError_ScoreIsZero_SeverityIsNone()
+    {
+        // When every leaf is an infra failure the composite should not explode: score=0, severity=none.
+        var results = new[] { ErrorResult(), ErrorResult() };
+        var components = new[] { Comp(1), Comp(1) };
+
+        var (score, severity) = _sut.Aggregate(results, components);
+
+        Assert.Equal(0, score);
+        Assert.Equal("none", severity);
+    }
+
+    [Fact]
+    public void Aggregate_MixOfSkippedAndError_BothOmitted_OnlyRealContributes()
+    {
+        var results = new[] { MakeResult(0.6), SkippedResult(), ErrorResult() };
+        var components = new[] { Comp(1), Comp(1), Comp(1) };
+
+        var (score, _) = _sut.Aggregate(results, components);
+
+        Assert.Equal(0.6, score, precision: 10);   // only the real leaf contributes
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
@@ -117,3 +117,4 @@ public class AgentEvaluatorEvalLeafTests
             result.Details.Evidence!,
             e => e.Reference == "report_url" && e.Message == portalUrl.ToString());
     }
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/AgentEvaluatorEvalLeafTests.cs
@@ -67,4 +67,53 @@ public class AgentEvaluatorEvalLeafTests
         Assert.True(result.Score.Passed);          // both components pass -> weighted sum clears 0.5
         Assert.True(result.Score.Value > 0.0);
     }
-}
+
+    // ── Skipped path (TracingAgentEvaluator bypass for known upstream bugs) ─────────────────
+
+    [Fact]
+    public async Task AsEvalLeaf_SkippedResult_ProducesNeutralSkippedLeaf_NotErrorLeaf()
+    {
+        // When TracingAgentEvaluator returns Status="skipped" the leaf must be neutral (severity none,
+        // label="skipped") so it doesn’t drag down CompositeEval weighted aggregation with a 0-score.
+        IEval leaf = Skipped("foundry", "Blocked by upstream bug #6991").AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+
+        var result = await leaf.EvaluateAsync(new EvalInput("q", "r"));
+
+        Assert.Equal("skipped", result.Score.Label);
+        Assert.Equal("none", result.Score.Severity);
+        Assert.False(result.Score.Passed);
+        Assert.Equal(0.0, result.Score.Value);
+        Assert.Contains(result.Details.Evidence!, e => e.Message.Contains("#6991"));
+    }
+
+    [Fact]
+    public async Task AsEvalLeaf_SkippedLeaf_DoesNotDragDownCompositeAggregation()
+    {
+        // A skipped leaf must be neutral in CompositeEval roll-ups: only non-neutral leaves contribute.
+        IEval foundrySkipped = Skipped("foundry").AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+        IEval agentEvalLeaf  = new StubComposite(Leaf("task_completion", 1.0));  // passes at 100%
+
+        var benchmark = new CompositeEval(
+            key: "hybrid.bench", name: "Hybrid", category: "hybrid", version: "1.0.0",
+            components: new[] { new EvalComponent(agentEvalLeaf, 0.5), new EvalComponent(foundrySkipped, 0.5) },
+            aggregation: WeightedSumAggregation.Instance,
+            threshold: 0.5);
+
+        var result = await benchmark.EvaluateAsync(new EvalInput("q", "r"));
+
+        // The skipped leaf has severity=none so the composite is not dragged to fail.
+        Assert.NotEqual("fail", result.Score.Label);
+    }
+
+    [Fact]
+    public async Task AsEvalLeaf_ReportUrl_SurfacedInEvidence()
+    {
+        var portalUrl = new Uri("https://ai.azure.com/foundry/eval/run/abc123");
+        IEval leaf = WithReportUrl("foundry", portalUrl).AsEvalLeaf("foundry.relevance", "Foundry Relevance");
+
+        var result = await leaf.EvaluateAsync(new EvalInput("q", "r"));
+
+        Assert.Contains(
+            result.Details.Evidence!,
+            e => e.Reference == "report_url" && e.Message == portalUrl.ToString());
+    }

--- a/tests/AgentEval.Tests/MAF/Evaluators/HybridEvalTestHelpers.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/HybridEvalTestHelpers.cs
@@ -50,6 +50,23 @@ internal static class HybridEvalTestHelpers
     public static FakeEvaluator Slow(string s, int ms) => new(s, async (items, ct) => { await Task.Delay(ms, ct); return Pass(items, s); });
     public static FakeEvaluator Throws(string s) => new(s, (_, _) => throw new InvalidOperationException($"{s} boom"));
 
+    /// <summary>Fake that returns a skipped result (Status="skipped"), simulating a graceful bypass.</summary>
+    public static FakeEvaluator Skipped(string s, string reason = "skipped by test") =>
+        new(s, (items, _) => Task.FromResult(new AgentEvaluationResults(s + " (skipped)", [], inputItems: items)
+        {
+            Status = "skipped",
+            Error = reason,
+        }));
+
+    /// <summary>Fake that returns a passing result with a portal <see cref="Uri"/> attached.</summary>
+    public static FakeEvaluator WithReportUrl(string s, Uri reportUrl) =>
+        new(s, (items, _) =>
+        {
+            var r = Pass(items, s);
+            r.ReportUrl = reportUrl;
+            return Task.FromResult(r);
+        });
+
     /// <summary>An <see cref="IEval"/> that returns a fixed tree (no LLM) — populates CapturedResults cheaply.</summary>
     public sealed class StubComposite(EvalResult tree) : IEval
     {

--- a/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
@@ -162,3 +162,4 @@ public class MeaiToEvalResultBridgeTests
         Assert.Equal(1.0, leaf.Score.Value, 3);
         Assert.True(leaf.Score.Passed);
     }
+}

--- a/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
@@ -162,4 +162,18 @@ public class MeaiToEvalResultBridgeTests
         Assert.Equal(1.0, leaf.Score.Value, 3);
         Assert.True(leaf.Score.Passed);
     }
+
+    [Fact]
+    public void Build_NormalizesVBelow1_As0To1Proportion_EvenWhenFailed()
+    {
+        // Regression: v < 1.0 with Failed=true must use 0-1 proportion, NOT the 1-5 formula.
+        // task_adherence=0.5 (partial failure on 0-1 scale) → 50%, not clamped-to-0%.
+        var meai = ResultWith(("task_adherence",
+            new NumericMetric("task_adherence", 0.5)
+            { Interpretation = new EvaluationMetricInterpretation(EvaluationRating.Unacceptable, failed: true) }));
+
+        var leaf = FirstLeaf(MeaiToEvalResultBridge.Build("Eval", new[] { "q1" }, Wrap(meai)));
+
+        Assert.Equal(0.50, leaf.Score.Value, 3);
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
@@ -176,4 +176,24 @@ public class MeaiToEvalResultBridgeTests
 
         Assert.Equal(0.50, leaf.Score.Value, 3);
     }
+
+    [Theory]
+    [InlineData(1.0 - 5e-10, false, 1.0)]   // slightly below 1.0, not failed → near-1.0, treat as 0-1 best → 100%
+    [InlineData(1.0 + 5e-10, false, 1.0)]   // slightly above 1.0, not failed → near-1.0, treat as 0-1 best → 100%
+    [InlineData(1.0 - 5e-10, true,  0.0)]   // slightly below 1.0, failed → near-1.0, treat as 1-5 worst → 0%
+    [InlineData(1.0 + 5e-10, true,  0.0)]   // slightly above 1.0, failed → near-1.0, treat as 1-5 worst → 0%
+    public void Build_NearOne_EpsilonBoundary_DisambiguatesViaInterpretation(
+        double rawValue, bool failed, double expectedScore)
+    {
+        // Regression: exact equality (v==1.0) is fragile under floating-point deserialisation.
+        // Values within epsilon of 1.0 must use Interpretation.Failed for disambiguation.
+        var rating = failed ? EvaluationRating.Unacceptable : EvaluationRating.Good;
+        var meai = ResultWith(("task_adherence",
+            new NumericMetric("task_adherence", rawValue)
+            { Interpretation = new EvaluationMetricInterpretation(rating, failed: failed) }));
+
+        var leaf = FirstLeaf(MeaiToEvalResultBridge.Build("Eval", new[] { "q1" }, Wrap(meai)));
+
+        Assert.Equal(expectedScore, leaf.Score.Value, 6);
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
+++ b/tests/AgentEval.Tests/MAF/Evaluators/MeaiToEvalResultBridgeTests.cs
@@ -117,4 +117,48 @@ public class MeaiToEvalResultBridgeTests
         Assert.Equal("critical", leaf.Score.Severity);
         Assert.False(leaf.Score.Passed);
     }
-}
+
+    // ── Mixed-scale normalisation (Foundry: 0–1 vs 1–5) ───────────────────────────────────────
+
+    [Fact]
+    public void Build_NormalizesZeroToOneScale_WhenValueIsBelow1AndNotFailed()
+    {
+        // Foundry task_adherence uses 0–1; 0.5 (mid-range) should map to 50%, not a negative clamped value.
+        var meai = ResultWith(("task_adherence",
+            new NumericMetric("task_adherence", 0.5)
+            { Interpretation = new EvaluationMetricInterpretation(EvaluationRating.Good, failed: false) }));
+
+        var leaf = FirstLeaf(MeaiToEvalResultBridge.Build("Eval", new[] { "q1" }, Wrap(meai)));
+
+        Assert.Equal(0.50, leaf.Score.Value, 3);
+        Assert.True(leaf.Score.Passed);
+    }
+
+    [Fact]
+    public void Build_NormalizesAmbiguousV1_AsZero_WhenInterpretationIsFailed()
+    {
+        // v==1.0 is ambiguous: best on 0–1 scale OR worst on 1–5 scale.
+        // Interpretation.Failed=true disambiguates to 1–5 worst → (1-1)/4*100 = 0%.
+        var meai = ResultWith(("relevance",
+            new NumericMetric("relevance", 1.0)
+            { Interpretation = new EvaluationMetricInterpretation(EvaluationRating.Unacceptable, failed: true) }));
+
+        var leaf = FirstLeaf(MeaiToEvalResultBridge.Build("Eval", new[] { "q1" }, Wrap(meai)));
+
+        Assert.Equal(0.0, leaf.Score.Value, 3);
+        Assert.False(leaf.Score.Passed);
+    }
+
+    [Fact]
+    public void Build_NormalizesAmbiguousV1_As100Percent_WhenInterpretationIsNotFailed()
+    {
+        // v==1.0, Interpretation.Failed=false → 0–1 scale, best → 1.0*100 = 100%.
+        var meai = ResultWith(("task_adherence",
+            new NumericMetric("task_adherence", 1.0)
+            { Interpretation = new EvaluationMetricInterpretation(EvaluationRating.Good, failed: false) }));
+
+        var leaf = FirstLeaf(MeaiToEvalResultBridge.Build("Eval", new[] { "q1" }, Wrap(meai)));
+
+        Assert.Equal(1.0, leaf.Score.Value, 3);
+        Assert.True(leaf.Score.Passed);
+    }


### PR DESCRIPTION
## Summary

End-to-end hardening of the Azure AI Foundry integration across samples 12 & 13, the `UnifiedEvalReport` / `AgentEvaluatorEvalLeaf` bridges, and the HTML renderer. All changes were validated against a live Foundry project (`msfoundryjose.services.ai.azure.com`).

---

## Changes

### 🐛 Bug fixes — core libraries

| File | Fix |
|---|---|
| `MeaiToEvalResultBridge` | **Scale normalization**: Foundry agent evaluators (`task_adherence` etc.) use 0–1; quality evaluators (`relevance` etc.) use 1–5. The bridge assumed 1–5 for everything — `task_adherence=1.0` (perfect) rendered as **0%**. Fix: `v ≤ 1.0 → v×100`; `v > 1.0 → (v-1)/4×100`. |
| `UnifiedEvalReport` | **Empty-string Error**: Foundry returns `"error": null` in the run JSON. `JsonElement.ToString()` gives `""` (not `null`). `Error is not null` was treating a successful eval as an ERROR branch. Fix: `!string.IsNullOrEmpty(result.Error)`. |
| `AgentEvaluatorEvalLeaf` | Same `IsNullOrEmpty` fix. Also: **attach `ReportUrl` to evidence** so the Foundry portal link surfaces in reports and console output for sample 13. |
| `UnifiedEvalReport` | **Flatten hierarchy**: single-query Foundry branches had 4 levels (`hybrid.foundry → maf.eval → query0 → leaves`). Now: `hybrid.foundry → leaves` (single query) or `hybrid.foundry → query nodes → leaves` (multi-query). |

### ✨ New features — HTML renderer

`HtmlEvalResultRenderer`: **source-provider chips** on node summary rows, so Foundry and local branches are immediately distinguishable without expanding the node:
- `hybrid.*` keys → driven by suffix (☁ Foundry / ⚙ AgentEval)  
- `foundry.*` keys → always ☁ Foundry (blue pill)

### ✨ New features — samples

**`AIConfig`** — new properties:
- `FoundryEndpoint` reads `AZURE_FOUNDRY_ENDPOINT` (`https://<hub>.services.ai.azure.com/api/projects/<project>`)
- `IsFoundryConfigured` — both OpenAI + Foundry vars set

**Sample 12 (`FoundryHybridBenchmark`)**:
- Use `AIConfig.FoundryEndpoint` instead of `AZURE_OPENAI_ENDPOINT`
- Restore `foundryOn` guard (Foundry branch only added when endpoint is set)
- Per-source console breakdown after `agent.EvaluateAsync`: ☁/⚙ icons, passed/total, Foundry portal URL, per-metric scores

**Sample 13 (`FoundryHierarchyBenchmark`)**:
- Same `AIConfig.FoundryEndpoint` wiring and `foundryOn` guard
- Per-component console breakdown with ☁/⚙ icons and portal URLs

**`TracingAgentEvaluator`** (in `_BenchmarkSampleHelpers`, used by both samples):
- Wraps any `IAgentEvaluator`; prints `[Foundry ▶]` before the call and `[Foundry ✔]` / `[Foundry ⚠]` / `[Foundry ✘]` after
- **Graceful bypass for [microsoft/agent-framework#6991](https://github.com/microsoft/agent-framework/issues/6991)**: detects the HTTP 400 `azure_ai_evaluator` bug and returns a structured `skipped` result — local AgentEval results survive unaffected

### 🐛 Upstream bug filed

**[microsoft/agent-framework#6991](https://github.com/microsoft/agent-framework/issues/6991)** — `FoundryEvals` hardcodes `"type": "azure_ai_evaluator"` in `WireTestingCriterion` (in `FoundryEvalWireModels.cs`). The Foundry API at `*.services.ai.azure.com` no longer accepts this type. Fix is pending upstream.

---

## Testing

Validated against live Foundry project:
- `AZURE_FOUNDRY_ENDPOINT=https://msfoundryjose.services.ai.azure.com/api/projects/MsFoundry`
- `FoundryEvals.TaskAdherence` + `FoundryEvals.Relevance`
- Both samples run end-to-end, HTML report shows correct scores and ☁ chips
- Bypass tested: `[Foundry ⚠]` fires correctly, local results unaffected

---

## Environment variables required

```powershell
$env:AZURE_OPENAI_ENDPOINT   = "https://<resource>.openai.azure.com/"
$env:AZURE_OPENAI_API_KEY    = "<key>"
$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
$env:AZURE_FOUNDRY_ENDPOINT  = "https://<hub>.services.ai.azure.com/api/projects/<project>"
# + az login --tenant <tenant-id>
```
