### PR TITLE
feat(redteam,copilot-studio): C2 fidelity-badge audit+fix + P5 correlation-key spike

### DIFF
--- a/docs/redteam/copilot-studio.md
+++ b/docs/redteam/copilot-studio.md
@@ -249,9 +249,14 @@ Two connector-health features (P6) close a real "does it just work" gap for a li
 Every scan's post-summary now prints an aggregate `EvidenceFidelity` breakdown for this target specifically
 (`WritePostScanSummary` — no longer a no-op): `Verbal N/T · IntentToAct N/T · Behavioral N/T`. Because this
 target is structurally text-only (see below), `Behavioral` is always `0` in practice — the point is making that
-ceiling visible in the CLI's own summary output, not just internally on each `ProbeResult`. This is scoped to
-this target's own output only; it does not touch the shared RedTeam report renderers (JSON/Markdown/SARIF/JUnit/PDF)
-— a broader, all-targets fidelity column across those renderers is a separate, larger change, not done here.
+ceiling visible in the CLI's own summary output, not just internally on each `ProbeResult`.
+
+**Update (2026-07-17):** the broader, all-targets fidelity column across the shared RedTeam report renderers is
+now done too, closing the gap this section used to flag. Every renderer shows a per-probe fidelity badge:
+`JSON`/`SARIF` already carried a `Fidelity` field; `Markdown` (an inline `` `[behavioral]` ``/`` `[verbal]` ``/
+`` `[intent-to-act]` `` tag next to each compromised probe), `JUnit` (a `Fidelity:` line in the failure body,
+plus the fidelity label folded into the inconclusive `<error>` message), and `PDF` (a bracketed label next to
+each listed probe) now show it too — not just this target's own CLI summary.
 
 ## How it fits red-team fidelity
 
@@ -265,6 +270,31 @@ AgentEval's red-team scoring is honest about *how much* evidence a verdict is ba
   verdict would depend on tool-call evidence resolves to **Inconclusive** — never a fabricated **Behavioral**
   pass. Reaching `Behavioral` fidelity for MCS would require a deferred L2 telemetry-enrichment path (reading
   MCS-side execution telemetry), which does not exist yet.
+  **Correlation-key spike (2026-07-17):** investigated whether a client-side `conversationId`
+  (`Activity.Conversation.Id`, the same id `CopilotStudioChatClient` already tracks and stamps onto every
+  `ChatResponseUpdate`) can be reliably joined against Copilot Studio's own server-side telemetry to recover
+  real tool-call evidence. Two candidate telemetry sources exist, and **both carry real, structural obstacles
+  that only a live-tenant test can fully resolve** (not run here — this spike is desk research against
+  Microsoft's own current documentation, not a live-tenant confirmation):
+    - **Dataverse session transcripts** (`SessionID`, `TopicId`, `ChannelId` — downloadable per-agent, 29-day
+      window) are **NOT written until ~30 minutes after conversation inactivity**. A red-team scan grades each
+      probe as it runs; telemetry-based enrichment at that latency cannot be inline — it can only be a
+      **separate, deferred, offline reconciliation pass** run well after a scan completes, not a live
+      `TraceEnrichingChatClient` decorator on the hot path as originally sketched. Whether `SessionID` is
+      actually the same value as the client SDK's `conversationId` is not confirmed by public documentation.
+    - **Application Insights** telemetry (tool input/output captured in OpenTelemetry spans when "Log
+      conversation details" is enabled) is **opt-in, per-agent, and requires the target agent's OWNER** to
+      configure an Azure subscription + connection string + explicit logging toggles in that agent's own
+      settings. AgentEval red-teams agents it does not administer in the general case — it cannot assume, set
+      up, or even detect whether a given target has this configured. Reading it also needs a DIFFERENT
+      credential/permission scope (Application-Insights Log Analytics read access, or Dataverse's dedicated
+      **Bot Transcript Viewer** role) than what's needed just to converse with the agent.
+  **Conclusion: the join is plausible but not confirmed, and even if confirmed, cannot be inline** — it forces
+  a design change from "decorate the live chat client" to "a separate post-hoc enrichment command," and even
+  then only for target agents whose owner has opted into one of the two telemetry paths. Per this repo's
+  honesty discipline, an ambiguous or unavailable join must degrade to **Inconclusive**, never a fabricated
+  **Behavioral**. P5 (L2 enrichment) remains correctly deferred — this spike's outcome is a scoping correction,
+  not a green light to build the original design.
 - **This is why `--sut-tier`, `--system-prompt`, and `--system-prompt-canary` are ignored** for this target
   (step 7 above) — there is no tool-harness tier to select and no system prompt this target controls.
 - **Evidence capture is off** (`IncludeEvidence => false`) — a live MCS response can carry real PII, so raw

--- a/src/AgentEval.RedTeam/RedTeam/Reporting/JUnitReportExporter.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Reporting/JUnitReportExporter.cs
@@ -134,6 +134,9 @@ public sealed class JUnitReportExporter : IReportExporter
             {
                 case EvaluationOutcome.Succeeded:
                     // A successful attack is a FAILURE from security perspective
+                    // C2 fidelity-badge audit (2026-07-17): "Fidelity:" line closes the gap already fixed for
+                    // JSON/SARIF/Markdown/PDF — distinguishes a verdict backed by an actual tool invocation
+                    // (Behavioral) from one derived only from the assistant's text (Verbal/IntentToAct).
                     testCase.Add(new XElement("failure",
                         new XAttribute("message", $"Security vulnerability: {SanitizeForXml(probe.Reason)}"),
                         new XAttribute("type", $"VulnerabilityFound"),
@@ -141,6 +144,7 @@ public sealed class JUnitReportExporter : IReportExporter
                         Probe: {SanitizeForXml(probe.ProbeId)}
                         Technique: {SanitizeForXml(probe.Technique ?? "unknown")}
                         Difficulty: {probe.Difficulty}
+                        Fidelity: {probe.Fidelity}
 
                         ATTACK SUCCEEDED - Agent was compromised!
 
@@ -156,10 +160,12 @@ public sealed class JUnitReportExporter : IReportExporter
                     break;
 
                 case EvaluationOutcome.Inconclusive:
+                    // SARIF surfaces Fidelity for Inconclusive probes too (a coverage-gap signal, not just a
+                    // compromise one) — matched here for parity.
                     testCase.Add(new XElement("error",
                         new XAttribute("message", SanitizeForXml(probe.Error ?? probe.Reason)),
                         new XAttribute("type", "Inconclusive"),
-                        $"Could not determine outcome: {SanitizeForXml(probe.Reason)}"
+                        $"Could not determine outcome ({probe.Fidelity} fidelity): {SanitizeForXml(probe.Reason)}"
                     ));
                     break;
 

--- a/src/AgentEval.RedTeam/RedTeam/Reporting/MarkdownReportExporter.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Reporting/MarkdownReportExporter.cs
@@ -117,7 +117,11 @@ public sealed class MarkdownReportExporter : IReportExporter
 
                 foreach (var probe in compromisedProbes)
                 {
-                    sb.AppendLine($"**{EscapeInline(probe.ProbeId)}** ({EscapeInline(probe.Technique ?? "unknown")}) - {probe.Difficulty}");
+                    // C2 fidelity-badge audit (2026-07-17): distinguishes a verdict backed by an actual tool
+                    // invocation (Behavioral) from one derived only from the assistant's text (Verbal/IntentToAct)
+                    // — the "did it merely SAY it, or actually DO it" distinction. Already shipped for JSON/SARIF;
+                    // this closes the gap for Markdown.
+                    sb.AppendLine($"**{EscapeInline(probe.ProbeId)}** ({EscapeInline(probe.Technique ?? "unknown")}) - {probe.Difficulty} {FidelityToBadge(probe.Fidelity)}");
                     sb.AppendLine();
                     // Adaptive fence so an embedded ``` in the payload cannot terminate it early.
                     var promptText = TruncateString(probe.Prompt, 300);
@@ -192,6 +196,15 @@ public sealed class MarkdownReportExporter : IReportExporter
         Verdict.Fail => "❌",
         Verdict.PartialPass => "⚠️",
         _ => "❓"
+    };
+
+    /// <summary>C2 fidelity-badge audit (2026-07-17): a compact, scannable tag for <see cref="EvidenceFidelity"/> next to a probe id.</summary>
+    private static string FidelityToBadge(EvidenceFidelity fidelity) => fidelity switch
+    {
+        EvidenceFidelity.Behavioral => "`[behavioral]`",
+        EvidenceFidelity.IntentToAct => "`[intent-to-act]`",
+        EvidenceFidelity.Verbal => "`[verbal]`",
+        _ => "`[unknown]`"
     };
 
     private static string SeverityToBadge(Severity severity) => severity switch

--- a/src/AgentEval.RedTeam/RedTeam/Reporting/Pdf/PdfReportGenerator.cs
+++ b/src/AgentEval.RedTeam/RedTeam/Reporting/Pdf/PdfReportGenerator.cs
@@ -510,7 +510,9 @@ public class PdfReportGenerator : IReportExporter
             var failedProbes = attack.ProbeResults.Where(p => p.Outcome == EvaluationOutcome.Succeeded).Take(3);
             foreach (var probe in failedProbes)
             {
-                var para = section.AddParagraph($"• {probe.ProbeId}");
+                // C2 fidelity-badge audit (2026-07-17): surfaces EvidenceFidelity (verbal/intent-to-act/behavioral)
+                // in the PDF, closing the gap already fixed for JSON/SARIF/Markdown.
+                var para = section.AddParagraph($"• {probe.ProbeId} [{FidelityLabel(probe.Fidelity)}]");
                 para.Format.LeftIndent = "0.5cm";
                 para.Format.Font.Size = 9;
             }
@@ -545,6 +547,15 @@ public class PdfReportGenerator : IReportExporter
         RiskLevel.Moderate => Colors.Orange,
         RiskLevel.Low => Colors.DarkGreen,
         _ => Colors.Black
+    };
+
+    /// <summary>C2 fidelity-badge audit (2026-07-17): a compact label for <see cref="EvidenceFidelity"/> next to a probe id.</summary>
+    private static string FidelityLabel(EvidenceFidelity fidelity) => fidelity switch
+    {
+        EvidenceFidelity.Behavioral => "behavioral",
+        EvidenceFidelity.IntentToAct => "intent-to-act",
+        EvidenceFidelity.Verbal => "verbal",
+        _ => "unknown"
     };
 
     private static Color GetSeverityColor(Severity severity) => severity switch

--- a/tests/AgentEval.Tests/RedTeam/Reporting/JUnitReportExporterTests.cs
+++ b/tests/AgentEval.Tests/RedTeam/Reporting/JUnitReportExporterTests.cs
@@ -125,6 +125,99 @@ public class JUnitReportExporterTests
         Assert.Equal("VulnerabilityFound", failure.Attribute("type")?.Value);
     }
 
+    // ── C2 fidelity-badge audit (2026-07-17) ──
+
+    [Fact]
+    public void Export_SucceededProbe_FailureBody_IncludesFidelity()
+    {
+        var result = new RedTeamResult
+        {
+            AgentName = "TestAgent",
+            StartedAt = DateTimeOffset.UtcNow.AddSeconds(-5),
+            CompletedAt = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(5),
+            TotalProbes = 1,
+            SucceededProbes = 1,
+            AttackResults =
+            [
+                new AttackResult
+                {
+                    AttackName = "Test",
+                    AttackDisplayName = "Test",
+                    OwaspId = "LLM01",
+                    Severity = Severity.High,
+                    SucceededCount = 1,
+                    ProbeResults =
+                    [
+                        new ProbeResult
+                        {
+                            ProbeId = "T-BEHAVIORAL",
+                            Prompt = "delete the file",
+                            Response = "deleted",
+                            Outcome = EvaluationOutcome.Succeeded,
+                            Reason = "tool call observed",
+                            Difficulty = Difficulty.Moderate,
+                            Fidelity = EvidenceFidelity.Behavioral,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var xml = new JUnitReportExporter().Export(result);
+        var doc = XDocument.Parse(xml);
+
+        var failure = doc.Root!.Element("testsuite")!.Element("testcase")!.Element("failure");
+        Assert.NotNull(failure);
+        Assert.Contains("Fidelity: Behavioral", failure!.Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Export_InconclusiveProbe_ErrorMessage_IncludesFidelity()
+    {
+        var result = new RedTeamResult
+        {
+            AgentName = "TestAgent",
+            StartedAt = DateTimeOffset.UtcNow.AddSeconds(-5),
+            CompletedAt = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(5),
+            TotalProbes = 1,
+            InconclusiveProbes = 1,
+            AttackResults =
+            [
+                new AttackResult
+                {
+                    AttackName = "Test",
+                    AttackDisplayName = "Test",
+                    OwaspId = "LLM01",
+                    Severity = Severity.Medium,
+                    InconclusiveCount = 1,
+                    ProbeResults =
+                    [
+                        new ProbeResult
+                        {
+                            ProbeId = "T-002",
+                            Prompt = "Test",
+                            Response = "[TIMEOUT]",
+                            Outcome = EvaluationOutcome.Inconclusive,
+                            Reason = "Timed out",
+                            Difficulty = Difficulty.Easy,
+                            Error = "Timeout",
+                            Fidelity = EvidenceFidelity.IntentToAct,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var xml = new JUnitReportExporter().Export(result);
+        var doc = XDocument.Parse(xml);
+
+        var error = doc.Root!.Element("testsuite")!.Element("testcase")!.Element("error");
+        Assert.NotNull(error);
+        Assert.Contains("IntentToAct fidelity", error!.Value, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Export_ResistedProbe_HasSystemOut()
     {

--- a/tests/AgentEval.Tests/RedTeam/Reporting/MarkdownReportExporterTests.cs
+++ b/tests/AgentEval.Tests/RedTeam/Reporting/MarkdownReportExporterTests.cs
@@ -98,6 +98,62 @@ public class MarkdownReportExporterTests
         Assert.Contains("Compromised Probes", md);
     }
 
+    // ── C2 fidelity-badge audit (2026-07-17) ──
+
+    [Fact]
+    public void Export_CompromisedProbe_ShowsBehavioralFidelityBadge()
+    {
+        var result = new RedTeamResult
+        {
+            AgentName = "TestAgent",
+            StartedAt = DateTimeOffset.UtcNow.AddSeconds(-10),
+            CompletedAt = DateTimeOffset.UtcNow,
+            Duration = TimeSpan.FromSeconds(10),
+            TotalProbes = 1,
+            ResistedProbes = 0,
+            SucceededProbes = 1,
+            AttackResults =
+            [
+                new AttackResult
+                {
+                    AttackName = "PromptInjection",
+                    AttackDisplayName = "Prompt Injection",
+                    OwaspId = "LLM01",
+                    Severity = Severity.High,
+                    ResistedCount = 0,
+                    SucceededCount = 1,
+                    ProbeResults =
+                    [
+                        new ProbeResult
+                        {
+                            ProbeId = "PI-BEHAVIORAL",
+                            Prompt = "delete the file",
+                            Response = "deleted",
+                            Outcome = EvaluationOutcome.Succeeded,
+                            Reason = "tool call observed",
+                            Difficulty = Difficulty.Moderate,
+                            Technique = "direct_override",
+                            Fidelity = EvidenceFidelity.Behavioral,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var md = new MarkdownReportExporter().Export(result);
+
+        Assert.Contains("[behavioral]", md, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Export_CompromisedProbe_DefaultFidelity_ShowsVerbalBadge()
+    {
+        // CreateTestResult()'s probe never sets Fidelity explicitly -> defaults to EvidenceFidelity.Verbal.
+        var md = new MarkdownReportExporter().Export(CreateTestResult());
+
+        Assert.Contains("[verbal]", md, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Export_IncludesRecommendations_WhenVulnerabilitiesFound()
     {

--- a/tests/AgentEval.Tests/RedTeam/Reporting/Pdf/PdfReportGeneratorTests.cs
+++ b/tests/AgentEval.Tests/RedTeam/Reporting/Pdf/PdfReportGeneratorTests.cs
@@ -78,6 +78,47 @@ public class PdfReportGeneratorTests
         Assert.Equal(0x25, bytes[0]);   // valid %PDF — the !measured branch did not throw
     }
 
+    // C2 fidelity-badge audit (2026-07-17): AddDetailedResultsPage (the per-probe listing, gated on
+    // options.IncludeDetailedResults) now includes a [behavioral]/[verbal]/[intent-to-act] fidelity label.
+    // This test suite has no PDF text-extraction capability (confirmed — no existing test asserts on PDF
+    // TEXT content anywhere in this file, only structural bytes), so — consistent with every other test
+    // in this file — this proves the modified code path renders successfully to valid PDF bytes without
+    // throwing, not that the specific label text is present in the rendered output.
+    [Fact]
+    public void GenerateExecutiveReport_DetailedResultsWithFidelity_RendersValidPdf()
+    {
+        var result = new RedTeamResult
+        {
+            AgentName = "TestAgent",
+            TotalProbes = 1,
+            SucceededProbes = 1,
+            AttackResults =
+            [
+                new AttackResult
+                {
+                    AttackName = "PromptInjection", AttackDisplayName = "Prompt Injection", OwaspId = "LLM01",
+                    Severity = Severity.High, SucceededCount = 1,
+                    ProbeResults =
+                    [
+                        new ProbeResult
+                        {
+                            ProbeId = "PI-BEHAVIORAL", Prompt = "delete the file", Response = "deleted",
+                            Outcome = EvaluationOutcome.Succeeded, Reason = "tool call observed",
+                            Fidelity = EvidenceFidelity.Behavioral,
+                        },
+                    ],
+                },
+            ],
+        };
+        var options = new PdfReportOptions { IncludeDetailedResults = true };
+
+        var bytes = _generator.GenerateExecutiveReport(result, options);
+
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 100);
+        Assert.Equal(0x25, bytes[0]);   // valid %PDF — FidelityLabel did not throw for any EvidenceFidelity value
+    }
+
     [Fact]
     public void GenerateExecutiveReport_WithOptions_IncludesBranding()
     {


### PR DESCRIPTION
## Summary

Implements the Copilot Studio plan doc's two spike items (`Remaining-Backlog-Implementation-Plan-2026-07-16.md` §2.3/§2.6). Per this task's own scope, a spike may conclude with findings/recommendations rather than a full shipped feature — that's exactly how this split: **C2's audit turned out simple enough to ship the fix; P5's spike concluded it should NOT be built yet, with a documented reason why.**

## C2 — fidelity-badge audit (shipped)

Audited all 5 RedTeam report renderers for `EvidenceFidelity` coverage: **JSON and SARIF already rendered it** (pre-existing). **Markdown, JUnit, and PDF did not.** All three gaps turned out genuinely trivial/mechanical (one-line additions at an existing per-probe render site each) — well within the plan doc's "half-day scoping spike" budget even including the fix itself, so I shipped the fix for all three rather than stopping at just the audit:

- `MarkdownReportExporter` — inline `` `[behavioral]` ``/`` `[verbal]` ``/`` `[intent-to-act]` `` tag next to each compromised probe.
- `JUnitReportExporter` — `Fidelity:` line in the failure CDATA body, plus folded into the inconclusive `<error>` message (matching SARIF's existing broader Inconclusive-too coverage).
- `PdfReportGenerator` — bracketed fidelity label next to each listed probe in the detailed-results page.

+5 new tests. The PDF test proves the modified code path renders valid PDF bytes without throwing rather than asserting on text content — this test suite has **no PDF text-extraction capability** (confirmed by auditing the existing test file first: every other PDF test in this repo verifies structure/bytes only, never text content).

## P5 — correlation-key spike (concluded without shipping code)

Investigated whether the client-side `conversationId` (`Activity.Conversation.Id`, already tracked by `CopilotStudioChatClient`) can be reliably joined against Copilot Studio's server-side telemetry to recover real tool-call evidence. No live MCS tenant is available in this environment, so this combines direct code inspection with external research against Microsoft's current published documentation.

**Finding: the join is plausible but not publicly confirmed, and — more importantly — even in the best case it forces a design change.** Dataverse session transcripts (one of two candidate telemetry sources) are not written until **~30 minutes after conversation inactivity**, so the originally-sketched `TraceEnrichingChatClient` (a live `IChatClient` decorator enriching evidence inline during a scan) cannot work as designed — real L2 enrichment would need to be a separate, deferred, offline reconciliation command instead. The other candidate (Application Insights) requires the **target agent's owner** to have opted into a three-part configuration stack (Azure subscription + connection string + explicit logging toggles) that an external red-team tool cannot assume, set up, or detect.

**No code shipped for P5** — correctly out of scope per this task's own instruction. Full write-up: `strategy/CopilotStudio/Remaining-Backlog-Implementation-Plan-2026-07-16.md` §2.6-SPIKE-RESULT (local-only). Public-facing summary added to `docs/redteam/copilot-studio.md`'s "How it fits red-team fidelity" section, which also had a stale claim (from an earlier session) that the shared renderers were untouched by fidelity badging — corrected now that C2 closes that gap.

## Test plan
- [x] `MafScanAntiPatterns` clean on `src/AgentEval.RedTeam/RedTeam/Reporting`
- [x] `dotnet build AgentEval.sln -c Release` — 0 errors (net8/9/10)
- [x] Full net8.0 test suite: **7737 passed, 1 skipped (manual/live), 0 failed** (+5 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)