### PR TITLE
chore(deps): bump Microsoft Agent Framework 1.12.0 -> 1.13.0

### DIFF
--- a/.claude/maf-doctor.md
+++ b/.claude/maf-doctor.md
@@ -20,9 +20,16 @@ and the maf-doctor registry is kept current via an AI-fill loop.
    training data — MAF ships breaking changes every minor version, so
    training data is likely outdated.
 
-3. **Before manually editing MAF code to fix an anti-pattern** — call
-   `MafAutoFixAll --dry-run` and offer to apply the deterministic
-   rewrites first. Manual edits drift; the rewrites are tested.
+3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
+   *mechanical* rules deterministically (offer this first; the rewrites are
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -31,6 +38,13 @@ and the maf-doctor registry is kept current via an AI-fill loop.
 5. **For deep architectural / security / migration questions** — use the
    `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
    `@maf-incident-responder` specialist agents.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+   MAF version bump) — call `MafDetectSourceFramework` (CLI:
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
+   **new MAF project beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.claude/maf-doctor.md
+++ b/.claude/maf-doctor.md
@@ -22,14 +22,12 @@ and the maf-doctor registry is kept current via an AI-fill loop.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). To fix **everything**, run the `maf-remediate` prompt (or just
-   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
-   → then works each semantic finding. Every finding carries a **`confidence`**
-   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
-   **false positive** — confirm it with `MafExplainFinding` before editing.
-   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
-   (structured manifest); per-rule fix + false-positive guidance lives in the
-   `maf-remediation-playbook` skill.
+   tested). For the rest, just ask "fix all the issues maf-doctor found" —
+   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
+   structured manifest) → autofix → then work each semantic finding. Every
+   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
+   **`heuristic`** finding may be a **false positive** — confirm it with
+   `MafExplainFinding` before editing.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -41,10 +39,9 @@ and the maf-doctor registry is kept current via an AI-fill loop.
 
 6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
-   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
-   **new MAF project beside the original** and ports it construct-by-construct,
-   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
+   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
+   migration strategy (bridgeable / rewrite / re-architect), and get a
+   complexity verdict before scoping the port.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.claude/maf-doctor.md
+++ b/.claude/maf-doctor.md
@@ -1,11 +1,8 @@
-## Microsoft Agent Framework code — use MAF Doctor
+## Using maf-doctor for Microsoft Agent Framework code
 
 This repository uses Microsoft Agent Framework. The maf-doctor MCP server
-is installed and exposes specialist tools for MAF code.
-
-You should defer to maf-doctor's tools over training-data knowledge for
-anything MAF-related, because MAF ships breaking changes every minor version
-and the maf-doctor registry is kept current via an AI-fill loop.
+(also called "MAF Doctor") is installed and exposes tools for diagnosing,
+fixing, and migrating MAF code.
 
 **Before answering MAF questions or proposing changes:**
 
@@ -33,11 +30,7 @@ and the maf-doctor registry is kept current via an AI-fill loop.
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **For deep architectural / security / migration questions** — use the
-   `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
-   `@maf-incident-responder` specialist agents.
-
-6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
    `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
    migration strategy (bridgeable / rewrite / re-architect), and get a

--- a/.github/instructions/maf-doctor.instructions.md
+++ b/.github/instructions/maf-doctor.instructions.md
@@ -34,11 +34,7 @@ fixing, and migrating MAF code.
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **For deep architectural / security / migration questions** — use the
-   `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
-   `@maf-incident-responder` specialist agents.
-
-6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
    `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
    migration strategy (bridgeable / rewrite / re-architect), and get a

--- a/.github/instructions/maf-doctor.instructions.md
+++ b/.github/instructions/maf-doctor.instructions.md
@@ -23,14 +23,12 @@ fixing, and migrating MAF code.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). To fix **everything**, run the `maf-remediate` prompt (or just
-   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
-   → then works each semantic finding. Every finding carries a **`confidence`**
-   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
-   **false positive** — confirm it with `MafExplainFinding` before editing.
-   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
-   (structured manifest); per-rule fix + false-positive guidance lives in the
-   `maf-remediation-playbook` skill.
+   tested). For the rest, just ask "fix all the issues maf-doctor found" —
+   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
+   structured manifest) → autofix → then work each semantic finding. Every
+   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
+   **`heuristic`** finding may be a **false positive** — confirm it with
+   `MafExplainFinding` before editing.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -42,10 +40,9 @@ fixing, and migrating MAF code.
 
 6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
-   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
-   **new MAF project beside the original** and ports it construct-by-construct,
-   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
+   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
+   migration strategy (bridgeable / rewrite / re-architect), and get a
+   complexity verdict before scoping the port.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.github/instructions/maf-doctor.instructions.md
+++ b/.github/instructions/maf-doctor.instructions.md
@@ -21,9 +21,16 @@ fixing, and migrating MAF code.
    training data — MAF ships breaking changes every minor version, so
    training data is likely outdated.
 
-3. **Before manually editing MAF code to fix an anti-pattern** — call
-   `MafAutoFixAll --dry-run` and offer to apply the deterministic
-   rewrites first. Manual edits drift; the rewrites are tested.
+3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
+   *mechanical* rules deterministically (offer this first; the rewrites are
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -32,6 +39,13 @@ fixing, and migrating MAF code.
 5. **For deep architectural / security / migration questions** — use the
    `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
    `@maf-incident-responder` specialist agents.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+   MAF version bump) — call `MafDetectSourceFramework` (CLI:
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
+   **new MAF project beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,11 @@
 {
   "mcpServers": {
     "maf-doctor": {
-      "type": "stdio",
       "command": "maf-doctor",
       "args": [],
-      "env": {}
+      "env": {
+        "MAF_DOCTOR_INIT_VERSION": "1.9.0"
+      }
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,7 @@
 {
   "mcpServers": {
     "maf-doctor": {
+      "type": "stdio",
       "command": "maf-doctor",
       "args": [],
       "env": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,9 +187,16 @@ fixing, and migrating MAF code.
    training data — MAF ships breaking changes every minor version, so
    training data is likely outdated.
 
-3. **Before manually editing MAF code to fix an anti-pattern** — call
-   `MafAutoFixAll --dry-run` and offer to apply the deterministic
-   rewrites first. Manual edits drift; the rewrites are tested.
+3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
+   *mechanical* rules deterministically (offer this first; the rewrites are
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -198,6 +205,13 @@ fixing, and migrating MAF code.
 5. **For deep architectural / security / migration questions** — use the
    `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
    `@maf-incident-responder` specialist agents.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+   MAF version bump) — call `MafDetectSourceFramework` (CLI:
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
+   **new MAF project beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4o
 
 
 <!-- BEGIN maf-doctor (managed by `maf-doctor init` — overwritten on re-run) -->
-## Microsoft Agent Framework — MAF Doctor is installed
+## Using maf-doctor for Microsoft Agent Framework code
 
 This repository uses Microsoft Agent Framework. The maf-doctor MCP server
 (also called "MAF Doctor") is installed and exposes tools for diagnosing,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,14 +189,12 @@ fixing, and migrating MAF code.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). To fix **everything**, run the `maf-remediate` prompt (or just
-   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
-   → then works each semantic finding. Every finding carries a **`confidence`**
-   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
-   **false positive** — confirm it with `MafExplainFinding` before editing.
-   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
-   (structured manifest); per-rule fix + false-positive guidance lives in the
-   `maf-remediation-playbook` skill.
+   tested). For the rest, just ask "fix all the issues maf-doctor found" —
+   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
+   structured manifest) → autofix → then work each semantic finding. Every
+   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
+   **`heuristic`** finding may be a **false positive** — confirm it with
+   `MafExplainFinding` before editing.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
@@ -208,10 +206,9 @@ fixing, and migrating MAF code.
 
 6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
-   `maf-migrate-from` prompt or the `@maf-cross-migration` agent. It scaffolds a
-   **new MAF project beside the original** and ports it construct-by-construct,
-   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
+   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
+   migration strategy (bridgeable / rewrite / re-architect), and get a
+   complexity verdict before scoping the port.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,11 +200,7 @@ fixing, and migrating MAF code.
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **For deep architectural / security / migration questions** — use the
-   `@maf-best-practice-reviewer`, `@maf-auditor`, `@maf-migration`, or
-   `@maf-incident-responder` specialist agents.
-
-6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
    `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
    migration strategy (bridgeable / rewrite / re-architect), and get a

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,19 +8,26 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <!-- Microsoft Agent Framework — core packages on 1.12.0 (stable), bumped from 1.11.1.
-         Microsoft.Agents.AI.Foundry has no stable 1.12.0 yet (published preview-only), so it's pinned to
-         the matching 1.12.0-preview and is referenced only by the SAMPLES (the
+    <!-- Microsoft Agent Framework — core packages on 1.13.0 (stable), bumped from 1.12.0.
+         Microsoft.Agents.AI.Foundry has no stable 1.13.0 yet (published preview-only), so it's pinned to
+         the matching 1.13.0-preview and is referenced only by the SAMPLES (the
          AgentEval.MafEvalFoundryAlongsideLocal standalone + the AgentEval.Samples H12/H13 benchmarks) —
-         the shipping libraries stay provider-agnostic. Stable core 1.12.0 satisfies the preview's
-         Microsoft.Agents.AI dependency (a stable version outranks a same-version prerelease). -->
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.12.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.12.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.12.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.12.0" />
-    <PackageVersion Include="Microsoft.Agents.AI.Foundry" Version="1.12.0-preview.260629.1" /><!-- preview-only; sample-only -->
-    <PackageVersion Include="Microsoft.Agents.AI.Harness" Version="1.12.0-preview.260629.1" /><!-- preview-only; sample-only — the real Agent Harness (AsHarnessAgent) -->
-    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.3" /><!-- required by Microsoft.Agents.AI.Foundry -->
+         the shipping libraries stay provider-agnostic. Stable core 1.13.0 satisfies the preview's
+         Microsoft.Agents.AI dependency (a stable version outranks a same-version prerelease).
+         1.13.0 breaking changes (dotnet-1.13.0 release notes): (1) file-store API renamed —
+         *FileAsync methods removed from AgentFileStore/FileSystemAgentFileStore/InMemoryAgentFileStore
+         (use WriteAsync/ReadAsync/DeleteAsync/ListChildrenAsync/SearchAsync), FileListEntry.FileName→Name,
+         FileAccessProvider tool-name constants renamed — AgentEval does not use this API (verified, zero
+         references); (2) Hosting.OpenAI OptionsMapping + Foundry.Hosting AddFoundryToolboxes breaking
+         changes — both in Microsoft.Agents.AI.Hosting.OpenAI / Microsoft.Agents.AI.Foundry.Hosting, packages
+         AgentEval does not reference. No source changes required for this bump. -->
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows.Generators" Version="1.13.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Foundry" Version="1.13.0-preview.260703.1" /><!-- preview-only; sample-only -->
+    <PackageVersion Include="Microsoft.Agents.AI.Harness" Version="1.13.0-preview.260703.1" /><!-- preview-only; sample-only — the real Agent Harness (AsHarnessAgent) -->
+    <PackageVersion Include="Azure.AI.Projects" Version="2.1.0-beta.4" /><!-- required by Microsoft.Agents.AI.Foundry 1.13.0-preview (raised from 2.1.0-beta.3) -->
     
     <!-- Microsoft Extensions AI -->
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
@@ -31,7 +38,7 @@
     <!-- SEC-13: Azure.AI.OpenAI is a direct ref of AgentEval.Cli (packed/published as a global
          dotnet tool), so a -beta dependency risks yank/unlist and API churn. It is pinned to beta
          deliberately: the only stable 2.x release on NuGet is 2.0.0 (Nov 2024), which predates the
-         API surface used by the Microsoft.Agents.AI 1.11.1 stack and AzureChatAgentFactory — there is
+         API surface used by the Microsoft.Agents.AI 1.13.0 stack and AzureChatAgentFactory — there is
          no recent GA to move to. Mitigations: (1) the CLI itself ships on the -prerelease channel,
          so a beta dependency is in-band; (2) the version is centrally pinned here (CPM) so it cannot
          float. ACTION: upgrade to a stable Azure.AI.OpenAI 2.x as soon as one ships (tracked, vNext). -->
@@ -39,17 +46,17 @@
     <PackageVersion Include="Azure.Identity" Version="1.18.0" />
     
     <!-- Core -->
-    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.8" /><!-- floor raised by Microsoft.Extensions.AI 10.6.0 (MAF 1.11.1 still depends on Extensions.AI 10.6.0) -->
-    <PackageVersion Include="System.Memory.Data" Version="10.0.3" />
-    <!-- Security: pin to patch that resolves GHSA-g94r-2vxg-569j (transitive via MAF 1.11.1; the
-         1.11.1 Workflows packages still declare OpenTelemetry.Api 1.15.3, so this pin stays valid) -->
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.8" /><!-- floor raised by Microsoft.Extensions.AI 10.6.0 (MAF 1.13.0 still depends on Extensions.AI 10.6.0) -->
+    <PackageVersion Include="System.Memory.Data" Version="10.0.9" /><!-- floor raised by Azure.Core 1.60.0 (transitive via Azure.AI.Projects 2.1.0-beta.4, required by Microsoft.Agents.AI.Foundry 1.13.0-preview) -->
+    <!-- Security: pin to patch that resolves GHSA-g94r-2vxg-569j (transitive via MAF; the
+         1.13.0 Workflows packages still declare OpenTelemetry.Api 1.15.3, so this pin stays valid) -->
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.3" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <!-- Abstractions packages target netstandard2.0/net8.0 — safe for net8/9/10 TFMs.
          10.0.3 required transitively by Azure.Identity 1.18.0. -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" /><!-- floor raised by Azure.Core 1.60.0 (transitive via Azure.AI.Projects 2.1.0-beta.4, required by Microsoft.Agents.AI.Foundry 1.13.0-preview) -->
     
     <!-- PDF Generation -->
     <PackageVersion Include="PdfSharp-MigraDoc" Version="6.2.4" />

--- a/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
+++ b/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
@@ -11,7 +11,6 @@
     <!-- Exclude from Central Package Management - standalone consumer sample -->
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     
-    <!-- This is intentionally NOT included in the main solution -->
     <!-- It tests the NuGet package as an external consumer would -->
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- Bumps MAF core packages (`Microsoft.Agents.AI`/`.OpenAI`/`.Workflows`/`.Workflows.Generators`) 1.12.0 → 1.13.0, and the sample-only Foundry/Harness previews to the matching 1.13.0-preview.
- Cross-checked the official `dotnet-1.13.0` release notes against `maf-doctor`'s compatibility data: of 3 `[BREAKING]` PRs upstream, only the file-store API rename could plausibly touch AgentEval — grepped the repo, **zero usage**. The other two live in `Hosting.OpenAI`/`Foundry.Hosting` packages AgentEval doesn't reference.
- Bumping the Foundry preview surfaced a real transitive floor cascade no static tool flagged: `Azure.AI.Projects` → `2.1.0-beta.4` (was `.3`) → `Azure.Core >= 1.60.0` → raises `System.Memory.Data` / `Microsoft.Extensions.Hosting.Abstractions` floors to `>= 10.0.9` (were `10.0.3`). Caught by an actual `dotnet restore` (`NU1109`), fixed by bumping both.
- Only `Directory.Packages.props` changed — no `.cs`/`.csproj` edits needed anywhere.
- Also includes a `maf-doctor init` refresh (global tool 1.8.0 → 1.9.0; MCP wiring + steering docs) as a separate commit.

Full assessment doc (local-only): `strategy/MAF-1.13.0-Migration-Assessment-and-Plan.md`.

## Test plan
- [x] `dotnet restore AgentEval.sln` — clean (after the two floor fixes)
- [x] `dotnet build AgentEval.sln -c Debug` — 0 errors, 66 pre-existing warnings (net8/9/10)
- [x] `dotnet test tests/AgentEval.Tests` — net8 7055/7055, net9 7055/7055, net10 7258/7259 (1 pre-existing skip)
- [x] `dotnet test tests/AgentEval.Memory.Tests` — 500/500 × 3 TFMs
- [x] `AgentEval.NuGetConsumer` (+`.Tests`) — builds clean, correctly unaffected (frozen to published `0.13.1-beta`/MAF `1.11.1` by design)
- [x] Real CLI smoke test — `agenteval redteam --sut gatekeeper-demo` ran a live MAF-backed agent through the gate correctly (Pass, 2 blocked calls)
- [x] `maf-doctor doctor .` — Grade C, same 3 pre-existing findings before and after (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)