### PR TITLE
docs(gatekeeper): document UseGatekeeper, coverage analyzer, and telemetry

### DIFF
--- a/docs/gatekeeper/examples.md
+++ b/docs/gatekeeper/examples.md
@@ -33,6 +33,39 @@ judge below.) Runnable: sample **`Gatekeeper/00_GatekeeperHelloWorld`**.
 > the most powerful: if you control the tool list, not granting the tool is stronger. The examples below are the
 > ones that catch what a tool list can't.
 
+## The recommended way to compose more than one gate — `UseGatekeeper`
+
+Every example below chains the low-level builder calls by hand (`.UseAgentEvalGate()` →
+`.UseAgentEvalToolGate(...)`) to keep each one focused on ONE gate at a time. For real code wiring several gates
+together, use `UseGatekeeper(enforcement, configure)` instead — it installs them in the correct order and
+refuses to construct (rather than silently misbehave) if it can prove the composition is unsafe. See the
+[introduction](introduction.md#wiring-it-together-usegatekeeper) for the full explanation; here's the shape:
+
+```csharp
+using AgentEval.MAF.Gatekeeper;
+
+var agent = baseAgent.AsBuilder()
+    .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+    {
+        g.Add(new SequenceGate(["read_customer_data"], ["send_email", "http_post"]));
+        g.Add(new RunBudgetGate(maxToolCalls: 20));
+        g.AddPreGate(new TokenInjectionGate());
+        g.Trace = trace;
+    })
+    .Build();
+```
+
+`GatekeeperEnforcement` is **required** — `Observe` (record findings, block nothing — the safe first rollout),
+`ReplaceResult`, or `Terminate`. Start with `.ObserveWithAgentEvalGates(configure)` to see what a gate set
+*would* have blocked with zero behavior change, then switch to `.EnforceAgentEvalGates(configure)` once you
+trust it.
+
+> **⚠ Never chain two separate `UseAgentEvalToolGate(...)` calls on the same builder.** Register every tool
+> gate you want in ONE call, in ONE list (or use `UseGatekeeper`, which already does that for you). MAF's
+> function-invocation middleware wraps each registration around the pipeline built so far — the SECOND (later)
+> call becomes the OUTERMOST layer, so its gates see every call FIRST. If that gate blocks without forwarding,
+> the FIRST call's gates are never even invoked for that call — silently starved, not merely "checked second."
+
 ## Block data exfiltration — a dangerous *sequence*
 
 Each tool is fine on its own — you *want* `read_customer_data`, and you *want* `send_email`. The **combination**

--- a/docs/gatekeeper/gate-reference.md
+++ b/docs/gatekeeper/gate-reference.md
@@ -40,7 +40,11 @@ result; `Terminate` → stop the loop), so adding a gate never silently changes 
 
 > **Enforcement floor.** A gate whose purpose is to *stop* an action can declare a `MinimumPolicy`; a honeypot
 > refuses to be registered `WarnOnly`, so `UseAgentEvalToolGate` throws rather than let it be downgraded to
-> observe‑only.
+> observe‑only. This means a `MinimumPolicy`-floored gate (e.g. `CanaryToolGate`) **cannot be composed under
+> `UseGatekeeper(GatekeeperEnforcement.Observe, ...)`** either — `Observe` always resolves to `WarnOnly`, so the
+> same floor check fires there too. That's deliberate, not a bug: running a honeypot under `WarnOnly` would
+> silently defeat the trap, so it's excluded from Observe's "zero behavior change" guarantee by design — add it
+> separately once you're ready to enforce at its `MinimumPolicy` or stronger.
 
 ### Budget & egress (off the `RunLedger`)
 
@@ -181,6 +185,38 @@ gates are supporting parts. Fail‑closed: at least one gate is required, and a 
 *every* gate affirms it routine — a throwing gate, or a call it can't affirm, escalates.
 
 ---
+
+## Composing gates safely — `UseGatekeeper`
+
+Wiring more than one layer by hand (`.UseAgentEvalGate()` → `.UseAgentEvalToolGate(...)` →
+`.UseAgentEvalToolApproval(...)` → `.UseAgentEvalShadowJudge(...)`) means getting the order right yourself, and
+some misconfigurations run silently instead of failing loudly. `UseGatekeeper(enforcement, configure)` installs
+all four in the correct order in one call, and refuses to construct — before any middleware is wired, never
+partially — for the two ways manual composition can silently misbehave: a `GateRequirements.RunScope` gate
+registered without a guaranteed run scope (falls back to shared, process-wide state instead of throwing), and a
+`MinimumPolicy`-floored gate registered under an enforcement level too weak to meet it (see the callout above).
+`GatekeeperEnforcement` (`Observe`/`ReplaceResult`/`Terminate`) is a required parameter — there is no default,
+on purpose. Full walkthrough: [introduction — Wiring it together](introduction.md#wiring-it-together-usegatekeeper).
+
+> **⚠ Never chain two separate `UseAgentEvalToolGate(...)` calls on one builder** — the later registration
+> becomes the outermost middleware layer and can fully starve the earlier one's gates if it blocks without
+> forwarding (empirically confirmed against the underlying MAF seam). Register every tool gate in one call, in
+> one list — `UseGatekeeper` already does this for you.
+
+## Coverage & telemetry
+
+Two capabilities answer "is this actually working," not "did I call the API":
+
+| Capability | What it does | Honest reasoning |
+|---|---|---|
+| **`GatekeeperCoverageAnalyzer`** | Classifies every tool exposed to the agent's model — `InterceptedLocalFunction` (a local `AIFunction`, the only execution model any tool gate can ever see) vs. `ProviderHostedOpaque` (executed by the model provider itself, structurally invisible to every mechanism in this namespace) — and a coarse `ToolRiskLevel` heuristic (`ToolRiskClassifier`, keyword-based, override via `AnalyzeOptions.IsHighRisk`). Reports `EnforcementCoveragePercent`; `AnalyzeOrThrow`/`GatekeeperOptions.RefuseUnprotectedHighRiskTools` refuse construction on an unprotected high-risk tool. | The "false assurance" fix: "Gatekeeper is installed" reads as "my tools are protected," which isn't automatically true. **Honest limits, not just a feature:** blind to a tool an `AIContextProvider` (Agent Skills, memory providers) contributes dynamically — only the static `ChatOptions.Tools` list is inspectable; blind to a tool's parameter schema (a generically-named dispatch tool whose `operation` parameter includes `"delete"` isn't flagged); and `AnalyzeOrThrow` itself throws `ToolInventoryUnavailableException` (not a silent pass) when the tool list can't be read at all — "I couldn't verify" fails the same direction as "I verified and it's bad." |
+| **`GateTelemetry`** | A caller-owned counter/histogram (pass it to `UseAgentEvalToolGate`/`UseGatekeeper`): per-gate invocation count, allow/block/mutate counts, and latency. Records what the gate *found* (its verdict), not whether the enforcing `ToolGatePolicy` actually blocked the call — cross-reference the trace's `gate.tool.*` `action` (`"Block"` vs `"Warn"`) for the enforced/observed split. | Pairs with the coverage analyzer: coverage answers "is this tool structurally reachable by a gate," telemetry answers "when it ran, what did the gate actually do." No I/O, no new subsystem — a thin surface bolted onto the existing per-call gate loop. |
+
+`Mutate` verdict evidence (a tool gate rewriting arguments before the call proceeds) is captured into the trace
+per `TraceCaptureMode` — `None`/`SchemaOnly`/`Redacted`/`Hashed`/`Full`. **`Redacted` is the default** (argument
+names visible, values replaced with a fixed marker) — a prior version always recorded arguments verbatim, which
+could put a secret an argument carries into the trace. Pass `TraceCaptureMode.Full` explicitly only when you
+know your arguments never carry secrets and want the exact before/after values for debugging.
 
 ## Extending the Gatekeeper: LLM-backed detection
 

--- a/docs/gatekeeper/introduction.md
+++ b/docs/gatekeeper/introduction.md
@@ -7,9 +7,10 @@ checks **in the request path** so a forbidden tool call, a poisoned argument, or
 **blocked before it happens**. It plugs into the Microsoft Agent Framework agent pipeline — no rewrite — and
 every gate is **fail‑closed**: if a gate cannot prove an action safe, it does not run it.
 
-> **Where to go:** this page is the **introduction** (concepts + the layer categories). The
-> [**Gate reference**](gate-reference.md) is the ranked catalogue — every gate, what it does, and *how much it
-> actually earns its keep*. The [**Examples**](examples.md) page is the runnable cookbook.
+> **Where to go:** this page is the **introduction** (concepts, the layer categories, and how to wire them
+> together with `UseGatekeeper`). The [**Gate reference**](gate-reference.md) is the ranked catalogue — every
+> gate, what it does, and *how much it actually earns its keep*. The [**Examples**](examples.md) page is the
+> runnable cookbook.
 
 ## The design principle: fail closed, and prove it
 
@@ -41,6 +42,78 @@ network / LLM work at construction (via `GateCost`) — an LLM judge on every to
 risk a fabricated verdict. Expensive judgment goes to the **shadow judge**, or — for a *fast, calibrated* judge —
 the run‑pre/run‑post seam (see The Tribunal, below); run and session gates reuse `IChatGate` (no cost member), so
 keeping those pure‑code is a convention.
+
+## Wiring it together: `UseGatekeeper`
+
+Every example on the [examples page](examples.md) that wires more than one layer chains the low‑level builder
+calls by hand: `.UseAgentEvalGate()` → `.UseAgentEvalToolGate(...)` → `.UseAgentEvalToolApproval(...)` →
+`.UseAgentEvalShadowJudge(...)`. That works, but the order matters (run‑scope must be established before the
+tool gate that depends on it) and it's easy to get wrong silently — a stateful gate that needs a run scope
+still *runs* without one, it just falls back to shared, process‑wide state instead of throwing.
+
+**`UseGatekeeper(enforcement, configure)`** is the recommended composite builder for anything beyond a single
+gate: it installs run‑scope, tool gates, approval interop, and the shadow judge together, in the correct order,
+in one call — and it **validates what manual composition can't catch**, at construction time:
+
+```csharp
+using AgentEval.MAF.Gatekeeper;
+
+var agent = baseAgent.AsBuilder()
+    .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+    {
+        g.Add(new SequenceGate(["read_customer_data"], ["send_email", "http_post"]));
+        g.Add(new RunBudgetGate(maxToolCalls: 20));
+        g.Trace = trace;               // shared Glass Box trace across every mechanism composed here
+        g.Telemetry = telemetry;       // optional GateTelemetry sink — which gates fire, how often, how long
+    })
+    .Build();
+```
+
+`GatekeeperEnforcement` is a **required** parameter — `Observe` (record every finding, block nothing — the
+recommended safe first rollout), `ReplaceResult` (block the call, keep the loop running), or `Terminate` (block
+and stop the function‑calling loop). There is deliberately no default: the whole point of a name like
+"Gatekeeper" is that developers assume it enforces, so a silent `WarnOnly` default would be the exact false
+assurance this toolkit argues against elsewhere. Two named sugar methods make the choice visible in the call
+site itself: `ObserveWithAgentEvalGates(configure)` and `EnforceAgentEvalGates(configure, level: ...)` (defaults
+to `Terminate`, the strongest level — "enforce" unqualified should mean "actually protect me").
+
+`UseGatekeeper` refuses to construct — throwing before any middleware is wired, never partially — when it can
+prove the composition is unsafe:
+
+- A gate that needs an established run scope (`GateRequirements.RunScope` — `RunBudgetGate`, `MonetaryLimitGate`,
+  `PerToolCallBudgetGate`, `SequenceGate`) is registered without one (`EstablishRunScope = false` and no pre/post
+  gate) under a non‑`Observe` enforcement level.
+- A gate with an enforcement floor above the resolved policy — a canary/honeypot's `MinimumPolicy` — is
+  registered under `Observe` (which always resolves to `WarnOnly`). Running a honeypot under `WarnOnly` would
+  silently defeat the trap, so `UseGatekeeper` refuses rather than downgrade it; exclude such gates from an
+  `Observe`‑mode rollout and add them separately once you're ready to enforce.
+
+**Know what's actually protected — `GatekeeperCoverageAnalyzer`.** "I called `UseGatekeeper`" is not the same
+question as "is every high‑risk tool actually reachable by a gate." The analyzer answers that honestly: it
+classifies every tool exposed to the agent's model (a local `AIFunction` a tool gate can see vs. a
+provider‑hosted tool no Gatekeeper mechanism ever will) and reports an `EnforcementCoveragePercent`.
+
+```csharp
+var options = new GatekeeperOptions();
+var agent = baseAgent.AsBuilder()
+    .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+    {
+        g.Add(new ForbiddenToolGate("delete_account"));
+        g.KnownTools = myTools;                    // the SAME list you set on ChatOptions.Tools
+        g.RefuseUnprotectedHighRiskTools = true;    // eager, construction-time refusal
+        options = g;
+    })
+    .Build();
+
+Console.WriteLine(options.CoverageReport!.Render());   // the AUTHORITATIVE report — same gates that were actually wired
+```
+
+`RefuseUnprotectedHighRiskTools` throws `UnprotectedHighRiskToolException` right at registration if a tool a
+coarse keyword heuristic (`ToolRiskClassifier` — override via `AnalyzeOptions.IsHighRisk` when it misclassifies
+yours) flags as high‑risk has zero protecting gate — before the agent ever starts. It's a heuristic safety net,
+not a proof: it's blind to a tool an `AIContextProvider` (e.g. Agent Skills) contributes dynamically, since only
+`ChatOptions.Tools` is inspectable at this point — see the gate reference's [Coverage &
+telemetry](gate-reference.md#coverage--telemetry) section for the full honest limits.
 
 ## The Beachhead and The Tribunal
 


### PR DESCRIPTION
## Summary
- Follow-up to #96: the public `docs/gatekeeper/*.md` pages never mentioned `UseGatekeeper`, `GatekeeperCoverageAnalyzer`, `GatekeeperEnforcement`, or `GateTelemetry` at all, despite the code's own XML docs calling `UseGatekeeper` "the recommended way for new code." Found via a dedicated staleness check before writing anything (9 other candidate staleness points were checked and found already accurate — not touched).
- `introduction.md` — new "Wiring it together: `UseGatekeeper`" section: the manual-chaining ordering pitfall it solves, the required `GatekeeperEnforcement` axis (no default, by design) with the `ObserveWithAgentEvalGates`/`EnforceAgentEvalGates` sugar, the two construction-time refusal cases, and the coverage analyzer with its honest limits.
- `examples.md` — new runnable `UseGatekeeper` example, plus a prominent warning against chaining two separate `UseAgentEvalToolGate` calls (the empirically-confirmed gate-ordering-inversion hazard from #96's review).
- `gate-reference.md` — the `MinimumPolicy` enforcement-floor callout now covers the `Observe`-specific case explicitly; new "Composing gates safely" and "Coverage & telemetry" sections.

Every code snippet was checked against the actual shipped API (constructor signatures, property names) before writing it.

## Test plan
- [x] Docs-only change, no code touched — nothing to build/test.
- [x] Verified every new header's anchor link resolves (checked for duplicate headers / anchor collisions).
- [x] Verified every C# snippet's API surface against the real, currently-shipped signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro