### PR TITLE
docs: Feature Maturity table + [Experimental] attrs on volatile Gatekeeper types

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,22 @@ Every evidence document is cryptographically chained to its source run; `agentev
 
 ---
 
+## Feature Maturity
+
+AgentEval ships as a single lockstep-versioned package (see [Installation](#installation)) — there is no per-package version to signal maturity the way some multi-package frameworks do. Instead, maturity is tracked per front, here, plus `[Experimental]` attributes on individual volatile APIs (compiler-enforced — referencing one without acknowledging it is a build **error**, not just a warning).
+
+| Front | Maturity | Why |
+|---|---|---|
+| Core eval (assertions, RAG metrics, LLM-as-judge, benchmarks, exporters) | **GA-track** | Stable since early releases, no breaking changes across this project's history, the foundation every other front builds on. |
+| RedTeam core (OWASP LLM Top 10, attacks/probes, Composite Judges) | **GA-track** | Feature-complete for its stated scope; remaining backlog items are additive, not destabilizing to what's shipped. |
+| Compliance benchmarks (GDPR, EU AI Act) | **GA-track** | Calibrated, stable, reproducible evidence figures. |
+| **Gatekeeper** (runtime enforcement) | **Beta** | The most differentiated subsystem and heavily tested (multiple calibrated judge axes) — but also the one still absorbing breaking API changes as it stabilizes. Real, valuable, actively evolving — exactly what "beta" means. A handful of the newest types are individually marked `[Experimental]`. |
+| Agent Skills | **Beta** | Genuinely shipped and tested, but depends on a very recently-GA'd upstream (MAF Agent Skills) and is still actively growing. |
+| Copilot Studio | **Experimental** | The connector has not yet been verified against a real tenant. |
+| Mission Control | **Experimental** | Real and functioning, but with acknowledged gaps and comparatively less investment than Core/RedTeam. |
+
+---
+
 ## Installation
 
 ```bash

--- a/src/AgentEval.Core/Guardrails/Judges/GatekeeperFleetHealthIndex.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/GatekeeperFleetHealthIndex.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AgentEval.Guardrails.Judges;
 
 /// <summary>
@@ -13,7 +15,11 @@ namespace AgentEval.Guardrails.Judges;
 /// <para>High value for an ops/Mission-Control surface once one exists (Mission Control's compliance-matrix
 /// GraphQL layer is a real, live precedent for exactly this kind of cross-cutting health surface) — this type
 /// itself is transport-agnostic, no MC/CLI dependency.</para>
+/// <para><b>Experimental:</b> shipped 2026-07-17, no real-world consumer yet (no CLI verb, no Mission Control
+/// wiring) — the shape may still change once one exists. Suppress via
+/// <c>&lt;NoWarn&gt;$(NoWarn);AGENTEVAL_GATEKEEPER_PREVIEW001&lt;/NoWarn&gt;</c> once you've read this note.</para>
 /// </summary>
+[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]
 public static class GatekeeperFleetHealthIndex
 {
     /// <summary>
@@ -84,6 +90,7 @@ public static class GatekeeperFleetHealthIndex
 /// <param name="StaleAxes">Axes whose report is older than the caller-supplied staleness threshold — informational, does not affect the means.</param>
 /// <param name="NeverCalibratedAxes">Axes with no report at all.</param>
 /// <param name="Explanation">Human-readable summary — states plainly which axes were/weren't measured, never silently treats a missing axis as passing.</param>
+[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]
 public sealed record GatekeeperFleetHealthReport(
     IReadOnlyDictionary<string, CalibrationReport?> ReportsByAxis,
     double? MeanDecisiveAccuracy,

--- a/src/AgentEval.Core/Guardrails/Judges/ICalibrationReportStore.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/ICalibrationReportStore.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AgentEval.Guardrails.Judges;
 
 /// <summary>
@@ -12,7 +14,10 @@ namespace AgentEval.Guardrails.Judges;
 /// "what does this axis look like right now," not a time series. (A full multi-snapshot history ledger is a
 /// separate, larger feature — see the Agent Skills baseline ledger for that shape, deliberately NOT
 /// duplicated here.)
+/// <para><b>Experimental:</b> shipped 2026-07-17, no real-world consumer yet — see
+/// <see cref="GatekeeperFleetHealthIndex"/>'s own experimental note.</para>
 /// </summary>
+[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]
 public interface ICalibrationReportStore
 {
     /// <summary>

--- a/src/AgentEval.Core/Guardrails/Judges/JsonFileCalibrationReportStore.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JsonFileCalibrationReportStore.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using AgentEval.Guardrails;
@@ -20,7 +21,10 @@ namespace AgentEval.Guardrails.Judges;
 /// (<c>AgentEval.Core</c>) — this store lives in the SAME assembly/namespace specifically so it can
 /// reconstruct a report directly from persisted data via that constructor, rather than needing a public
 /// settable-everything shape on the type callers actually consume.</para>
+/// <para><b>Experimental:</b> shipped 2026-07-17, no real-world consumer yet — see
+/// <see cref="ICalibrationReportStore"/>'s own experimental note.</para>
 /// </summary>
+[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]
 public sealed partial class JsonFileCalibrationReportStore : ICalibrationReportStore
 {
     private readonly string _rootPath;

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeAnomalyGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeAnomalyGate.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace AgentEval.MAF.Gatekeeper;
 
 /// <summary>
@@ -16,7 +18,11 @@ namespace AgentEval.MAF.Gatekeeper;
 /// <para><b>v1 (this gate): fixed-multiplier-per-tool, no real statistics.</b> Cheap, deterministic, no
 /// statistics library needed — a true rolling mean/stddev or median-absolute-deviation is deferred as a
 /// documented v2 follow-on (more robust to the first few calls skewing a small-N mean), not built here.</para>
+/// <para><b>Experimental:</b> shipped 2026-07-17 as v1 of a heuristic its own doc comment already flags as
+/// likely to be superseded by a real-statistics v2 — the detection approach, not just the implementation, may
+/// still change.</para>
 /// </summary>
+[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]
 public sealed class ToolResultSizeAnomalyGate : IToolResultGate
 {
     /// <summary>Default: a result &gt; 5x this tool's own running average this run is flagged.</summary>

--- a/tests/AgentEval.Tests/AgentEval.Tests.csproj
+++ b/tests/AgentEval.Tests/AgentEval.Tests.csproj
@@ -4,6 +4,11 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Tests deliberately exercise [Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]-marked Gatekeeper
+         next-wave types (GatekeeperFleetHealthIndex, ICalibrationReportStore, JsonFileCalibrationReportStore,
+         ToolResultSizeAnomalyGate) — the diagnostic is error-severity by design, so this suppression is a
+         deliberate acknowledgment, not a blanket warning bypass. -->
+    <NoWarn>$(NoWarn);AGENTEVAL_GATEKEEPER_PREVIEW001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds a **Feature Maturity** table to the README (GA-track / Beta / Experimental per front: Core eval, RedTeam core, Compliance = GA-track; Gatekeeper, Agent Skills = Beta; Copilot Studio, Mission Control = Experimental) — signals maturity without a packaging restructure, since the repo ships one lockstep-versioned package.
- Marks the 4 newest, least-proven Gatekeeper types `[Experimental("AGENTEVAL_GATEKEEPER_PREVIEW001")]`: `GatekeeperFleetHealthIndex` (+ its report record), `ICalibrationReportStore`, `JsonFileCalibrationReportStore`, `ToolResultSizeAnomalyGate`. This is a real .NET 8+ BCL mechanism — the compiler emits an **error** (not warning) for any unsuppressed reference, forcing deliberate opt-in.
- Suppresses the diagnostic in `AgentEval.Tests.csproj`, since the test project legitimately exercises these types.

Pre-1.0 polish requested ahead of today's release — see `strategy/AgentEval-Core-GA-and-Subsystem-Maturity-Model-2026-07-17.md` for the full comparison of this (lightweight) approach vs. MAF's literal per-package maturity model.

## Test plan
- [x] `dotnet build AgentEval.sln` — 0 errors across net8.0/net9.0/net10.0
- [x] Full `net8.0` test suite: 7737 passed, 0 failed, 1 skipped
- [x] Confirmed no other project in the solution references the newly-experimental types outside the test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)