### PR TITLE
fix(missioncontrol): render promptHash in AdjudicationFlow + fix complianceEvidence doc type (A4, B5)

### DIFF
--- a/docs/missioncontrol/api-design.md
+++ b/docs/missioncontrol/api-design.md
@@ -140,7 +140,7 @@ Query.scenario(runId, scenarioId)              ScenarioResult?
 Query.scenarioTree(runId, scenarioId)          EvalResult?        ← recursive!
 Query.compliance                               [ComplianceRegulationSummary!]!
 Query.complianceMatrix(regulation)             ComplianceMatrix!  ← killer feature
-Query.complianceEvidence(reg, kind, name, ts)  ComplianceEvidence?
+Query.complianceEvidence(reg, kind, name, ts)  ComplianceEvidenceWithChain?
 Query.evaluators(category?, costTier?)         [EvaluatorCard!]!
 Query.evaluator(key)                           EvaluatorCard?
 Query.evaluatorTimeline(key, count = 30)       [EvaluatorTimelinePoint!]!  ← drift / calibration surface

--- a/src/AgentEval.MissionControl.Spa/src/components/AdjudicationFlow.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/components/AdjudicationFlow.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/eval-tree";
 import { VerdictBadge } from "@/components/VerdictBadge";
 import { ModelBadge } from "@/components/ModelBadge";
+import { PromptHashPill } from "@/components/ProvenancePills";
 import { formatScore, formatCost } from "@/lib/format";
 
 // Plan-08 Wave 8 (MC1.6.9): visualises a panel of judges + (optionally) an
@@ -99,6 +100,11 @@ export function AdjudicationFlow({ node }: Props) {
                   role="judge"
                 />
               )}
+              {/* Plan-08 portal-review A4 follow-up (2026-07-16): the
+                  adjudicator card is the highest-stakes place to show the
+                  pinned prompt hash — it's where a human is looking at
+                  panel DISAGREEMENT. Matches EvalResultNode.tsx's rendering. */}
+              <PromptHashPill promptHash={adjudicator.provenance.promptHash} />
               <span className="text-slate-500">
                 {formatCost(adjudicator.provenance.estimatedCost)}
               </span>
@@ -130,6 +136,10 @@ function JudgeCard({ judge }: { judge: EvalResultNodeShape }) {
             role="judge"
           />
         )}
+        {/* Plan-08 portal-review A4 follow-up (2026-07-16): panel judge
+            cards were the one place promptHash still didn't render
+            (EvalResultNode.tsx and ScenarioTreePage.tsx already show it). */}
+        <PromptHashPill promptHash={judge.provenance.promptHash} />
         {judge.provenance.estimatedCost > 0 && (
           <span className="text-slate-500">
             {formatCost(judge.provenance.estimatedCost)}


### PR DESCRIPTION
## Summary

Closes the two remaining real gaps in `portal-review.md`'s "trustworthy data" P0 cluster (per `strategy/FutureFeatures/MC/Compliance-Matrix-A1-Reverification-and-Next-Fix-Plan-2026-07-16.md`, a fresh re-verification against current code — A1/A5/B1/B2/B4 turned out to already be resolved back on 2026-05-24/25 despite the review doc still listing them as open; only A4 and B5 were genuinely open).

- **A4** — `AdjudicationFlow.tsx`'s `JudgeCard` and adjudicator card were the one place `provenance.promptHash` still wasn't rendered. `EvalResultNode.tsx` and `ScenarioTreePage.tsx` already showed it (shipped 2026-05-25), but the panel/adjudicated view — arguably the highest-stakes place, since it's where a human is looking at judge *disagreement* — silently dropped it. Wires the already-built `PromptHashPill` into both.
- **B5** — `docs/missioncontrol/api-design.md:143` advertised `Query.complianceEvidence -> ComplianceEvidence?`; the real resolver (`Query.cs:418`) returns `ComplianceEvidenceWithChain?`. One-line doc fix.

## Deviations from the plan doc (documented, not silently papered over)

- The plan doc guessed the import path as `@/components/PromptHashPill`. The actual export lives in `@/components/ProvenancePills` (confirmed by reading `EvalResultNode.tsx`'s real import line first, per this doc's own "verify before copying" discipline).
- Did **not** add `JudgeModePill` to the panel judge cards — only `PromptHashPill` was in scope per the plan doc and the task assignment; `JudgeModePill` for an individual panel member would almost always resolve to `single` (per `deriveJudgeMode`'s logic), so it wouldn't add real signal there.
- No Vitest/RTL component test was added — this repo's SPA has zero test infrastructure today (tracked separately as portal-review's X2, out of scope here). Verification is `tsc -b && vite build` passing clean (proves the prop wiring type-checks against `EvalProvenanceNode.promptHash: string | null`) plus the `PromptHashPill` implementation being identical, already-shipped code reused verbatim from `EvalResultNode.tsx` — not new component logic.

## Also included: staleness correction (plan doc §5's recommendation)

Updated `strategy/FutureFeatures/MC/portal-review.md`, `strategy/AgentEval-Status-and-Plan-Forward.md` (Front D + R1b), and `strategy/TODO.md` to flip A1/A4/A5/B1/B2/B4/B5 from "open P0" to their actual current (resolved) state, with fix dates and evidence pointers. These are local-only/gitignored, not part of this PR's diff, but done as instructed to stop the exact staleness bug this whole investigation was about from recurring a 4th time. (B3 and A2/X1 correctly remain flagged open — confirmed still genuinely unbuilt.)

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) — clean, no type errors
- [x] Full net8.0 test suite (no `.cs` files touched by this PR, run anyway per repo discipline): **7648 passed, 1 skipped (manual/live), 0 failed**
- [x] `dotnet build AgentEval.sln -c Release` — 0 errors (111 pre-existing warnings, unrelated to this change)
- [x] Manual diff review of both hunks against `EvalResultNode.tsx`'s established pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)