### PR TITLE
feat(skills): Agent Skills Wave 1 - baseline ledger, repo-wide discovery, provenance pointer

### DIFF
--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -83,6 +83,15 @@ markdown/json output, `--fail-on-noncompliant` for a CI gate). Credential-free a
 the scan itself — a no-op agent satisfies MAF's own `AgentSkillsSourceContext` constructor requirement only).
 See [CLI reference](cli.md#agenteval-skills-scan). v1 is compliance-only, not the full Security Index below.
 
+**Baseline ledger + repo-wide discovery (Wave 1):** `--write-baseline` captures a timestamped snapshot
+(structural fingerprint + full file-content hash per skill, reusing `ManifestFingerprint`/
+`ManifestDriftDetector` — the same primitive `McpToolDescriptionPoisoningGate` and skill manifest drift
+detection already use) into an append-only ledger (`AgentEval.Skills.ISkillBaselineStore`/
+`JsonFileSkillBaselineStore`, mirroring — not subtyping — the Memory benchmark's `JsonFileBaselineStore`
+pattern). `agenteval skills baseline list|diff|history` inspects it. `--repo` scans every known
+skill-directory convention under a repo root (`AgentEval.Skills.AgentSkillDirectoryConventions`) and
+aggregates the results. See [CLI reference](cli.md#agenteval-skills-baseline) for the full command surface.
+
 ## 3 — Skill-injection red-team attack + `run_skill_script` governance
 
 `AgentEval.RedTeam.Attacks.SkillInjectionAttack` (OWASP LLM01, in `Attack.All` — the framework now ships **14**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -418,6 +418,7 @@ suite ships, from the CLI.
 
 ```
 agenteval skills scan <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
+                              [--write-baseline] [--baseline-root <dir>] [--repo]
 ```
 
 **What it does**
@@ -425,17 +426,20 @@ agenteval skills scan <path> [--format console|markdown|json] [-o|--output <file
 Walks `<path>` for `SKILL.md`-rooted skill folders (the same convention MAF's own `AgentFileSkillsSource`
 discovers by), checks each against the GA `SKILL.md` authoring rules (name/description/compatibility) plus
 governance flags (script-execution review, untrusted resource sources, experimental `allowed-tools`), and
-renders a report. v1 is compliance-only — the composite Skill Health & Security Index and hash-pin drift
-detection are library-only for now (see [Agent Skills](agent-skills.md)).
+renders a report. v1 is compliance-only — the composite Skill Health & Security Index is library-only for now
+(see [Agent Skills](agent-skills.md)).
 
 **Options**
 
 | Option | Description |
 |--------|-------------|
-| `<path>` | Required, positional. Directory containing one or more skill folders. |
+| `<path>` | Required, positional. Directory containing one or more skill folders (a REPO ROOT when `--repo` is set). |
 | `--format <fmt>` | `console` (default), `markdown`, or `json`. |
 | `-o, --output <path>` | Write the rendered report to a file instead of stdout. |
 | `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Default off (informational-only). |
+| `--write-baseline` | Capture a timestamped baseline snapshot (structural fingerprint + full file-content hash per skill) into the baseline ledger. See [`agenteval skills baseline`](#agenteval-skills-baseline) below. |
+| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. |
+| `--repo` | Treat `<path>` as a repo root: scan every known skill-directory convention found under it (`.claude/skills`, `.agents/skills`, `.windsurf/skills`, ...) and aggregate the results into ONE combined report, instead of treating `<path>` itself as one skill directory. Per-convention breakdown (found/not-present, skill/finding counts) prints to stderr. |
 
 **Exit codes**
 
@@ -444,6 +448,45 @@ detection are library-only for now (see [Agent Skills](agent-skills.md)).
 | `0` | Scan completed (compliant, or `--fail-on-noncompliant` not set). |
 | `1` | `--fail-on-noncompliant` was set and a High-severity finding was found. |
 | `3` | Runtime error (e.g. `<path>` does not exist). |
+
+---
+
+### `agenteval skills baseline`
+
+Inspects the multi-snapshot skill baseline ledger `agenteval skills scan --write-baseline` writes to. Each
+snapshot is a full point-in-time capture (structural fingerprint + file-content hash per skill, plus that
+skill's compliance findings at the time) — never overwritten, so the ledger accumulates history across scans.
+
+**Synopsis**
+
+```
+agenteval skills baseline list  [--baseline-root <dir>]
+agenteval skills baseline diff  [--baseline-root <dir>] [--since <id>] [--skill <name>] [--hash structural|content]
+agenteval skills baseline history <skill-name> [--baseline-root <dir>]
+```
+
+**`list`** — every captured snapshot (Id, capture time, scanned root, skill count), oldest listed first.
+
+**`diff`** — compares two snapshots (default: the two most recent; pass `--since <id>` to diff a specific
+snapshot against the latest) using the same `ManifestDriftDetector` primitive `PromptTemplateDriftGate`/
+`McpToolDescriptionPoisoningGate` use, over either the structural fingerprint or the full content hash
+(`--hash`, default `content` — the stronger signal). A `Changed` skill is flagged `CHANGED + NEW HIGH FINDING`
+when the change also introduced a new High-severity compliance finding (vs. `changed, no new High finding`
+for a cosmetic-only edit) — this is the "don't cry wolf on every cosmetic edit" guard.
+
+**`history <skill-name>`** — walks the ledger chronologically and reports every point where that skill's
+content hash changed, with any High-severity findings present at each change point.
+
+**Options common to all three**
+
+| Option | Description |
+|--------|-------------|
+| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines` (must match what `scan --write-baseline` used). |
+| `--since <id>` (`diff` only) | Diff this snapshot's Id against the most recent snapshot, instead of the two most recent. |
+| `--skill <name>` (`diff` only) | Only show the diff for this skill. |
+| `--hash structural\|content` (`diff` only) | Which hash to diff. Default `content`. |
+
+**Exit codes:** `0` on success (including "nothing to diff yet" — informational, not an error); `3` on a runtime error (e.g. `--since <id>` not found in the ledger).
 
 ---
 

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -4,6 +4,8 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using System.Text;
+using AgentEval.Guardrails;
 using AgentEval.MAF.Skills;
 using AgentEval.Skills;
 using AgentEval.Testing;
@@ -12,32 +14,52 @@ using Microsoft.Agents.AI;
 namespace AgentEval.Cli.Commands;
 
 /// <summary>
-/// The 'agenteval skills scan' command — a static, offline SKILL.md + governance-flag scan for a directory
-/// of MAF Agent Skills (<see cref="MafSkillScanner"/>/<see cref="SkillComplianceValidator"/>, shipped and
-/// tested as library code since Agent Skills Phase 2; this closes the "reachable from the CLI" gap —
-/// confirmed unreachable via <c>grep -rl "skills" src/AgentEval.Cli/Commands/</c> before this command).
-/// v1 scope is deliberately compliance-only, not the full Skill Health &amp; Security Index (see
-/// <c>strategy/FutureFeatures/Skills/Skills-Scan-CLI-Verb-Design.md</c> §2.3).
+/// The 'agenteval skills scan' + 'agenteval skills baseline' commands — a static, offline SKILL.md +
+/// governance-flag scan for a directory of MAF Agent Skills (<see cref="MafSkillScanner"/>/
+/// <see cref="SkillComplianceValidator"/>), plus Agent Skills Wave 1 (§4.1/§4.3): a timestamped baseline
+/// ledger (<c>--write-baseline</c> / <c>skills baseline list|diff|history</c>) and repo-wide multi-convention
+/// discovery (<c>--repo</c>). v1 scan scope is deliberately compliance-only, not the full Skill Health &amp;
+/// Security Index (see <c>strategy/FutureFeatures/Skills/Skills-Scan-CLI-Verb-Design.md</c> §2.3).
 /// </summary>
 internal static class SkillsScanCommand
 {
+    private const string DefaultBaselineRoot = ".agenteval/skills-baselines";
+
     public static Command Create()
     {
         var skillsCmd = new Command("skills", "MAF Agent Skills utilities");
+        skillsCmd.Subcommands.Add(BuildScanCommand());
+        skillsCmd.Subcommands.Add(BuildBaselineCommand());
+        return skillsCmd;
+    }
+
+    // ═══════════════════════════════════════════ scan ═══════════════════════════════════════════
+
+    private static Command BuildScanCommand()
+    {
         var scanCmd = new Command("scan", "Scan a directory of MAF Agent Skills for GA compliance + governance findings");
 
         var pathArg = new Argument<DirectoryInfo>("path")
-            { Description = "Directory containing one or more SKILL.md-rooted skill folders" };
+            { Description = "Directory containing one or more SKILL.md-rooted skill folders (a repo root when --repo is set)" };
         var formatOpt = new Option<string>("--format")
             { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" };
         var outputOpt = new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" };
         var failOnOpt = new Option<bool>("--fail-on-noncompliant")
             { Description = "Exit non-zero (1) when the scan finds a High-severity finding (report.IsCompliant == false). Default off (informational-only)." };
+        var writeBaselineOpt = new Option<bool>("--write-baseline")
+            { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." };
+        var repoOpt = new Option<bool>("--repo")
+            { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory." };
+        var baselineRootOpt = new Option<string>("--baseline-root")
+            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline)." };
 
         scanCmd.Arguments.Add(pathArg);
         scanCmd.Options.Add(formatOpt);
         scanCmd.Options.Add(outputOpt);
         scanCmd.Options.Add(failOnOpt);
+        scanCmd.Options.Add(writeBaselineOpt);
+        scanCmd.Options.Add(repoOpt);
+        scanCmd.Options.Add(baselineRootOpt);
 
         scanCmd.SetAction(async (parseResult, ct) =>
         {
@@ -48,6 +70,9 @@ internal static class SkillsScanCommand
                     parseResult.GetValue(formatOpt)!,
                     parseResult.GetValue(outputOpt),
                     parseResult.GetValue(failOnOpt),
+                    parseResult.GetValue(writeBaselineOpt),
+                    parseResult.GetValue(repoOpt),
+                    parseResult.GetValue(baselineRootOpt)!,
                     ct);
             }
             catch (Exception ex)
@@ -57,54 +82,51 @@ internal static class SkillsScanCommand
             }
         });
 
-        skillsCmd.Subcommands.Add(scanCmd);
-        return skillsCmd;
+        return scanCmd;
     }
 
     /// <summary>
     /// Core execution logic — separated from command wiring for testability. The scan itself never invokes
-    /// a model — confirmed empirically this session (not just by re-reading <see cref="MafSkillScanner"/>'s
-    /// doc comments): <see cref="MafSkillScanner.ScanFileSkillsAsync"/> only reads
-    /// <see cref="AgentSkillsSourceContext"/>'s <c>Agent</c> reference to satisfy MAF's own constructor
-    /// requirement and never calls it, exactly like the existing <c>MafSkillScannerTests.FakeAgent()</c>
-    /// precedent, which is reused (not reinvented) below via <see cref="ScriptedChatClient"/> — so no
-    /// credentials are ever required for this verb.
+    /// a model — confirmed empirically: <see cref="MafSkillScanner.ScanFileSkillsWithInfoAsync"/> only
+    /// reads <see cref="AgentSkillsSourceContext"/>'s <c>Agent</c> reference to satisfy MAF's own
+    /// constructor requirement and never calls it, exactly like the existing
+    /// <c>MafSkillScannerTests.FakeAgent()</c> precedent, reused (not reinvented) below via
+    /// <see cref="ScriptedChatClient"/> — so no credentials are ever required for this verb.
     /// </summary>
-    /// <remarks>
-    /// <b>Historical honesty finding, now CLOSED (Item 5):</b> MAF's own <c>AgentFileSkillsSource</c>
-    /// frontmatter parsing silently excludes a directory from discovery whenever its <c>SKILL.md</c> fails
-    /// certain GA rules (invalid name characters, consecutive hyphens, a name/directory mismatch, or a
-    /// missing/too-long description — confirmed empirically; the description trigger widens the original
-    /// name-only hypothesis) — confirmed by scanning several separately hand-crafted malformed fixtures,
-    /// each previously returning "Skills scanned: 0" with zero mention of the excluded folder.
-    /// <see cref="MafSkillScanner.ScanFileSkillsAsync"/> now runs a second, independent raw directory walk
-    /// (<see cref="RawSkillDirectoryScanner"/>) reconciled against MAF's actual returned set, so a silently-
-    /// excluded folder produces a <see cref="SkillComplianceRule.SkillExcludedFromDiscovery"/> High finding
-    /// instead of vanishing — see
-    /// <c>strategy/FutureFeatures/Skills/Skill-Discovery-Exclusion-Detection-Design.md</c> and
-    /// <c>MafSkillScannerTests</c>'s "Item 5" test group for real, on-disk, end-to-end coverage (no longer
-    /// only a hand-built-report test, per <see cref="ComputeExitCode"/> below).
-    /// </remarks>
     internal static async Task<int> ExecuteAsync(
-        DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant, CancellationToken ct)
+        DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
+        bool writeBaseline = false, bool repo = false, string baselineRoot = DefaultBaselineRoot, CancellationToken ct = default)
     {
         if (!path.Exists)
+        {
             throw new DirectoryNotFoundException($"Skills directory not found: {path.FullName}");
+        }
 
         AIAgent noOpAgent = new ChatClientAgent(new ScriptedChatClient(), new ChatClientAgentOptions { Name = "SkillsScanCommand" });
-        var report = await MafSkillScanner.ScanFileSkillsAsync(path.FullName, noOpAgent, options: null, ct);
 
-        var rendered = (format ?? "console").Trim().ToLowerInvariant() switch
+        SkillComplianceReport report;
+        SkillBaselineSnapshot? snapshot;
+
+        if (repo)
         {
-            "json" => SkillComplianceReportRenderer.RenderJson(report),
-            "markdown" or "md" => SkillComplianceReportRenderer.RenderMarkdown(report),
-            "console" or "" => SkillComplianceReportRenderer.RenderConsole(report),
-            _ => throw new ArgumentException($"Unknown --format '{format}'. Valid: console, markdown, json."),
-        };
+            var (combinedReport, combinedSnapshot, conventionSummary) =
+                await ScanRepoWideAsync(path.FullName, noOpAgent, writeBaseline, ct).ConfigureAwait(false);
+            report = combinedReport;
+            snapshot = combinedSnapshot;
+            Console.Error.WriteLine(conventionSummary);
+        }
+        else
+        {
+            var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(path.FullName, noOpAgent, options: null, ct).ConfigureAwait(false);
+            report = result.Report;
+            snapshot = writeBaseline ? BuildSnapshot(path.FullName, result.Skills, report.Findings) : null;
+        }
+
+        var rendered = RenderReport(report, format);
 
         if (output is not null)
         {
-            await File.WriteAllTextAsync(output.FullName, rendered, ct);
+            await File.WriteAllTextAsync(output.FullName, rendered, ct).ConfigureAwait(false);
             Console.Error.WriteLine($"  Report written to: {output.FullName}");
         }
         else
@@ -112,8 +134,24 @@ internal static class SkillsScanCommand
             Console.WriteLine(rendered);
         }
 
+        if (snapshot is not null)
+        {
+            var store = new JsonFileSkillBaselineStore(baselineRoot);
+            var id = await store.SaveAsync(snapshot, ct).ConfigureAwait(false);
+            Console.Error.WriteLine($"  Baseline snapshot saved: {id} ({snapshot.Skills.Count} skill(s) -> {baselineRoot})");
+        }
+
         return ComputeExitCode(report, failOnNoncompliant);
     }
+
+    private static string RenderReport(SkillComplianceReport report, string format) =>
+        (format ?? "console").Trim().ToLowerInvariant() switch
+        {
+            "json" => SkillComplianceReportRenderer.RenderJson(report),
+            "markdown" or "md" => SkillComplianceReportRenderer.RenderMarkdown(report),
+            "console" or "" => SkillComplianceReportRenderer.RenderConsole(report),
+            _ => throw new ArgumentException($"Unknown --format '{format}'. Valid: console, markdown, json."),
+        };
 
     /// <summary>
     /// Pure exit-code gate, separated for direct testing (see the honesty finding on
@@ -121,4 +159,350 @@ internal static class SkillsScanCommand
     /// </summary>
     internal static int ComputeExitCode(SkillComplianceReport report, bool failOnNoncompliant)
         => (failOnNoncompliant && !report.IsCompliant) ? ExitCodes.TestFailure : ExitCodes.Success;
+
+    // ═══════════════════════════════ --repo multi-convention discovery (§4.3) ═══════════════════════════════
+
+    /// <summary>
+    /// Loops <see cref="AgentSkillDirectoryConventions.KnownConventions"/>, running the EXISTING
+    /// <see cref="MafSkillScanner.ScanFileSkillsWithInfoAsync"/> pipeline per hit — a discovery-layer loop
+    /// calling the existing pipeline N times, no changes to <see cref="SkillComplianceValidator"/>/
+    /// <see cref="MafSkillScanner"/>/<see cref="RawSkillDirectoryScanner"/>. Findings/coverage are merged
+    /// into ONE combined <see cref="SkillComplianceReport"/> (so every <c>--format</c> renders it exactly
+    /// like a single-root scan); the per-convention breakdown (which conventions existed, which didn't) is
+    /// returned separately and printed to stderr — keeping stdout's shape (console/markdown/JSON) identical
+    /// across <c>--repo</c> and non-<c>--repo</c> scans, rather than inventing a second JSON schema.
+    /// </summary>
+    private static async Task<(SkillComplianceReport Report, SkillBaselineSnapshot? Snapshot, string ConventionSummary)> ScanRepoWideAsync(
+        string repoRoot, AIAgent agent, bool writeBaseline, CancellationToken ct)
+    {
+        var allFindings = new List<SkillComplianceFinding>();
+        int skillCount = 0, withResources = 0, withScripts = 0, silentlyExcluded = 0;
+        var histogram = new Dictionary<string, int>(StringComparer.Ordinal);
+        var entries = new List<SkillBaselineEntry>();
+        var summary = new StringBuilder();
+        summary.AppendLine("  Repo-wide skill directory conventions:");
+
+        foreach (var convention in AgentSkillDirectoryConventions.KnownConventions)
+        {
+            var conventionPath = Path.Combine(repoRoot, convention);
+            if (!Directory.Exists(conventionPath))
+            {
+                summary.AppendLine($"    {convention}: not present");
+                continue;
+            }
+
+            var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(conventionPath, agent, options: null, ct).ConfigureAwait(false);
+            summary.AppendLine($"    {convention}: {result.Skills.Count} skill(s), {result.Report.Findings.Count} finding(s)");
+
+            allFindings.AddRange(result.Report.Findings);
+            skillCount += result.Report.Coverage.SkillCount;
+            withResources += result.Report.Coverage.WithResources;
+            withScripts += result.Report.Coverage.WithScripts;
+            silentlyExcluded += result.Report.Coverage.SilentlyExcludedCount;
+            foreach (var (stage, count) in result.Report.Coverage.StageHistogram)
+            {
+                histogram[stage] = histogram.GetValueOrDefault(stage) + count;
+            }
+
+            if (writeBaseline)
+            {
+                foreach (var info in result.Skills)
+                {
+                    entries.Add(ToBaselineEntry(info, result.Report.Findings, convention));
+                }
+            }
+        }
+
+        var combinedReport = new SkillComplianceReport(
+            allFindings, new SkillCoverageSummary(skillCount, withResources, withScripts, histogram, silentlyExcluded));
+        var snapshot = writeBaseline
+            ? new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, repoRoot, entries)
+            : null;
+
+        return (combinedReport, snapshot, summary.ToString().TrimEnd());
+    }
+
+    // ═══════════════════════════════ baseline entry building (§4.1) ═══════════════════════════════
+
+    private static SkillBaselineSnapshot BuildSnapshot(
+        string scannedRoot, IReadOnlyList<ScannedSkillInfo> skills, IReadOnlyList<SkillComplianceFinding> findings)
+    {
+        var entries = skills.Select(info => ToBaselineEntry(info, findings, conventionPrefix: null)).ToList();
+        return new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, scannedRoot, entries);
+    }
+
+    private static SkillBaselineEntry ToBaselineEntry(
+        ScannedSkillInfo info, IReadOnlyList<SkillComplianceFinding> allFindings, string? conventionPrefix)
+    {
+        var manifest = info.Manifest;
+        var structuralFingerprint = SkillManifestPoisoningGate.Fingerprint(manifest);
+        string? contentHash = null;
+        if (!string.IsNullOrWhiteSpace(info.AbsolutePath) && Directory.Exists(info.AbsolutePath))
+        {
+            contentHash = SkillContentHasher.HashSkillFolder(info.AbsolutePath);
+        }
+
+        var dirName = manifest.ParentDirectoryName ?? manifest.Name;
+        var relativePath = string.IsNullOrEmpty(conventionPrefix) ? dirName : $"{conventionPrefix}/{dirName}";
+        var skillFindings = allFindings
+            .Where(f => string.Equals(f.SkillName, manifest.Name, StringComparison.Ordinal))
+            .ToList();
+
+        return new SkillBaselineEntry(
+            manifest.Name, manifest.SourceKind, relativePath, structuralFingerprint, contentHash,
+            Source: null, SourceUrl: null, Ref: null, skillFindings);
+    }
+
+    // ═══════════════════════════════ skills baseline list|diff|history (§4.1) ═══════════════════════════════
+
+    private static Command BuildBaselineCommand()
+    {
+        var baselineCmd = new Command("baseline", "Inspect the skill-scan baseline ledger (see 'skills scan --write-baseline')");
+
+        var listCmd = new Command("list", "List every captured baseline snapshot");
+        var listRootOpt = new Option<string>("--baseline-root") { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory." };
+        listCmd.Options.Add(listRootOpt);
+        listCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await ListAsync(parseResult.GetValue(listRootOpt)!, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
+        var diffCmd = new Command("diff", "Diff two baseline snapshots (default: the two most recent)");
+        var diffRootOpt = new Option<string>("--baseline-root") { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory." };
+        var sinceOpt = new Option<string?>("--since") { Description = "Baseline snapshot Id to diff against the most recent snapshot (default: the two most recent snapshots)." };
+        var skillOpt = new Option<string?>("--skill") { Description = "Only show the diff for this skill name." };
+        var hashOpt = new Option<string>("--hash") { DefaultValueFactory = _ => "content", Description = "Which hash to diff: structural | content (default: content, the stronger signal)." };
+        diffCmd.Options.Add(diffRootOpt);
+        diffCmd.Options.Add(sinceOpt);
+        diffCmd.Options.Add(skillOpt);
+        diffCmd.Options.Add(hashOpt);
+        diffCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await DiffAsync(
+                    parseResult.GetValue(diffRootOpt)!,
+                    parseResult.GetValue(sinceOpt),
+                    parseResult.GetValue(skillOpt),
+                    parseResult.GetValue(hashOpt)!,
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
+        var historyCmd = new Command("history", "Show when a skill's content last changed across the baseline ledger");
+        var skillNameArg = new Argument<string>("skill-name") { Description = "The skill to show content-hash history for." };
+        var historyRootOpt = new Option<string>("--baseline-root") { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory." };
+        historyCmd.Arguments.Add(skillNameArg);
+        historyCmd.Options.Add(historyRootOpt);
+        historyCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await HistoryAsync(parseResult.GetValue(historyRootOpt)!, parseResult.GetValue(skillNameArg)!, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
+        baselineCmd.Subcommands.Add(listCmd);
+        baselineCmd.Subcommands.Add(diffCmd);
+        baselineCmd.Subcommands.Add(historyCmd);
+        return baselineCmd;
+    }
+
+    internal static async Task<int> ListAsync(string baselineRoot, CancellationToken ct)
+    {
+        var store = new JsonFileSkillBaselineStore(baselineRoot);
+        var snapshots = await store.ListAsync(ct).ConfigureAwait(false);
+        if (snapshots.Count == 0)
+        {
+            Console.WriteLine("No baseline snapshots captured yet. Run 'agenteval skills scan <path> --write-baseline' first.");
+            return ExitCodes.Success;
+        }
+
+        Console.WriteLine($"{"Id",-33} {"CapturedAt (UTC)",-20} {"ScannedRoot",-38} {"Skills",6}");
+        foreach (var s in snapshots)
+        {
+            Console.WriteLine($"{s.Id,-33} {s.CapturedAt:yyyy-MM-dd HH:mm:ss} {Truncate(s.ScannedRoot, 38),-38} {s.Skills.Count,6}");
+        }
+
+        return ExitCodes.Success;
+    }
+
+    internal static async Task<int> DiffAsync(string baselineRoot, string? sinceId, string? skillFilter, string hashKind, CancellationToken ct)
+    {
+        if (!string.Equals(hashKind, "structural", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(hashKind, "content", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Unknown --hash '{hashKind}'. Valid: structural, content.");
+        }
+
+        var store = new JsonFileSkillBaselineStore(baselineRoot);
+        var snapshots = await store.ListAsync(ct).ConfigureAwait(false);
+
+        SkillBaselineSnapshot baseline;
+        SkillBaselineSnapshot current;
+        if (sinceId is not null)
+        {
+            // Note: no separate "snapshots.Count == 0" check needed here — FirstOrDefault over an empty
+            // list already returns null, which the check above already handles.
+            var found = snapshots.FirstOrDefault(s => string.Equals(s.Id, sinceId, StringComparison.Ordinal));
+            if (found is null)
+            {
+                Console.Error.WriteLine($"  Error: no snapshot with Id '{sinceId}' found in {baselineRoot}.");
+                return ExitCodes.RuntimeError;
+            }
+
+            baseline = found;
+            current = snapshots[^1];
+            if (string.Equals(baseline.Id, current.Id, StringComparison.Ordinal))
+            {
+                Console.WriteLine("The --since snapshot IS the most recent snapshot — nothing to diff.");
+                return ExitCodes.Success;
+            }
+        }
+        else
+        {
+            if (snapshots.Count < 2)
+            {
+                Console.WriteLine($"Need at least 2 baseline snapshots to diff (found {snapshots.Count}). Run 'agenteval skills scan <path> --write-baseline' again after a change, or pass --since <id>.");
+                return ExitCodes.Success;
+            }
+
+            baseline = snapshots[^2];
+            current = snapshots[^1];
+        }
+
+        var useContent = string.Equals(hashKind, "content", StringComparison.OrdinalIgnoreCase);
+        var baselineHashes = HashesByName(baseline, useContent);
+        var currentHashes = HashesByName(current, useContent);
+        var findings = ManifestDriftDetector.Detect(baselineHashes, currentHashes);
+
+        if (skillFilter is not null)
+        {
+            findings = findings.Where(f => string.Equals(f.Key, skillFilter, StringComparison.Ordinal)).ToList();
+            if (findings.Count == 0)
+            {
+                Console.WriteLine($"'{skillFilter}' is not present (with a {hashKind} hash) in either snapshot ({baseline.Id} / {current.Id}).");
+                return ExitCodes.Success;
+            }
+        }
+
+        Console.WriteLine($"Diffing {baseline.Id} ({baseline.CapturedAt:yyyy-MM-dd HH:mm:ss} UTC) -> {current.Id} ({current.CapturedAt:yyyy-MM-dd HH:mm:ss} UTC), hash={hashKind}");
+        Console.WriteLine();
+
+        var baselineBySkill = baseline.Skills.ToDictionary(e => e.Name, StringComparer.Ordinal);
+        var currentBySkill = current.Skills.ToDictionary(e => e.Name, StringComparer.Ordinal);
+
+        foreach (var f in findings.OrderBy(f => f.Key, StringComparer.Ordinal))
+        {
+            switch (f.Kind)
+            {
+                case ManifestDriftKind.Unchanged:
+                    Console.WriteLine($"     [unchanged] {f.Key}");
+                    break;
+                case ManifestDriftKind.New:
+                    Console.WriteLine($"     [new]       {f.Key}");
+                    break;
+                case ManifestDriftKind.Removed:
+                    Console.WriteLine($"     [removed]   {f.Key}");
+                    break;
+                case ManifestDriftKind.Changed:
+                    // "Cry wolf on every cosmetic edit" guard (§1.2): distinguish a content change that also
+                    // introduced a NEW High compliance finding from one that didn't — the former is the
+                    // actually-alarming case.
+                    var beforeHigh = baselineBySkill.TryGetValue(f.Key, out var beforeEntry)
+                        ? beforeEntry.ComplianceFindings.Count(cf => cf.Severity == Severity.High) : 0;
+                    var afterHigh = currentBySkill.TryGetValue(f.Key, out var afterEntry)
+                        ? afterEntry.ComplianceFindings.Count(cf => cf.Severity == Severity.High) : 0;
+                    if (afterHigh > beforeHigh)
+                    {
+                        Console.WriteLine($"  !! [CHANGED + NEW HIGH FINDING] {f.Key} ({beforeHigh} -> {afterHigh} High finding(s))");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"     [changed, no new High finding] {f.Key}");
+                    }
+
+                    break;
+            }
+        }
+
+        return ExitCodes.Success;
+    }
+
+    internal static async Task<int> HistoryAsync(string baselineRoot, string skillName, CancellationToken ct)
+    {
+        var store = new JsonFileSkillBaselineStore(baselineRoot);
+        var snapshots = await store.ListAsync(ct).ConfigureAwait(false);   // oldest -> newest
+        if (snapshots.Count == 0)
+        {
+            Console.WriteLine("No baseline snapshots captured yet.");
+            return ExitCodes.Success;
+        }
+
+        Console.WriteLine($"Content-hash history for '{skillName}':");
+
+        string? previousHash = null;
+        var changePoints = 0;
+        var everSeen = false;
+        foreach (var snapshot in snapshots)
+        {
+            var entry = snapshot.Skills.FirstOrDefault(s => string.Equals(s.Name, skillName, StringComparison.Ordinal));
+            if (entry is null)
+            {
+                continue;   // skill absent from this particular snapshot — not itself a tracked "change"
+            }
+
+            everSeen = true;
+            if (previousHash is not null && !string.Equals(previousHash, entry.ContentHash, StringComparison.Ordinal))
+            {
+                changePoints++;
+                var newHighFindings = entry.ComplianceFindings.Count(f => f.Severity == Severity.High);
+                var suffix = newHighFindings > 0 ? $" — {newHighFindings} High finding(s) present at this point" : string.Empty;
+                Console.WriteLine($"  {snapshot.CapturedAt:yyyy-MM-dd HH:mm:ss} UTC — content changed (snapshot {snapshot.Id}){suffix}");
+            }
+
+            previousHash = entry.ContentHash;
+        }
+
+        if (!everSeen)
+        {
+            Console.WriteLine($"  '{skillName}' does not appear in any captured snapshot.");
+        }
+        else if (changePoints == 0)
+        {
+            Console.WriteLine($"  No content changes detected across {snapshots.Count} snapshot(s) that include it.");
+        }
+
+        return ExitCodes.Success;
+    }
+
+    // Non-file-sourced skills (InMemory/Class/Mcp/Custom) have no folder to content-hash — ContentHash is
+    // null for them (see SkillBaselineEntry's remarks). With --hash content (the default), such a skill is
+    // silently OMITTED from the diff entirely rather than reported as New/Removed/Changed/Unchanged with a
+    // fabricated hash — pass --hash structural to diff those skills too (their StructuralFingerprint always exists).
+    private static Dictionary<string, string> HashesByName(SkillBaselineSnapshot snapshot, bool useContent) =>
+        snapshot.Skills
+            .Where(e => !useContent || e.ContentHash is not null)
+            .ToDictionary(e => e.Name, e => useContent ? e.ContentHash! : e.StructuralFingerprint, StringComparer.Ordinal);
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..(maxLength - 1)] + "…";
 }

--- a/src/AgentEval.Core/Skills/AgentSkillDirectoryConventions.cs
+++ b/src/AgentEval.Core/Skills/AgentSkillDirectoryConventions.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Skills;
+
+/// <summary>
+/// Agent Skills Wave 1 (§4.3) — a representative seed of known repo-relative skill-directory conventions
+/// used across the agent-tooling ecosystem. AgentEval-OWNED — an independent copy, not a dependency on any
+/// third-party registry (e.g. Skillz) — extend this list independently of any upstream source; this is
+/// deliberately NOT a claim of "supporting" every agent tool that has ever existed, just the well-known,
+/// commonly-seen ones worth checking for by default.
+/// </summary>
+public static class AgentSkillDirectoryConventions
+{
+    /// <summary>
+    /// Repo-relative directory conventions checked by <c>agenteval skills scan --repo</c>. Includes
+    /// <c>.agents/skills</c> — the agentskills.io-recommended universal path — alongside several
+    /// popular per-tool conventions and a bare, non-dot-prefixed <c>skills</c> fallback.
+    /// </summary>
+    public static IReadOnlyList<string> KnownConventions { get; } =
+    [
+        ".claude/skills",
+        ".agents/skills",
+        ".windsurf/skills",
+        ".roo/skills",
+        ".continue/skills",
+        ".augment/skills",
+        ".cursor/skills",
+        ".codeium/skills",
+        "skills",
+    ];
+}

--- a/src/AgentEval.Core/Skills/ISkillBaselineStore.cs
+++ b/src/AgentEval.Core/Skills/ISkillBaselineStore.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Skills;
+
+/// <summary>
+/// Agent Skills Wave 1 (§4.1) — persistence for the multi-snapshot baseline ledger. A SIBLING of
+/// <c>AgentEval.Memory.Reporting.JsonFileBaselineStore</c>, not a subtype — that one is hard-typed to
+/// <c>MemoryBaseline</c> and does Memory-specific side effects (manifest.json rebuild, report.html/
+/// archetypes.json embedded-resource copying) that don't apply here. This interface copies the PROVEN
+/// PATTERN (one file per snapshot, never overwritten, <see cref="ListAsync"/> orders oldest→newest), not
+/// the type.
+/// </summary>
+public interface ISkillBaselineStore
+{
+    /// <summary>Saves a new snapshot. Never overwrites a prior one — returns <see cref="SkillBaselineSnapshot.Id"/>.</summary>
+    Task<string> SaveAsync(SkillBaselineSnapshot snapshot, CancellationToken ct = default);
+
+    /// <summary>Loads a snapshot by its <see cref="SkillBaselineSnapshot.Id"/>, or <see langword="null"/> if not found.</summary>
+    Task<SkillBaselineSnapshot?> LoadAsync(string id, CancellationToken ct = default);
+
+    /// <summary>Every snapshot ever saved, ordered oldest → newest by <see cref="SkillBaselineSnapshot.CapturedAt"/>.</summary>
+    Task<IReadOnlyList<SkillBaselineSnapshot>> ListAsync(CancellationToken ct = default);
+}

--- a/src/AgentEval.Core/Skills/JsonFileSkillBaselineStore.cs
+++ b/src/AgentEval.Core/Skills/JsonFileSkillBaselineStore.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AgentEval.Skills;
+
+/// <summary>
+/// File-system-backed <see cref="ISkillBaselineStore"/> — one JSON file per snapshot, NEVER overwritten,
+/// under <c>{rootPath}/skills-baseline-{CapturedAt:yyyyMMddHHmmssfff}-{Id}.json</c>. Both the timestamp AND
+/// the <see cref="SkillBaselineSnapshot.Id"/> are in the filename — timestamp alone (even to millisecond
+/// precision) is not a safe uniqueness guarantee on a fast CI runner or in a tight test loop, which is the
+/// exact reason <see cref="SkillBaselineSnapshot.Id"/> is a ULID/GUID and not itself timestamp-derived (see
+/// its own remarks); the filename honors that same reasoning rather than silently reintroducing the
+/// collision risk the Id field exists to avoid. <see cref="ListAsync"/> orders by
+/// <see cref="SkillBaselineSnapshot.CapturedAt"/> (not filename) so the sort is correct even if a caller
+/// ever renames files.
+/// </summary>
+public sealed class JsonFileSkillBaselineStore : ISkillBaselineStore
+{
+    private const string FilePrefix = "skills-baseline-";
+
+    private readonly string _rootPath;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    /// <summary>Creates a store rooted at <paramref name="rootPath"/> (default <c>.agenteval/skills-baselines</c>).</summary>
+    public JsonFileSkillBaselineStore(string rootPath = ".agenteval/skills-baselines")
+    {
+        ArgumentNullException.ThrowIfNull(rootPath);
+        _rootPath = rootPath;
+    }
+
+    /// <inheritdoc/>
+    public async Task<string> SaveAsync(SkillBaselineSnapshot snapshot, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        Directory.CreateDirectory(_rootPath);
+        var fileName = $"{FilePrefix}{snapshot.CapturedAt:yyyyMMddHHmmssfff}-{snapshot.Id}.json";
+        var path = Path.Combine(_rootPath, fileName);
+        var json = JsonSerializer.Serialize(snapshot, JsonOptions);
+        await File.WriteAllTextAsync(path, json, ct).ConfigureAwait(false);
+        return snapshot.Id;
+    }
+
+    /// <inheritdoc/>
+    public async Task<SkillBaselineSnapshot?> LoadAsync(string id, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        if (!Directory.Exists(_rootPath))
+        {
+            return null;
+        }
+
+        foreach (var file in Directory.GetFiles(_rootPath, $"{FilePrefix}*.json"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = await TryReadAsync(file, ct).ConfigureAwait(false);
+            if (snapshot?.Id == id)
+            {
+                return snapshot;
+            }
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<SkillBaselineSnapshot>> ListAsync(CancellationToken ct = default)
+    {
+        var results = new List<SkillBaselineSnapshot>();
+        if (!Directory.Exists(_rootPath))
+        {
+            return results;
+        }
+
+        foreach (var file in Directory.GetFiles(_rootPath, $"{FilePrefix}*.json"))
+        {
+            ct.ThrowIfCancellationRequested();
+            var snapshot = await TryReadAsync(file, ct).ConfigureAwait(false);
+            if (snapshot is not null)
+            {
+                results.Add(snapshot);
+            }
+        }
+
+        return results.OrderBy(s => s.CapturedAt).ToList();
+    }
+
+    private static async Task<SkillBaselineSnapshot?> TryReadAsync(string path, CancellationToken ct)
+    {
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
+            return JsonSerializer.Deserialize<SkillBaselineSnapshot>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            // Tolerate a corrupt file rather than fail the whole load — same discipline as
+            // JsonFileBaselineStore.TryDeserializeBaseline / JsonFileCalibrationReportStore.TryReadAsync.
+            return null;
+        }
+    }
+}

--- a/src/AgentEval.Core/Skills/SkillBaselineEntry.cs
+++ b/src/AgentEval.Core/Skills/SkillBaselineEntry.cs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Skills;
+
+/// <summary>
+/// Agent Skills Wave 1 (§4.1) — one skill's snapshot within a <see cref="SkillBaselineSnapshot"/>. Carries
+/// TWO independent hashes on purpose (see each field's remarks) — they catch different kinds of drift and
+/// neither subsumes the other. Distinct from <see cref="SkillManifestBaseline"/> (that type is a
+/// single-pin, Gatekeeper/runtime-adjacent CI-gate baseline — "commit this file, compare a later run
+/// against it"); this type is one ENTRY in a historical, multi-snapshot, scan-verb-adjacent LEDGER. Do not
+/// conflate the two — see <see cref="SkillBaselineSnapshot"/> remarks.
+/// </summary>
+/// <param name="Name">Skill name (matches <see cref="SkillManifest.Name"/>).</param>
+/// <param name="SourceKind"><see cref="SkillManifest.SourceKind"/> at scan time.</param>
+/// <param name="RelativePath">Path within the scanned root (file-sourced skills only; empty for non-file sources).</param>
+/// <param name="StructuralFingerprint">
+/// <see cref="SkillManifestPoisoningGate.Fingerprint(SkillManifest)"/> — REUSED, not recomputed: catches
+/// name/description/resource-list/script-list/allowed-tools/compatibility-length changes. Cheap (no file
+/// I/O beyond what the scan already did).
+/// </param>
+/// <param name="ContentHash">
+/// <see cref="SkillContentHasher.HashSkillFolder"/> — full file-CONTENT hash. Catches a resource/script
+/// FILE'S CONTENT changing even when its name and the frontmatter don't (<see cref="StructuralFingerprint"/>
+/// alone cannot see this — it only hashes resource/script NAMES, not bytes). <see langword="null"/> for
+/// non-file-sourced skills (no folder to hash).
+/// </param>
+/// <param name="Source">From a discovered <c>skills-lock.json</c> if present, else <see langword="null"/> — not required, most repos won't have one. No lock-file parser exists yet in Wave 1; this field is wired end-to-end (store → renderer) but always <see langword="null"/> until Wave 2/3 populates it from a real source.</param>
+/// <param name="SourceUrl">As <see cref="Source"/>.</param>
+/// <param name="Ref">Git ref/commit, if known from a discovered lock file. As <see cref="Source"/>.</param>
+/// <param name="ComplianceFindings">This skill's findings, filtered from the scan's <see cref="SkillComplianceReport.Findings"/> by <see cref="SkillComplianceFinding.SkillName"/> — <see cref="SkillComplianceReport"/> is flat, no per-skill grouping type exists, so this is a client-side filter, not a reuse of an existing per-skill type.</param>
+public sealed record SkillBaselineEntry(
+    string Name,
+    SkillSourceKind SourceKind,
+    string RelativePath,
+    string StructuralFingerprint,
+    string? ContentHash,
+    string? Source,
+    string? SourceUrl,
+    string? Ref,
+    IReadOnlyList<SkillComplianceFinding> ComplianceFindings);
+
+/// <summary>
+/// Agent Skills Wave 1 (§4.1) — a timestamped, content-hashed snapshot of every skill scanned at once.
+/// Historical (many snapshots accumulate over time via <see cref="ISkillBaselineStore"/>, one JSON file
+/// each, never overwritten) — deliberately NOT the same shape as <see cref="SkillManifestBaseline"/>'s
+/// single-pin CI-gate baseline. See that type's remarks and <see cref="SkillBaselineEntry"/>'s remarks for
+/// the full disambiguation — two very-similarly-purposed but structurally different types live in this
+/// namespace on purpose.
+/// </summary>
+/// <param name="Id">A ULID/GUID, not a timestamp-derived slug — timestamps alone can collide within a second on fast test/CI runs.</param>
+/// <param name="CapturedAt">When this snapshot was taken.</param>
+/// <param name="ScannedRoot">The root path that was scanned to produce this snapshot.</param>
+/// <param name="Skills">One entry per skill scanned.</param>
+public sealed record SkillBaselineSnapshot(
+    string Id,
+    DateTimeOffset CapturedAt,
+    string ScannedRoot,
+    IReadOnlyList<SkillBaselineEntry> Skills);

--- a/src/AgentEval.Core/Skills/SkillComplianceReportRenderer.cs
+++ b/src/AgentEval.Core/Skills/SkillComplianceReportRenderer.cs
@@ -17,7 +17,16 @@ public static class SkillComplianceReportRenderer
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 
     /// <summary>Renders a plain-text console report (severity-sorted findings + a coverage summary).</summary>
-    public static string RenderConsole(SkillComplianceReport report)
+    /// <param name="report">The report to render.</param>
+    /// <param name="provenanceByName">
+    /// Agent Skills Wave 1 (§4.5 tier 1) — optional, keyed by skill name. When a finding's skill has a
+    /// <see cref="SkillBaselineEntry.Source"/>/<see cref="SkillBaselineEntry.SourceUrl"/>, prints it inline
+    /// next to the finding (e.g. <c>"→ from chillicream/agent-skills@a1b2c3d"</c>). <see langword="null"/>-safe
+    /// and backward compatible — every existing call site keeps working unchanged when omitted. No lock-file
+    /// parser exists yet to populate this from a real source (Wave 1 scope) — the wiring is real and tested,
+    /// the data source is a Wave 2/3 follow-on.
+    /// </param>
+    public static string RenderConsole(SkillComplianceReport report, IReadOnlyDictionary<string, SkillBaselineEntry>? provenanceByName = null)
     {
         ArgumentNullException.ThrowIfNull(report);
         var sb = new StringBuilder();
@@ -40,7 +49,7 @@ public static class SkillComplianceReportRenderer
         {
             foreach (var f in SortedBySeverity(report.Findings))
             {
-                sb.AppendLine($"[{f.Severity}] {f.SkillName} — {f.Rule}: {f.Message}");
+                sb.AppendLine($"[{f.Severity}] {f.SkillName} — {f.Rule}: {f.Message}{ProvenanceSuffix(f.SkillName, provenanceByName)}");
             }
         }
 
@@ -55,7 +64,9 @@ public static class SkillComplianceReportRenderer
     }
 
     /// <summary>Renders a Markdown report (severity-sorted findings table + a coverage table).</summary>
-    public static string RenderMarkdown(SkillComplianceReport report)
+    /// <param name="report">The report to render.</param>
+    /// <param name="provenanceByName">See <see cref="RenderConsole"/>'s parameter of the same name.</param>
+    public static string RenderMarkdown(SkillComplianceReport report, IReadOnlyDictionary<string, SkillBaselineEntry>? provenanceByName = null)
     {
         ArgumentNullException.ThrowIfNull(report);
         var sb = new StringBuilder();
@@ -90,22 +101,93 @@ public static class SkillComplianceReportRenderer
             return sb.ToString();
         }
 
-        sb.AppendLine("| Severity | Skill | Rule | Message |");
-        sb.AppendLine("|---|---|---|---|");
+        sb.AppendLine("| Severity | Skill | Rule | Message | Source |");
+        sb.AppendLine("|---|---|---|---|---|");
         foreach (var f in SortedBySeverity(report.Findings))
         {
             var escapedMessage = f.Message.Replace("|", "\\|", StringComparison.Ordinal);
-            sb.AppendLine($"| {f.Severity} | {f.SkillName} | {f.Rule} | {escapedMessage} |");
+            var provenance = ProvenanceCell(f.SkillName, provenanceByName);
+            sb.AppendLine($"| {f.Severity} | {f.SkillName} | {f.Rule} | {escapedMessage} | {provenance} |");
         }
 
         return sb.ToString();
     }
 
     /// <summary>Renders the report as indented JSON (machine-readable, for CI).</summary>
-    public static string RenderJson(SkillComplianceReport report)
+    /// <param name="report">The report to render.</param>
+    /// <param name="provenanceByName">
+    /// See <see cref="RenderConsole"/>'s parameter of the same name. When supplied, each finding's JSON
+    /// object gains a <c>provenance</c> field (<c>source</c>/<c>sourceUrl</c>/<c>ref</c>) whenever a
+    /// matching entry exists — omitted (not <c>null</c>-padded) for a skill with no provenance data, so a
+    /// <see langword="null"/> <paramref name="provenanceByName"/> produces byte-identical output to the
+    /// pre-Wave-1 shape (backward compatible).
+    /// </param>
+    public static string RenderJson(SkillComplianceReport report, IReadOnlyDictionary<string, SkillBaselineEntry>? provenanceByName = null)
     {
         ArgumentNullException.ThrowIfNull(report);
-        return JsonSerializer.Serialize(report, JsonOptions);
+        if (provenanceByName is null or { Count: 0 })
+        {
+            return JsonSerializer.Serialize(report, JsonOptions);
+        }
+
+        // PascalCase field names throughout, matching the exact casing System.Text.Json's DEFAULT (no
+        // naming-policy override — see JsonOptions above) produces for the plain SkillComplianceReport
+        // shape the no-provenance branch above still serializes as-is — so the two branches differ only in
+        // the ADDED Provenance field, not in casing convention.
+        var findingsWithProvenance = report.Findings.Select(f =>
+        {
+            provenanceByName.TryGetValue(f.SkillName, out var entry);
+            object? provenance = entry is { Source: not null } or { SourceUrl: not null } or { Ref: not null }
+                ? new { Source = entry.Source, SourceUrl = entry.SourceUrl, Ref = entry.Ref }
+                : null;
+            return new
+            {
+                SkillName = f.SkillName,
+                Rule = f.Rule,
+                Severity = f.Severity,
+                Message = f.Message,
+                Field = f.Field,
+                Provenance = provenance,
+            };
+        });
+
+        var shape = new { Findings = findingsWithProvenance, Coverage = report.Coverage, IsCompliant = report.IsCompliant };
+        return JsonSerializer.Serialize(shape, JsonOptions);
+    }
+
+    // "→ from chillicream/agent-skills@a1b2c3d" — printed inline next to a console finding when the
+    // finding's skill has a Source in provenanceByName. Empty string (no-op) when absent, so the caller
+    // never has to special-case a missing entry.
+    private static string ProvenanceSuffix(string skillName, IReadOnlyDictionary<string, SkillBaselineEntry>? provenanceByName)
+    {
+        if (provenanceByName is null || !provenanceByName.TryGetValue(skillName, out var entry))
+        {
+            return string.Empty;
+        }
+
+        var label = ProvenanceLabel(entry);
+        return label is null ? string.Empty : $" → from {label}";
+    }
+
+    private static string ProvenanceCell(string skillName, IReadOnlyDictionary<string, SkillBaselineEntry>? provenanceByName)
+    {
+        if (provenanceByName is null || !provenanceByName.TryGetValue(skillName, out var entry))
+        {
+            return string.Empty;
+        }
+
+        return ProvenanceLabel(entry) ?? string.Empty;
+    }
+
+    private static string? ProvenanceLabel(SkillBaselineEntry entry)
+    {
+        if (entry.Source is null && entry.SourceUrl is null)
+        {
+            return null;
+        }
+
+        var label = entry.Source ?? entry.SourceUrl!;
+        return entry.Ref is null ? label : $"{label}@{entry.Ref}";
     }
 
     // High severity first, then by skill name for a stable, scannable ordering.

--- a/src/AgentEval.Core/Skills/SkillContentHasher.cs
+++ b/src/AgentEval.Core/Skills/SkillContentHasher.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+using AgentEval.Guardrails;
+
+namespace AgentEval.Skills;
+
+/// <summary>
+/// Agent Skills Wave 1 (§4.1) — the genuinely NEW hash function this wave needed (everything else reuses
+/// existing primitives). <see cref="SkillManifestPoisoningGate.Fingerprint"/> only hashes resource/script
+/// NAMES (frontmatter-derived), not file bytes, so a resource file's CONTENT silently changing (the text of
+/// a <c>.md</c> resource, the body of a script) would not be caught by that fingerprint alone — this fills
+/// that gap.
+/// </summary>
+public static class SkillContentHasher
+{
+    /// <summary>
+    /// Enumerates every file under <paramref name="skillFolderAbsolutePath"/> (SKILL.md + resources/ +
+    /// scripts/ + anything else present), sorted by relative path (<see cref="StringComparer.Ordinal"/> —
+    /// insensitive to enumeration order, sensitive to any byte changing), SHA-256s each file's bytes, then
+    /// reuses <see cref="ManifestFingerprint.Hash"/> over the concatenation of
+    /// <c>"{relativePath}\n{fileHashHex}\n"</c> per entry in sorted order — the final hashing step reuses
+    /// the existing primitive even though the file-walk itself is new. Bounded, deterministic, no network.
+    /// Read-only — never mutates the scanned directory.
+    /// </summary>
+    public static string HashSkillFolder(string skillFolderAbsolutePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(skillFolderAbsolutePath);
+        if (!Directory.Exists(skillFolderAbsolutePath))
+        {
+            throw new DirectoryNotFoundException($"Skill folder not found: {skillFolderAbsolutePath}");
+        }
+
+        var relativePaths = Directory.EnumerateFiles(skillFolderAbsolutePath, "*", SearchOption.AllDirectories)
+            .Select(f => Path.GetRelativePath(skillFolderAbsolutePath, f).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        var canonical = new StringBuilder();
+        foreach (var relativePath in relativePaths)
+        {
+            var fullPath = Path.Combine(skillFolderAbsolutePath, relativePath);
+            var bytes = File.ReadAllBytes(fullPath);
+            var fileHashHex = Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+            canonical.Append(relativePath).Append('\n').Append(fileHashHex).Append('\n');
+        }
+
+        return ManifestFingerprint.Hash(canonical.ToString());
+    }
+}

--- a/src/AgentEval.MAF/Skills/MafSkillScanner.cs
+++ b/src/AgentEval.MAF/Skills/MafSkillScanner.cs
@@ -8,6 +8,23 @@ using Microsoft.Agents.AI;
 namespace AgentEval.MAF.Skills;
 
 /// <summary>
+/// Agent Skills Wave 1 (§1.2) — one scanned skill's manifest paired with its on-disk absolute folder path
+/// (file-sourced skills only; <see langword="null"/> for non-file sources, which have no folder to hash).
+/// The baseline-ledger builder (<c>SkillsScanCommand</c>'s <c>--write-baseline</c> path) needs this path to
+/// call <c>SkillContentHasher.HashSkillFolder</c> — <see cref="SkillManifest"/> alone does not carry it
+/// (see <see cref="SkillManifest.ParentDirectoryName"/>'s remarks: that field is a bare directory NAME for
+/// the GA name-matches-directory rule, not a usable path).
+/// </summary>
+/// <param name="Manifest">The scanned skill's manifest.</param>
+/// <param name="AbsolutePath">The skill's own folder (containing its <c>SKILL.md</c>), or <see langword="null"/> for a non-file-sourced skill.</param>
+public sealed record ScannedSkillInfo(SkillManifest Manifest, string? AbsolutePath);
+
+/// <summary>Agent Skills Wave 1 (§1.2) — <see cref="MafSkillScanner.ScanFileSkillsWithInfoAsync"/>'s result: the compliance report PLUS enough per-skill metadata to build a <c>SkillBaselineSnapshot</c>.</summary>
+/// <param name="Report">Identical to what <see cref="MafSkillScanner.ScanFileSkillsAsync"/> alone returns.</param>
+/// <param name="Skills">One entry per skill actually returned by MAF's discovery (excludes silently-excluded folders — those have no manifest to pair a path with).</param>
+public sealed record SkillScanResult(SkillComplianceReport Report, IReadOnlyList<ScannedSkillInfo> Skills);
+
+/// <summary>
 /// The ONLY place in this feature that touches a live <c>AgentSkill</c> / <c>AgentSkillsSource</c> — maps
 /// GA MAF Agent Skills types to the pure, MAF-free <see cref="SkillManifest"/> DTO, then delegates to
 /// <see cref="SkillComplianceValidator"/> (which never sees a <c>Microsoft.Agents.AI</c> type; see the design
@@ -95,6 +112,20 @@ public static class MafSkillScanner
     public static async Task<SkillComplianceReport> ScanFileSkillsAsync(
         string skillPath, AIAgent agent, SkillScanOptions? options = null, CancellationToken cancellationToken = default)
     {
+        var result = await ScanFileSkillsWithInfoAsync(skillPath, agent, options, cancellationToken).ConfigureAwait(false);
+        return result.Report;
+    }
+
+    /// <summary>
+    /// Agent Skills Wave 1 (§1.2) — identical scan/validation/exclusion-detection behavior to
+    /// <see cref="ScanFileSkillsAsync"/> (which is now a thin wrapper over this method, discarding the
+    /// extra per-skill path info) — additionally returns each skill's on-disk absolute folder path, which
+    /// <c>SkillsScanCommand</c>'s <c>--write-baseline</c> path needs to compute
+    /// <c>SkillContentHasher.HashSkillFolder</c> per skill.
+    /// </summary>
+    public static async Task<SkillScanResult> ScanFileSkillsWithInfoAsync(
+        string skillPath, AIAgent agent, SkillScanOptions? options = null, CancellationToken cancellationToken = default)
+    {
         if (string.IsNullOrWhiteSpace(skillPath))
         {
             throw new ArgumentException("skillPath must be non-empty.", nameof(skillPath));
@@ -126,20 +157,27 @@ public static class MafSkillScanner
                 "nothing under this path is functional until discovery succeeds.",
                 null);
             var emptyHistogram = new Dictionary<string, int> { ["load"] = 0, ["read"] = 0, ["run"] = 0 };
-            return new SkillComplianceReport(
+            var crashReport = new SkillComplianceReport(
                 new[] { crashFinding },
                 new SkillCoverageSummary(0, 0, 0, emptyHistogram, SilentlyExcludedCount: 0));
+            return new SkillScanResult(crashReport, Array.Empty<ScannedSkillInfo>());
         }
 
         var manifests = new List<SkillManifest>(skills.Count);
+        var scannedInfos = new List<ScannedSkillInfo>(skills.Count);
         var returnedDirectories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var skill in skills)
         {
-            manifests.Add(ToManifest(skill));
+            var manifest = ToManifest(skill);
+            manifests.Add(manifest);
+            string? absolutePath = null;
             if (skill is AgentFileSkill fileSkill && !string.IsNullOrWhiteSpace(fileSkill.Path))
             {
+                absolutePath = Path.GetFullPath(fileSkill.Path);
                 returnedDirectories.Add(NormalizeDirectory(fileSkill.Path));
             }
+
+            scannedInfos.Add(new ScannedSkillInfo(manifest, absolutePath));
         }
 
         var baseReport = SkillComplianceValidator.Validate(manifests, options);
@@ -147,14 +185,15 @@ public static class MafSkillScanner
         var exclusionFindings = FindSilentExclusions(skillPath, returnedDirectories, options);
         if (exclusionFindings.Count == 0)
         {
-            return baseReport;
+            return new SkillScanResult(baseReport, scannedInfos);
         }
 
         var combinedFindings = new List<SkillComplianceFinding>(baseReport.Findings.Count + exclusionFindings.Count);
         combinedFindings.AddRange(baseReport.Findings);
         combinedFindings.AddRange(exclusionFindings);
         var combinedCoverage = baseReport.Coverage with { SilentlyExcludedCount = exclusionFindings.Count };
-        return new SkillComplianceReport(combinedFindings, combinedCoverage);
+        var combinedReport = new SkillComplianceReport(combinedFindings, combinedCoverage);
+        return new SkillScanResult(combinedReport, scannedInfos);
     }
 
     /// <summary>

--- a/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli;
+using AgentEval.Cli.Commands;
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Cli;
+
+/// <summary>
+/// Agent Skills Wave 1 (§1.2/§4.1/§4.3) — <c>skills scan --write-baseline</c> / <c>--repo</c>, and the
+/// <c>skills baseline list|diff|history</c> subcommand group. All real, on-disk, credential-free (same
+/// no-op-agent discipline as <see cref="SkillsScanCommandTests"/>).
+/// </summary>
+public class SkillsBaselineCommandTests : IDisposable
+{
+    private readonly string _baselineRoot;
+
+    public SkillsBaselineCommandTests()
+    {
+        _baselineRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-baseline-cmd-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baselineRoot, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // ── command wiring ──
+
+    [Fact]
+    public void Create_ReturnsSkillsCommand_WithBaselineSubcommand()
+    {
+        var command = SkillsScanCommand.Create();
+        Assert.Contains(command.Subcommands, c => c.Name == "baseline");
+    }
+
+    [Fact]
+    public void Create_BaselineSubcommand_HasListDiffHistory()
+    {
+        var baselineCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "baseline");
+        Assert.Contains(baselineCmd.Subcommands, c => c.Name == "list");
+        Assert.Contains(baselineCmd.Subcommands, c => c.Name == "diff");
+        Assert.Contains(baselineCmd.Subcommands, c => c.Name == "history");
+    }
+
+    [Fact]
+    public void Create_ScanSubcommand_HasWriteBaselineAndRepoOptions()
+    {
+        var scanCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--write-baseline");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--repo");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--baseline-root");
+    }
+
+    // ── --write-baseline: scan a real fixture, confirm a snapshot lands in the ledger ──
+
+    [Fact]
+    public async Task ExecuteAsync_WriteBaseline_SavesSnapshotWithContentAndStructuralHashes()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            var exit = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", output: null, failOnNoncompliant: false,
+                writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+
+            var store = new JsonFileSkillBaselineStore(_baselineRoot);
+            var snapshots = await store.ListAsync();
+            var snapshot = Assert.Single(snapshots);
+            Assert.Equal(dir.FullName, snapshot.ScannedRoot);
+
+            var entry = Assert.Single(snapshot.Skills, s => s.Name == skillName);
+            Assert.False(string.IsNullOrEmpty(entry.StructuralFingerprint));
+            Assert.NotNull(entry.ContentHash);
+            Assert.Equal(SkillSourceKind.File, entry.SourceKind);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoWriteBaseline_NoSnapshotSaved()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(
+                dir, "console", output: null, failOnNoncompliant: false,
+                writeBaseline: false, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            Assert.False(Directory.Exists(_baselineRoot), "no baseline directory should be created when --write-baseline is not passed");
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    // ── skills baseline list ──
+
+    [Fact]
+    public async Task ListAsync_NoSnapshots_ReturnsSuccessWithMessage()
+    {
+        var exit = await SkillsScanCommand.ListAsync(_baselineRoot, default);
+        Assert.Equal(ExitCodes.Success, exit);
+    }
+
+    [Fact]
+    public async Task ListAsync_AfterTwoScans_ListsBoth()
+    {
+        var dir1 = CreateCompliantFixture(out _);
+        var dir2 = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir1, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+            await SkillsScanCommand.ExecuteAsync(dir2, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            var store = new JsonFileSkillBaselineStore(_baselineRoot);
+            var snapshots = await store.ListAsync();
+            Assert.Equal(2, snapshots.Count);
+
+            var exit = await SkillsScanCommand.ListAsync(_baselineRoot, default);
+            Assert.Equal(ExitCodes.Success, exit);
+        }
+        finally { dir1.Delete(recursive: true); dir2.Delete(recursive: true); }
+    }
+
+    // ── skills baseline diff ──
+
+    [Fact]
+    public async Task DiffAsync_FewerThanTwoSnapshots_ReturnsSuccessWithMessage_NotError()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+            var exit = await SkillsScanCommand.DiffAsync(_baselineRoot, sinceId: null, skillFilter: null, hashKind: "content", default);
+            Assert.Equal(ExitCodes.Success, exit);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task DiffAsync_UnknownHashKind_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => SkillsScanCommand.DiffAsync(_baselineRoot, null, null, "bogus", default));
+    }
+
+    [Fact]
+    public async Task DiffAsync_ContentChanged_DetectedAsChanged()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            // Mutate the skill's resource content between the two scans.
+            var skillDir = Path.Combine(dir.FullName, skillName);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+                $"---\nname: {skillName}\ndescription: A compliant fixture skill for SkillsScanCommandTests. CHANGED.\n---\n\nBody changed.\n");
+
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            var store = new JsonFileSkillBaselineStore(_baselineRoot);
+            var snapshots = await store.ListAsync();
+            Assert.Equal(2, snapshots.Count);
+
+            var exit = await SkillsScanCommand.DiffAsync(_baselineRoot, sinceId: null, skillFilter: skillName, hashKind: "content", default);
+            Assert.Equal(ExitCodes.Success, exit);
+            // (Console output assertion intentionally omitted here — DiffAsync writes to Console.Out, which
+            // isn't captured by this test; the exit-code + no-throw path plus the dedicated ManifestDriftDetector
+            // unit coverage in PromptTemplateDriftGateTests/McpToolDescriptionPoisoningGateTests already prove
+            // the underlying Changed-detection logic. See SkillContentHasherTests for the hash-sensitivity proof.)
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task DiffAsync_UnchangedContent_NoChangedFinding()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            var store = new JsonFileSkillBaselineStore(_baselineRoot);
+            var snapshots = await store.ListAsync();
+            var oldest = snapshots[0];
+            var newest = snapshots[1];
+
+            var oldHash = oldest.Skills.Single().ContentHash;
+            var newHash = newest.Skills.Single().ContentHash;
+            Assert.Equal(oldHash, newHash);   // unchanged fixture -> unchanged hash
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task DiffAsync_SinceUnknownId_ReturnsRuntimeError()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+            var exit = await SkillsScanCommand.DiffAsync(_baselineRoot, sinceId: "does-not-exist", skillFilter: null, hashKind: "content", default);
+            Assert.Equal(ExitCodes.RuntimeError, exit);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    // ── skills baseline history ──
+
+    [Fact]
+    public async Task HistoryAsync_NeverSeen_ReturnsSuccess()
+    {
+        var exit = await SkillsScanCommand.HistoryAsync(_baselineRoot, "never-existed-skill", default);
+        Assert.Equal(ExitCodes.Success, exit);
+    }
+
+    [Fact]
+    public async Task HistoryAsync_ContentChangedOnce_ReturnsSuccess_AfterTwoScans()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            var skillDir = Path.Combine(dir.FullName, skillName);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+                $"---\nname: {skillName}\ndescription: Changed description for history test.\n---\n\nBody.\n");
+
+            await SkillsScanCommand.ExecuteAsync(dir, "console", null, false, writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            var exit = await SkillsScanCommand.HistoryAsync(_baselineRoot, skillName, default);
+            Assert.Equal(ExitCodes.Success, exit);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    // ── --repo: multi-convention discovery ──
+
+    [Fact]
+    public async Task ExecuteAsync_Repo_ScansKnownConventions_AggregatesAcrossThem()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-repo-test-" + Guid.NewGuid().ToString("N"));
+        var claudeSkillsDir = Path.Combine(repoRoot, ".claude", "skills", "skill-a");
+        var agentsSkillsDir = Path.Combine(repoRoot, ".agents", "skills", "skill-b");
+        Directory.CreateDirectory(claudeSkillsDir);
+        Directory.CreateDirectory(agentsSkillsDir);
+        File.WriteAllText(Path.Combine(claudeSkillsDir, "SKILL.md"), "---\nname: skill-a\ndescription: Present under .claude/skills.\n---\n\nBody.\n");
+        File.WriteAllText(Path.Combine(agentsSkillsDir, "SKILL.md"), "---\nname: skill-b\ndescription: Present under .agents/skills.\n---\n\nBody.\n");
+        // .windsurf/skills etc. deliberately absent — proves the "not present" branch is exercised too.
+
+        try
+        {
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-repo-out-" + Guid.NewGuid().ToString("N") + ".txt"));
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteAsync(
+                    new DirectoryInfo(repoRoot), "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: true, repo: true, baselineRoot: _baselineRoot, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                // Both fixture skills are fully compliant (no findings expected) — the JSON report's
+                // Findings array is legitimately empty; SkillCount in the merged Coverage is the real
+                // signal that BOTH conventions' skills were folded into one combined report.
+                Assert.Contains("\"SkillCount\": 2", content, StringComparison.Ordinal);
+
+                var store = new JsonFileSkillBaselineStore(_baselineRoot);
+                var snapshots = await store.ListAsync();
+                var snapshot = Assert.Single(snapshots);
+                Assert.Equal(2, snapshot.Skills.Count);
+                Assert.Contains(snapshot.Skills, s => s.RelativePath.Contains(".claude/skills", StringComparison.Ordinal));
+                Assert.Contains(snapshot.Skills, s => s.RelativePath.Contains(".agents/skills", StringComparison.Ordinal));
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Repo_NoConventionsPresent_ZeroSkillsFound_StillSucceeds()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-repo-empty-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(repoRoot);
+        try
+        {
+            var exit = await SkillsScanCommand.ExecuteAsync(
+                new DirectoryInfo(repoRoot), "console", null, failOnNoncompliant: false,
+                writeBaseline: false, repo: true, baselineRoot: _baselineRoot, ct: default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+        }
+        finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
+    // ── helpers (mirrors SkillsScanCommandTests' fixture builder) ──
+
+    private static DirectoryInfo CreateCompliantFixture(out string skillName)
+    {
+        skillName = "compliant-skill-" + Guid.NewGuid().ToString("N")[..8];
+        var root = Path.Combine(Path.GetTempPath(), "agenteval-skills-baseline-fixture-" + Guid.NewGuid().ToString("N"));
+        var skillDir = Path.Combine(root, skillName);
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            $"---\nname: {skillName}\ndescription: A compliant fixture skill for SkillsBaselineCommandTests.\n---\n\nBody.\n");
+        return new DirectoryInfo(root);
+    }
+}

--- a/tests/AgentEval.Tests/Cli/SkillsScanCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsScanCommandTests.cs
@@ -45,7 +45,7 @@ public class SkillsScanCommandTests
     {
         var missing = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-scan-missing-" + Guid.NewGuid().ToString("N")));
         await Assert.ThrowsAsync<DirectoryNotFoundException>(
-            () => SkillsScanCommand.ExecuteAsync(missing, "console", null, false, default));
+            () => SkillsScanCommand.ExecuteAsync(missing, "console", null, false, ct: default));
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class SkillsScanCommandTests
         try
         {
             var ex = await Assert.ThrowsAsync<ArgumentException>(
-                () => SkillsScanCommand.ExecuteAsync(dir, "yaml", null, false, default));
+                () => SkillsScanCommand.ExecuteAsync(dir, "yaml", null, false, ct: default));
             Assert.Contains("--format", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
         finally { dir.Delete(recursive: true); }
@@ -74,7 +74,7 @@ public class SkillsScanCommandTests
             var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-scan-out-" + Guid.NewGuid().ToString("N") + ".txt"));
             try
             {
-                var exit = await SkillsScanCommand.ExecuteAsync(dir, format, outFile, failOnNoncompliant: false, default);
+                var exit = await SkillsScanCommand.ExecuteAsync(dir, format, outFile, failOnNoncompliant: false, ct: default);
 
                 Assert.Equal(ExitCodes.Success, exit);
                 Assert.True(outFile.Exists, "the rendered report should have been written to --output");
@@ -94,7 +94,7 @@ public class SkillsScanCommandTests
         var dir = CreateCompliantFixture(out _, withScript: true);
         try
         {
-            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", null, failOnNoncompliant: true, default);
+            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", null, failOnNoncompliant: true, ct: default);
             Assert.Equal(ExitCodes.Success, exit);
         }
         finally { dir.Delete(recursive: true); }
@@ -106,7 +106,7 @@ public class SkillsScanCommandTests
         var dir = CreateCompliantFixture(out _);
         try
         {
-            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", output: null, failOnNoncompliant: false, default);
+            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", output: null, failOnNoncompliant: false, ct: default);
             Assert.Equal(ExitCodes.Success, exit);
         }
         finally { dir.Delete(recursive: true); }
@@ -124,7 +124,7 @@ public class SkillsScanCommandTests
         var dir = CreateMalformedFixture();
         try
         {
-            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", null, failOnNoncompliant: true, default);
+            var exit = await SkillsScanCommand.ExecuteAsync(dir, "console", null, failOnNoncompliant: true, ct: default);
             Assert.Equal(ExitCodes.TestFailure, exit);
         }
         finally { dir.Delete(recursive: true); }
@@ -139,7 +139,7 @@ public class SkillsScanCommandTests
             var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-scan-malformed-out-" + Guid.NewGuid().ToString("N") + ".txt"));
             try
             {
-                await SkillsScanCommand.ExecuteAsync(dir, "console", outFile, failOnNoncompliant: false, default);
+                await SkillsScanCommand.ExecuteAsync(dir, "console", outFile, failOnNoncompliant: false, ct: default);
                 var content = await File.ReadAllTextAsync(outFile.FullName);
                 Assert.Contains("SkillExcludedFromDiscovery", content, StringComparison.Ordinal);
                 Assert.Contains("SILENTLY EXCLUDED", content, StringComparison.Ordinal);

--- a/tests/AgentEval.Tests/Skills/AgentSkillDirectoryConventionsTests.cs
+++ b/tests/AgentEval.Tests/Skills/AgentSkillDirectoryConventionsTests.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Skills;
+
+/// <summary>Agent Skills Wave 1 (§4.3) — the repo-wide discovery seed list.</summary>
+public class AgentSkillDirectoryConventionsTests
+{
+    [Fact]
+    public void KnownConventions_IsNonEmpty()
+        => Assert.NotEmpty(AgentSkillDirectoryConventions.KnownConventions);
+
+    [Fact]
+    public void KnownConventions_IncludesTheAgentSkillsIoUniversalPath()
+        => Assert.Contains(".agents/skills", AgentSkillDirectoryConventions.KnownConventions);
+
+    [Fact]
+    public void KnownConventions_IncludesClaudeSkills()
+        => Assert.Contains(".claude/skills", AgentSkillDirectoryConventions.KnownConventions);
+
+    [Fact]
+    public void KnownConventions_HasNoDuplicates()
+    {
+        var distinct = AgentSkillDirectoryConventions.KnownConventions.Distinct(StringComparer.Ordinal).Count();
+        Assert.Equal(AgentSkillDirectoryConventions.KnownConventions.Count, distinct);
+    }
+}

--- a/tests/AgentEval.Tests/Skills/JsonFileSkillBaselineStoreTests.cs
+++ b/tests/AgentEval.Tests/Skills/JsonFileSkillBaselineStoreTests.cs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Skills;
+
+/// <summary>Agent Skills Wave 1 (§4.1) — the baseline ledger's persistence: one file per snapshot, NEVER overwritten (append-only history), unlike the single-pin Gatekeeper calibration-report store.</summary>
+public class JsonFileSkillBaselineStoreTests : IDisposable
+{
+    private readonly string _root;
+
+    public JsonFileSkillBaselineStoreTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "agenteval-skill-baseline-store-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static SkillBaselineSnapshot Snapshot(DateTimeOffset capturedAt, string scannedRoot = "/repo/skills") =>
+        new(
+            Id: Guid.NewGuid().ToString("N"),
+            CapturedAt: capturedAt,
+            ScannedRoot: scannedRoot,
+            Skills:
+            [
+                new SkillBaselineEntry(
+                    Name: "example-skill",
+                    SourceKind: SkillSourceKind.File,
+                    RelativePath: "example-skill",
+                    StructuralFingerprint: "abc123",
+                    ContentHash: "def456",
+                    Source: null,
+                    SourceUrl: null,
+                    Ref: null,
+                    ComplianceFindings: []),
+            ]);
+
+    [Fact]
+    public async Task SaveThenLoad_RoundTripsAllFields()
+    {
+        var store = new JsonFileSkillBaselineStore(_root);
+        var original = Snapshot(new DateTimeOffset(2026, 7, 17, 12, 0, 0, TimeSpan.Zero));
+
+        var savedId = await store.SaveAsync(original);
+        Assert.Equal(original.Id, savedId);
+
+        var loaded = await store.LoadAsync(original.Id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(original.Id, loaded!.Id);
+        Assert.Equal(original.CapturedAt, loaded.CapturedAt);
+        Assert.Equal(original.ScannedRoot, loaded.ScannedRoot);
+        var skill = Assert.Single(loaded.Skills);
+        Assert.Equal("example-skill", skill.Name);
+        Assert.Equal("abc123", skill.StructuralFingerprint);
+        Assert.Equal("def456", skill.ContentHash);
+    }
+
+    [Fact]
+    public async Task Load_NeverSaved_ReturnsNull()
+    {
+        var store = new JsonFileSkillBaselineStore(_root);
+        var loaded = await store.LoadAsync("does-not-exist");
+        Assert.Null(loaded);
+    }
+
+    [Fact]
+    public async Task Save_TwoSnapshots_ProducesTwoFiles_NeverOverwrites()
+    {
+        var store = new JsonFileSkillBaselineStore(_root);
+        var first = Snapshot(new DateTimeOffset(2026, 7, 17, 10, 0, 0, TimeSpan.Zero));
+        var second = Snapshot(new DateTimeOffset(2026, 7, 17, 11, 0, 0, TimeSpan.Zero));
+
+        await store.SaveAsync(first);
+        await store.SaveAsync(second);
+
+        var files = Directory.GetFiles(_root, "skills-baseline-*.json");
+        Assert.Equal(2, files.Length);
+
+        var all = await store.ListAsync();
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task Save_SameSecond_DifferentSnapshots_BothPersist_NoFilenameCollision()
+    {
+        // Same CapturedAt (to the second AND millisecond) for two DIFFERENT snapshots — the Id suffix in
+        // the filename must still keep them from colliding (this is exactly the risk
+        // SkillBaselineSnapshot.Id's own remarks flag: "timestamps alone can collide... on fast test runs").
+        var store = new JsonFileSkillBaselineStore(_root);
+        var sameInstant = new DateTimeOffset(2026, 7, 17, 12, 0, 0, 123, TimeSpan.Zero);
+        var a = Snapshot(sameInstant);
+        var b = Snapshot(sameInstant);
+
+        await store.SaveAsync(a);
+        await store.SaveAsync(b);
+
+        var all = await store.ListAsync();
+        Assert.Equal(2, all.Count);
+        Assert.NotNull(await store.LoadAsync(a.Id));
+        Assert.NotNull(await store.LoadAsync(b.Id));
+    }
+
+    [Fact]
+    public async Task ListAsync_OrdersOldestToNewest_ByCapturedAt_NotSaveOrder()
+    {
+        var store = new JsonFileSkillBaselineStore(_root);
+        var newer = Snapshot(new DateTimeOffset(2026, 7, 17, 15, 0, 0, TimeSpan.Zero));
+        var older = Snapshot(new DateTimeOffset(2026, 7, 17, 9, 0, 0, TimeSpan.Zero));
+
+        // Save NEWER first, older second — ListAsync must still return oldest-first.
+        await store.SaveAsync(newer);
+        await store.SaveAsync(older);
+
+        var all = await store.ListAsync();
+
+        Assert.Equal(2, all.Count);
+        Assert.Equal(older.Id, all[0].Id);
+        Assert.Equal(newer.Id, all[1].Id);
+    }
+
+    [Fact]
+    public async Task ListAsync_NothingSavedYet_ReturnsEmpty()
+    {
+        var store = new JsonFileSkillBaselineStore(_root);
+        var all = await store.ListAsync();
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task Load_CorruptFile_TreatedAsMissing_NotThrown()
+    {
+        Directory.CreateDirectory(_root);
+        await File.WriteAllTextAsync(Path.Combine(_root, "skills-baseline-20260717120000000-corrupt.json"), "{ not valid json");
+
+        var store = new JsonFileSkillBaselineStore(_root);
+        var all = await store.ListAsync();
+
+        Assert.Empty(all);   // corrupt file skipped, not thrown
+    }
+}

--- a/tests/AgentEval.Tests/Skills/SkillComplianceReportRendererTests.cs
+++ b/tests/AgentEval.Tests/Skills/SkillComplianceReportRendererTests.cs
@@ -114,4 +114,90 @@ public class SkillComplianceReportRendererTests
         var lowIdx = console.LastIndexOf("[Low]", StringComparison.Ordinal);
         Assert.True(highIdx >= 0 && lowIdx >= 0 && highIdx < lowIdx, "High-severity findings must render before Low-severity findings.");
     }
+
+    // ── Agent Skills Wave 1 (§4.5 tier 1): provenance pointer — null-safe, backward-compatible extension ──
+
+    private static IReadOnlyDictionary<string, SkillBaselineEntry> ProvenanceFor(string skillName, string source, string? sourceUrl = null, string? gitRef = null) =>
+        new Dictionary<string, SkillBaselineEntry>
+        {
+            [skillName] = new SkillBaselineEntry(
+                skillName, SkillSourceKind.File, skillName, "fp", "ch",
+                Source: source, SourceUrl: sourceUrl, Ref: gitRef, ComplianceFindings: []),
+        };
+
+    [Fact]
+    public void RenderConsole_NoProvenanceArg_IdenticalToOmittedParameter()
+    {
+        // Backward compatibility: every existing call site (RenderConsole(report)) keeps working unchanged.
+        var withDefault = SkillComplianceReportRenderer.RenderConsole(SampleReport());
+        var withExplicitNull = SkillComplianceReportRenderer.RenderConsole(SampleReport(), provenanceByName: null);
+        Assert.Equal(withDefault, withExplicitNull);
+    }
+
+    [Fact]
+    public void RenderConsole_ProvenanceForFindingSkill_PrintsInlineSource()
+    {
+        var provenance = ProvenanceFor("expense-report", "chillicream/agent-skills", gitRef: "a1b2c3d");
+        var text = SkillComplianceReportRenderer.RenderConsole(SampleReport(), provenance);
+        Assert.Contains("→ from chillicream/agent-skills@a1b2c3d", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderConsole_ProvenanceForDifferentSkill_NotPrinted()
+    {
+        var provenance = ProvenanceFor("some-other-skill", "chillicream/agent-skills", gitRef: "a1b2c3d");
+        var text = SkillComplianceReportRenderer.RenderConsole(SampleReport(), provenance);
+        Assert.DoesNotContain("→ from", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderConsole_ProvenanceEntryWithNoSourceOrUrl_NoOp()
+    {
+        var provenance = new Dictionary<string, SkillBaselineEntry>
+        {
+            ["expense-report"] = new SkillBaselineEntry(
+                "expense-report", SkillSourceKind.File, "expense-report", "fp", "ch",
+                Source: null, SourceUrl: null, Ref: null, ComplianceFindings: []),
+        };
+        var text = SkillComplianceReportRenderer.RenderConsole(SampleReport(), provenance);
+        Assert.DoesNotContain("→ from", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderMarkdown_ProvenanceForFindingSkill_AddsSourceColumn()
+    {
+        var provenance = ProvenanceFor("expense-report", "chillicream/agent-skills", gitRef: "a1b2c3d");
+        var md = SkillComplianceReportRenderer.RenderMarkdown(SampleReport(), provenance);
+        Assert.Contains("| Source |", md, StringComparison.Ordinal);
+        Assert.Contains("chillicream/agent-skills@a1b2c3d", md, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderJson_NoProvenanceArg_IdenticalToOmittedParameter_ByteForByte()
+    {
+        var withDefault = SkillComplianceReportRenderer.RenderJson(SampleReport());
+        var withExplicitNull = SkillComplianceReportRenderer.RenderJson(SampleReport(), provenanceByName: null);
+        Assert.Equal(withDefault, withExplicitNull);
+        // And identical to the pre-Wave-1 plain-record serialization shape (PascalCase Findings/Coverage).
+        Assert.Contains("\"Findings\"", withDefault);
+    }
+
+    [Fact]
+    public void RenderJson_WithProvenance_AddsProvenanceFieldToMatchingFinding()
+    {
+        var provenance = ProvenanceFor("expense-report", "chillicream/agent-skills", sourceUrl: "https://github.com/chillicream/agent-skills", gitRef: "a1b2c3d");
+        var json = SkillComplianceReportRenderer.RenderJson(SampleReport(), provenance);
+
+        Assert.Contains("\"Provenance\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"Source\": \"chillicream/agent-skills\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"Ref\": \"a1b2c3d\"", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderJson_EmptyProvenanceDictionary_TreatedSameAsNull()
+    {
+        var withEmpty = SkillComplianceReportRenderer.RenderJson(SampleReport(), new Dictionary<string, SkillBaselineEntry>());
+        var withNull = SkillComplianceReportRenderer.RenderJson(SampleReport(), provenanceByName: null);
+        Assert.Equal(withNull, withEmpty);
+    }
 }

--- a/tests/AgentEval.Tests/Skills/SkillContentHasherTests.cs
+++ b/tests/AgentEval.Tests/Skills/SkillContentHasherTests.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Skills;
+
+/// <summary>Agent Skills Wave 1 (§4.1) — the genuinely new hash function: full file-CONTENT coverage, complementing the structural (frontmatter-only) fingerprint.</summary>
+public class SkillContentHasherTests : IDisposable
+{
+    private readonly string _root;
+
+    public SkillContentHasherTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "agenteval-skill-content-hasher-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteSkill(string skillDir, string skillMd, string? resourceContent = null, string? scriptContent = null)
+    {
+        var dir = Path.Combine(_root, skillDir);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), skillMd);
+        if (resourceContent is not null)
+        {
+            var resourcesDir = Path.Combine(dir, "resources");
+            Directory.CreateDirectory(resourcesDir);
+            File.WriteAllText(Path.Combine(resourcesDir, "policy.md"), resourceContent);
+        }
+
+        if (scriptContent is not null)
+        {
+            var scriptsDir = Path.Combine(dir, "scripts");
+            Directory.CreateDirectory(scriptsDir);
+            File.WriteAllText(Path.Combine(scriptsDir, "run.py"), scriptContent);
+        }
+    }
+
+    [Fact]
+    public void HashSkillFolder_SameContentTwice_SameHash()
+    {
+        WriteSkill("skill-a", "---\nname: skill-a\n---\nBody", "resource text", "script text");
+        var dir = Path.Combine(_root, "skill-a");
+
+        var h1 = SkillContentHasher.HashSkillFolder(dir);
+        var h2 = SkillContentHasher.HashSkillFolder(dir);
+
+        Assert.Equal(h1, h2);
+    }
+
+    [Fact]
+    public void HashSkillFolder_ResourceContentChanged_DifferentHash_EvenThoughNameUnchanged()
+    {
+        // The whole point of this hasher: a resource file's CONTENT changing must be caught, even though
+        // its NAME (what SkillManifestPoisoningGate.Fingerprint alone would see) never changed.
+        WriteSkill("skill-a", "---\nname: skill-a\n---\nBody", "original resource text");
+        var dir = Path.Combine(_root, "skill-a");
+        var before = SkillContentHasher.HashSkillFolder(dir);
+
+        File.WriteAllText(Path.Combine(dir, "resources", "policy.md"), "TAMPERED resource text");
+        var after = SkillContentHasher.HashSkillFolder(dir);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void HashSkillFolder_ScriptContentChanged_DifferentHash()
+    {
+        WriteSkill("skill-a", "---\nname: skill-a\n---\nBody", scriptContent: "print('hi')");
+        var dir = Path.Combine(_root, "skill-a");
+        var before = SkillContentHasher.HashSkillFolder(dir);
+
+        File.WriteAllText(Path.Combine(dir, "scripts", "run.py"), "print('PWNED')");
+        var after = SkillContentHasher.HashSkillFolder(dir);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void HashSkillFolder_SkillMdBodyChanged_DifferentHash()
+    {
+        WriteSkill("skill-a", "---\nname: skill-a\n---\nOriginal body");
+        var dir = Path.Combine(_root, "skill-a");
+        var before = SkillContentHasher.HashSkillFolder(dir);
+
+        File.WriteAllText(Path.Combine(dir, "SKILL.md"), "---\nname: skill-a\n---\nChanged body");
+        var after = SkillContentHasher.HashSkillFolder(dir);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void HashSkillFolder_TwoDifferentSkillsWithIdenticalContent_SameHash()
+    {
+        WriteSkill("skill-a", "---\nname: same\n---\nBody", "res");
+        WriteSkill("skill-b", "---\nname: same\n---\nBody", "res");
+
+        var h1 = SkillContentHasher.HashSkillFolder(Path.Combine(_root, "skill-a"));
+        var h2 = SkillContentHasher.HashSkillFolder(Path.Combine(_root, "skill-b"));
+
+        Assert.Equal(h1, h2);
+    }
+
+    [Fact]
+    public void HashSkillFolder_NonExistentDirectory_Throws()
+    {
+        Assert.Throws<DirectoryNotFoundException>(() =>
+            SkillContentHasher.HashSkillFolder(Path.Combine(_root, "does-not-exist")));
+    }
+
+    [Fact]
+    public void HashSkillFolder_AddingAFile_ChangesHash()
+    {
+        WriteSkill("skill-a", "---\nname: skill-a\n---\nBody");
+        var dir = Path.Combine(_root, "skill-a");
+        var before = SkillContentHasher.HashSkillFolder(dir);
+
+        var resourcesDir = Path.Combine(dir, "resources");
+        Directory.CreateDirectory(resourcesDir);
+        File.WriteAllText(Path.Combine(resourcesDir, "new-file.md"), "brand new");
+        var after = SkillContentHasher.HashSkillFolder(dir);
+
+        Assert.NotEqual(before, after);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Wave 1 of `Wave-1-2-3-Implementation-Plan-2026-07-16.md` §1 — the largest of the 5 autonomous streams (plan doc's own estimate: 6-8 dev-days).

1. **Baseline ledger** — `SkillContentHasher` (genuinely new: full file-content hash, sorted-by-path, reusing `ManifestFingerprint.Hash`) + `SkillBaselineEntry`/`SkillBaselineSnapshot` (carries both the content hash AND `SkillManifestPoisoningGate.Fingerprint`'s structural hash — they catch different drift) + `ISkillBaselineStore`/`JsonFileSkillBaselineStore` (a **sibling** of `AgentEval.Memory`'s `JsonFileBaselineStore` — reuses the pattern, not the type, exactly as the plan doc predicted was viable).
2. **CLI** — `skills scan --write-baseline [--baseline-root <dir>]`, `skills scan --repo` (multi-convention repo-wide discovery, one merged report), `skills baseline list|diff|history` (diff reuses `ManifestDriftDetector` directly — zero new comparer code — with a "cry wolf on cosmetic edits" guard).
3. **Repo-wide discovery** — `AgentSkillDirectoryConventions` (an owned seed list), consumed by `--repo`. Zero changes to `SkillComplianceValidator`/`MafSkillScanner`'s validation path.
4. **Provenance pointer** — `SkillComplianceReportRenderer` gains an optional, null-safe `provenanceByName` parameter (backward compatible). No `skills-lock.json` parser exists yet (correctly out of Wave 1 scope) — the wiring is real and tested with hand-built fixtures.

`MafSkillScanner.ScanFileSkillsAsync` is now a thin wrapper over a new `ScanFileSkillsWithInfoAsync` (returns each skill's absolute folder path too) — zero behavior change, confirmed by the full pre-existing `MafSkillScannerTests` suite passing unmodified.

## Judgment calls (plan doc left these open)

- `SkillBaselineEntry.ContentHash` is nullable — non-file-sourced skills have no folder to hash; the plan doc's sketch didn't address this.
- `JsonFileSkillBaselineStore` filenames include both the timestamp AND the snapshot Id — the plan doc's own Id-field rationale ("timestamps alone can collide on fast test runs") applies equally to the filename.
- `--repo` renders ONE merged report (not a new JSON schema); the per-convention breakdown goes to stderr, keeping `--format`'s output shape identical with or without `--repo`.
- `skills baseline history` reports every change point chronologically, not just the first (the plan doc's literal text) — more useful for a command named "history," no more complex to implement.

## Self-review found and fixed a real bug before commit

A doc-comment placement error in `MafSkillScanner.cs`: two new record types' XML doc comments were inserted with no blank line separating them from the existing `MafSkillScanner` class's own doc block, silently mis-associating documentation between types. **The C# compiler does not error or warn on this** — confirmed only by inspecting the generated XML doc file directly before and after the fix. Also removed one piece of dead/unreachable code in `DiffAsync` found during review.

## Test plan
- [x] `MafScanAntiPatterns` clean on both touched MAF files
- [x] `dotnet build AgentEval.sln -c Release` — 0 errors (net8/9/10)
- [x] Full net8.0 test suite: **7732 passed, 1 skipped (manual/live), 0 failed** (+91 new tests)
- [x] Verified the doc-comment fix directly against the generated XML doc file (not just "build succeeds")

🤖 Generated with [Claude Code](https://claude.com/claude-code)