### PR TITLE
fix(missioncontrol): stop hard-coding "Mode A" when the server reports otherwise

### DIFF
--- a/docs/missioncontrol/getting-started.md
+++ b/docs/missioncontrol/getting-started.md
@@ -1,6 +1,9 @@
 # AgentEval Mission Control — Getting Started
 
-> **Status**: Phase 1 — local viewer + workspace aggregator (target v1.2–v1.4). Mode C self-hosted server is Phase 2 (target v1.5).
+> **Status**: Phase 1 — local viewer (Mode A) is shipped and what `agenteval mc serve` gives you today.
+> Mode B (multi-workspace aggregator) and Mode C (self-hosted server) are both **not yet built** — see the
+> Deployment Modes table below. `--workspace <path>` today only re-points the single workspace root Mode A
+> reads from; it does not aggregate multiple repos.
 
 Mission Control is the visualisation, aggregation, and governance layer on top of `.agenteval/`. This guide gets you a working portal in under 30 seconds against a populated solution.
 

--- a/src/AgentEval.MissionControl.Spa/src/components/AppShell.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { LayoutDashboard, ShieldCheck, ListChecks, Activity, History, Swords } from "lucide-react";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { gqlRequest } from "@/lib/graphql-client";
+import { fetchVersion, formatModeLabel } from "@/lib/rest-client";
 import { queryKeys } from "@/lib/keys";
 import { WorkspaceLandingPage } from "@/pages/WorkspaceLandingPage";
 
@@ -86,6 +87,16 @@ export function AppShell() {
 }
 
 function Header() {
+  // portal-review A16: this used to hard-code "Mode A — Local viewer" regardless of what mode the
+  // server actually reported. Query the same /api/v1/version endpoint DashboardPage already uses
+  // (shared queryKeys.version() cache key, so this doesn't add an extra network round trip on pages
+  // that also render DashboardPage) and render the REAL mode. Show nothing until it resolves rather
+  // than guess — a wrong label is worse than a brief blank.
+  const versionQ = useQuery({
+    queryKey: queryKeys.version(),
+    queryFn: fetchVersion,
+  });
+
   return (
     <header className="border-b border-slate-200 bg-white px-6 py-3 flex items-center justify-between">
       <div className="flex items-center gap-2">
@@ -97,7 +108,7 @@ function Header() {
         </h1>
       </div>
       <span className="text-xs text-slate-500">
-        Mode A — Local viewer
+        {versionQ.data ? formatModeLabel(versionQ.data.mode) : ""}
       </span>
     </header>
   );

--- a/src/AgentEval.MissionControl.Spa/src/lib/rest-client.ts
+++ b/src/AgentEval.MissionControl.Spa/src/lib/rest-client.ts
@@ -24,6 +24,25 @@ export async function fetchVersion(): Promise<VersionInfo> {
 }
 
 /**
+ * Human-readable label for the deployment mode reported by `/api/v1/version` (`mode` field —
+ * `"local"` | `"aggregator"` | `"server"`, see McHost.cs). This is the ONE place that maps mode -> display
+ * text — components must never hard-code a mode label, since Mode B/C would then render as "Mode A" even
+ * when the server is honestly reporting otherwise (portal-review A16).
+ */
+export function formatModeLabel(mode: string): string {
+  switch (mode.toLowerCase()) {
+    case "local":
+      return "Mode A — Local viewer";
+    case "aggregator":
+      return "Mode B — Workspace aggregator";
+    case "server":
+      return "Mode C — Server";
+    default:
+      return mode;
+  }
+}
+
+/**
  * Agent trace shape served by `/api/v1/runs/{runId}/trace`. Matches the
  * canonical AgentTrace + TraceEvent records in
  * src/AgentEval.Abstractions/Output/IOutputStore.cs (camelCase via

--- a/src/AgentEval.MissionControl.Spa/src/pages/DashboardPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { gqlRequest } from "@/lib/graphql-client";
-import { fetchVersion } from "@/lib/rest-client";
+import { fetchVersion, formatModeLabel } from "@/lib/rest-client";
 import { queryKeys } from "@/lib/keys";
 import { DataState } from "@/components/DataState";
 import { SubjectCard, type SubjectCardData } from "@/components/SubjectCard";
@@ -127,7 +127,7 @@ export function DashboardPage() {
       <header>
         <h2 className="text-2xl font-bold text-slate-900">Dashboard</h2>
         <p className="text-sm text-slate-600">
-          AgentEval Mission Control — Mode A (local viewer).
+          AgentEval Mission Control{versionQ.data ? ` — ${formatModeLabel(versionQ.data.mode)}` : ""}.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary
- `AppShell.tsx`'s header badge and `DashboardPage.tsx`'s subtitle both hard-coded "Mode A — Local viewer" regardless of what `/api/v1/version`'s `mode` field actually reports (portal-review A16). The backend was fixed 2026-05-24 to report the true mode; the frontend never consumed it. Both now query the endpoint and render the real mode via a new shared `formatModeLabel()` helper in `rest-client.ts` — showing nothing rather than guessing while in flight.
- Fixes `docs/missioncontrol/getting-started.md`'s status banner, which claimed the workspace aggregator (Mode B) ships as part of Phase 1 — directly contradicting the same doc's own Deployment Modes table further down, which correctly says aggregation is deferred to Phase 2.
- Confirmed the CLI's `--workspace` help text was already accurate (describes re-pointing a single workspace root, never claimed aggregation) — no change needed there.

No behavior change to Mode B/C support — this only makes the UI/docs honest about the mode that's actually running, matching the standard already applied to Gatekeeper's `[Experimental]` work today.

## Test plan
- [x] `npm run build` (tsc -b && vite build) — clean, no type errors
- [x] Grepped for any remaining hard-coded "Mode A" UI strings — none found outside the new helper/comments
- [x] Confirmed CLI `--workspace` help text needed no change

🤖 Generated with [Claude Code](https://claude.com/claude-code)