### PR TITLE
feat(copilot-studio): --max-credits enforcement + Bench Tier 2 (gdpr/eu-ai-act) --sut wiring

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -590,12 +590,12 @@ The CLI's exit-code contract, so CI can branch on the outcome. Source of truth: 
 | `5` | `gatekeeper inspect` — a gate **Blocked** on real evidence. |
 | `6` | `gatekeeper inspect` — **fail-closed**: the CLI could not evaluate (e.g. a history gate with no `messages`). Not a policy block. |
 | `7` | `gatekeeper inspect` — **not certified**: the honesty guard refused an un-calibrated judge (run `calibrate --certify`, or pass `--allow-uncalibrated`). |
-| `8` | **Reserved** (not emitted yet) — `redteam --sut copilot-studio` will return this when a live scan hits the `--max-credits` Copilot Credit budget cap (BudgetExceeded). The live connector itself is wired (see [Copilot Studio](redteam/copilot-studio.md)), but `--max-credits` enforcement is not — the SDK exposes no credit-cost field to enforce against — so no current run can produce it. |
+| `8` | `redteam --sut copilot-studio` — a live scan hit its `--max-credits` cap (BudgetExceeded). Enforced as an ESTIMATE (turns counted, not metered spend — the SDK exposes no real credit-cost field); see [Copilot Studio](redteam/copilot-studio.md#what---max-credits-does-today). |
 
 `redteam` uses `1` for failure, `3` for runtime error, and `4` for a `--fail-on regression` gate. Code `8` is
-**reserved** for a live `--sut copilot-studio` scan that hits `--max-credits` (BudgetExceeded); `--max-credits`
-enforcement has no credit-cost signal to key off yet, so it is not emitted by any current run. `gatekeeper`'s
-`5/6/7` are deliberately distinct from the overloaded `2` — see [Gatekeeper from any language](gatekeeper-cli.md#exit-codes).
+returned by a live `--sut copilot-studio` scan that hits `--max-credits` (BudgetExceeded) — an estimate, not a
+metered value. `gatekeeper`'s `5/6/7` are deliberately distinct from the overloaded `2` — see
+[Gatekeeper from any language](gatekeeper-cli.md#exit-codes).
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -321,7 +321,7 @@ agenteval bench agentic calibrate [--root <path>] [--out <path>]
 - Compliance and agentic families support calibration helpers where available.
 - Family-specific options and presets are documented under [Benchmarks](benchmarks.md) and the family pages in the TOC.
 - For the Trace Fidelity and AutoAudit families, see the GlassBox docs under `docs/GlassBox/` (now linked in the TOC).
-- **`owasp`/`mitre`/`nist` reach a live target** beyond the default built-in stub / `--azure-from-env`: `--sut copilot-studio` (same flags as `eval`/`redteam`) or a generic `--endpoint <url> --model <name> [--api-key <key>]` OpenAI-compatible endpoint. `gdpr`/`eu-ai-act`/`agentic`/`memory`/`perf` do not have this yet.
+- **`owasp`/`mitre`/`nist` reach a live target** beyond the default built-in stub / `--azure-from-env`: `--sut copilot-studio` (same flags as `eval`/`redteam`) or a generic `--endpoint <url> --model <name> [--api-key <key>]` OpenAI-compatible endpoint. **`gdpr`/`eu-ai-act` also support `--sut copilot-studio`** (drives the live agent per-scenario instead of grading a static `--response`) — no generic `--endpoint` for these two yet. `agentic`/`memory`/`perf` do not have `--sut` at all — whether they ever should is an open product question, not just unbuilt.
 
 ---
 

--- a/docs/redteam/copilot-studio.md
+++ b/docs/redteam/copilot-studio.md
@@ -186,23 +186,32 @@ round trip — has not been independently live-verified; see the callout at the 
 
 ## What `--max-credits` does today
 
-`--max-credits <n>` is **parsed and validated, but not enforced.** Concretely:
+`--max-credits <n>` is **enforced, as an ESTIMATE — not a metered value.** The Copilot Studio SDK's
+activity/response models expose no real per-turn cost field, so `CopilotStudioChatClient` counts turns
+instead (1 estimated credit per turn, a fixed constant — not a heuristic weighted by response size).
+Concretely:
 
 - The option defaults to `0` ("no cap") and must be `>= 0` — a negative value is rejected at validation time,
   before the config even loads.
-- There is no code path that spends or checks a Copilot Credit budget: the Copilot Studio SDK's activity/response
-  models expose no credit-cost field to enforce against, so there's nothing to wire this up to yet.
-- Exit code 8 (`ExitCodes.BudgetExceeded`) stays reserved and unemitted until a credit-cost signal exists. See the
-  [exit-code table](../cli.md#exit-codes) in the CLI reference.
+- Once a live scan starts, the check runs **before** each turn: a turn that would push estimated spend at or
+  past the cap never fires — the scan stops instead, so estimated spend never intentionally exceeds the cap.
+- The scan then exits with code 8 (`ExitCodes.BudgetExceeded`) — distinct from a crash (`RuntimeError`, 3) or
+  a policy/gate outcome (5/6/7). See the [exit-code table](../cli.md#exit-codes) in the CLI reference.
+- `eval`/`bench gdpr`/`bench eu-ai-act` also carry `--max-credits`, resolved through the same `--sut` seam —
+  a breach there surfaces as a thrown `CopilotStudioBudgetExceededException` rather than exit code 8
+  specifically (that exit code's mapping is `redteam`-scoped today).
 
 The CLI help text for the flag says this plainly:
 
-> Cap the Copilot Credits a live `--sut copilot-studio` scan may spend (0 = no cap). NOT YET ENFORCED — the SDK
-> exposes no credit-cost field to enforce against, so this is parsed/validated only; exit 8 (BudgetExceeded)
-> stays reserved. Every turn burns credits, and a reasoning turn costs substantially more than a scripted one.
+> Cap the Copilot Credits a live `--sut copilot-studio` scan may spend (0 = no cap). ENFORCED as an ESTIMATE —
+> the SDK exposes no real credit-cost field, so this counts turns (1 estimated credit each), not actual
+> metered spend; a turn that would reach or exceed the cap never fires, and the scan stops with exit 8
+> (BudgetExceeded). A real reasoning turn likely costs substantially more than this estimate assumes — set
+> the cap conservatively.
 
-Don't rely on `--max-credits` as a real spend guard — track Copilot Credit consumption through Power Platform's
-own admin tooling instead.
+Because this is an estimate, don't rely on `--max-credits` as your only spend guard for anything cost-sensitive
+— cross-check real Copilot Credit consumption through Power Platform's own admin tooling, especially before
+raising the cap for a reasoning-heavy agent.
 
 ## What's verified vs. what still needs a live check
 
@@ -366,7 +375,7 @@ AgentEval's red-team scoring is honest about *how much* evidence a verdict is ba
 ## See also
 
 - [Red Team Security](../redteam.md) — the full scanner: attacks, evidence fidelity, judge modes, CI baseline gate.
-- [CLI Reference — Exit codes](../cli.md#exit-codes) — the full exit-code table, including the reserved `8`
-  (`BudgetExceeded`) this target will use once `--max-credits` enforcement has a credit-cost signal to enforce.
+- [CLI Reference — Exit codes](../cli.md#exit-codes) — the full exit-code table, including `8`
+  (`BudgetExceeded`) — returned when a live `redteam --sut copilot-studio` scan hits its `--max-credits` cap.
 - [Attack the gate](../gatekeeper/attack-the-gate.md) — the credential-free `--sut gatekeeper-demo` closed loop,
   useful for CI where a live Copilot Studio agent + credentials aren't available.

--- a/docs/redteam/copilot-studio.md
+++ b/docs/redteam/copilot-studio.md
@@ -193,21 +193,29 @@ Concretely:
 
 - The option defaults to `0` ("no cap") and must be `>= 0` — a negative value is rejected at validation time,
   before the config even loads.
-- Once a live scan starts, the check runs **before** each turn: a turn that would push estimated spend at or
-  past the cap never fires — the scan stops instead, so estimated spend never intentionally exceeds the cap.
-- The scan then exits with code 8 (`ExitCodes.BudgetExceeded`) — distinct from a crash (`RuntimeError`, 3) or
-  a policy/gate outcome (5/6/7). See the [exit-code table](../cli.md#exit-codes) in the CLI reference.
-- `eval`/`bench gdpr`/`bench eu-ai-act` also carry `--max-credits`, resolved through the same `--sut` seam —
-  a breach there surfaces as a thrown `CopilotStudioBudgetExceededException` rather than exit code 8
-  specifically (that exit code's mapping is `redteam`-scoped today).
+- The check runs **before** each turn, at the call site (not deferred to first enumeration): a turn that
+  would push estimated spend PAST the cap never fires — spend may legitimately reach exactly the cap; only
+  the turn that would exceed it is refused.
+- `CopilotStudioBudgetExceededException` extends `AgentEval.Core.FatalEvaluationException` — a marker the
+  `redteam` probe loop, the compliance-benchmark scenario loop, and the `eval` dataset loop all specifically
+  let propagate (the same way they already special-case `OperationCanceledException`) instead of swallowing
+  it into a per-item "execution error" that would just repeat the identical root cause for every remaining
+  probe/scenario/test case — the cap, once hit, can never un-trip mid-run. **The run genuinely stops** for
+  all three verbs.
+- The exit code differs by verb, though: `redteam` returns `8` (`ExitCodes.BudgetExceeded` — distinct from a
+  crash/`RuntimeError`(3) or a policy/gate outcome 5/6/7; see the [exit-code table](../cli.md#exit-codes)).
+  `eval`/`bench gdpr`/`bench eu-ai-act` also enforce and stop on the same condition, but return their own
+  existing generic failure codes instead (`RuntimeError`(3) for `eval`, `1` for `bench`) — exit code 8 is
+  `redteam`-scoped by design (see `ExitCodes.BudgetExceeded`'s own doc comment).
 
 The CLI help text for the flag says this plainly:
 
-> Cap the Copilot Credits a live `--sut copilot-studio` scan may spend (0 = no cap). ENFORCED as an ESTIMATE —
+> Cap the Copilot Credits a live `--sut copilot-studio` run may spend (0 = no cap). ENFORCED as an ESTIMATE —
 > the SDK exposes no real credit-cost field, so this counts turns (1 estimated credit each), not actual
-> metered spend; a turn that would reach or exceed the cap never fires, and the scan stops with exit 8
-> (BudgetExceeded). A real reasoning turn likely costs substantially more than this estimate assumes — set
-> the cap conservatively.
+> metered spend, and a turn that would push spend past the cap never fires. The run then stops (redteam:
+> exit 8/BudgetExceeded; eval/bench: their normal failure exit code). A real reasoning turn likely costs
+> substantially MORE than this estimate counts — set the cap conservatively, and don't assume hitting it
+> means the estimate overcounted.
 
 Because this is an estimate, don't rely on `--max-credits` as your only spend guard for anything cost-sensitive
 — cross-check real Copilot Credit consumption through Power Platform's own admin tooling, especially before
@@ -255,16 +263,18 @@ conversation-id tracking, and configurable error injection (auth failure, a mid-
 rate-limit-shaped exception, hang-until-cancelled), so the activity-stream bridging logic itself can be
 exercised credential-free, closer to what a real `CopilotClient` would do, without touching the network.
 
-**The `--sut` seam also reaches `eval` and `bench` now.** `ISutTarget` + `SutTargetResolver`
-(`src/AgentEval.Cli/Commands/Targets/ISutTarget.cs`) let `CopilotStudioRedTeamTarget` resolve the same way from
-`agenteval eval` and `agenteval bench owasp`/`mitre`/`nist` as it already did from `agenteval redteam` — a
-`Validate`-drift contract test proves the redteam and shared-seam validation paths agree. `agenteval eval --sut
-copilot-studio --dataset <file>` evaluates your dataset's prompts + judge criteria against a live MCS agent;
-`agenteval bench owasp --sut copilot-studio --subject <name>` (and `mitre`/`nist`) run the curated compliance
-scan against one. `bench`'s three Tier-1 families also gained a generic `--endpoint <url> --model <name>
-[--api-key <key>]` option set for a plain OpenAI-compatible endpoint, independent of Copilot Studio. See
-[docs/cli.md](../cli.md#agenteval-eval) for the exact flags. Bench Tier 2 (`gdpr`/`eu-ai-act`) does not have
-this yet — scoped separately.
+**The `--sut` seam also reaches `eval` and `bench` now — all of it, Tier 1 and Tier 2.** `ISutTarget` +
+`SutTargetResolver` (`src/AgentEval.Cli/Commands/Targets/ISutTarget.cs`) let `CopilotStudioRedTeamTarget`
+resolve the same way from `agenteval eval` and `agenteval bench owasp`/`mitre`/`nist` as it already did from
+`agenteval redteam` — a `Validate`-drift contract test proves the redteam and shared-seam validation paths
+agree. `agenteval eval --sut copilot-studio --dataset <file>` evaluates your dataset's prompts + judge
+criteria against a live MCS agent; `agenteval bench owasp --sut copilot-studio --subject <name>` (and
+`mitre`/`nist`) run the curated compliance scan against one. `bench`'s three Tier-1 families also gained a
+generic `--endpoint <url> --model <name> [--api-key <key>]` option set for a plain OpenAI-compatible
+endpoint, independent of Copilot Studio. **Bench Tier 2 (`bench gdpr`/`bench eu-ai-act --sut copilot-studio`)
+is wired too** — reuses the same resolver (`--sut` only, no generic `--endpoint` for Tier 2 yet), driving the
+live agent per-scenario instead of grading a static `--response`. See
+[docs/cli.md](../cli.md#agenteval-eval) for the exact flags.
 
 ## Resilience: retry + config-identity drift detection
 

--- a/src/AgentEval.Cli/Commands/BenchCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchCommand.cs
@@ -137,8 +137,9 @@ public static class BenchCommand
             // The response is produced per scenario by the live agent (see AgentScenarioEval),
             // so this placeholder is never graded — each scenario substitutes the agent's real answer.
             agentResponse = "(driven per-scenario by the live agent under test)";
+            var agentSource = agentOverride is not null ? "--sut" : "--azure-from-env";
             Console.Error.WriteLine(
-                $"[bench gdpr] Driving live agent '{subject}' per scenario via --azure-from-env; " +
+                $"[bench gdpr] Driving live agent '{subject}' per scenario via {agentSource}; " +
                 "each scenario's own prompt is sent to the agent and its real answer is graded.");
         }
         else if (!string.IsNullOrWhiteSpace(responseText))

--- a/src/AgentEval.Cli/Commands/BenchCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchCommand.cs
@@ -35,7 +35,7 @@ public static class BenchCommand
         string? responseText = null,
         bool azureFromEnv = false,
         CancellationToken ct = default) =>
-        RunGdprAsync(preset, subject, rootOverride, inputText, evaluatorOverride: null, runs: runs, responseText: responseText, azureFromEnv: azureFromEnv, ct: ct);
+        RunGdprAsync(preset, subject, rootOverride, inputText, evaluatorOverride: null, agentOverride: null, runs: runs, responseText: responseText, azureFromEnv: azureFromEnv, ct: ct);
 
     /// <summary>Runs the bench gdpr command with optional overrides (used in tests).</summary>
     internal static async Task<int> RunGdprAsync(
@@ -44,6 +44,7 @@ public static class BenchCommand
         string? rootOverride,
         string? inputText,
         IEvaluator? evaluatorOverride,
+        IEvaluableAgent? agentOverride = null,
         int runs = 1,
         string? responseText = null,
         bool azureFromEnv = false,
@@ -87,12 +88,12 @@ public static class BenchCommand
         IEvaluator judge = resolvedJudge;
 
         // ── Agent under test ─────────────────────────────────────────────────
-        // With --azure-from-env, build the live agent from AZURE_OPENAI_* and drive it per scenario
-        // (each scenario's own prompt → real answer → judged). Without it, the benchmark grades the
-        // single provided --response as before. The agent uses AZURE_OPENAI_* while the judge resolves
-        // AZURE_OPENAI_JUDGE_* first (see JudgeFactory), so the two can target different endpoints.
-        AgentEval.Core.IEvaluableAgent? agent = null;
-        if (azureFromEnv)
+        // Priority: --sut (agentOverride, e.g. copilot-studio) > --azure-from-env > grade the supplied
+        // --response as before. Each scenario's own prompt → real answer → judged, once a live agent is
+        // resolved either way. The judge resolves AZURE_OPENAI_JUDGE_* first (see JudgeFactory), so the
+        // agent and judge can target different endpoints.
+        AgentEval.Core.IEvaluableAgent? agent = agentOverride;
+        if (agent is null && azureFromEnv)
         {
             var (builtAgent, agentExit) = AzureChatAgentFactory.TryBuildFromEnv(subject);
             if (builtAgent is null) return agentExit;

--- a/src/AgentEval.Cli/Commands/BenchEuAiActCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchEuAiActCommand.cs
@@ -144,8 +144,9 @@ public static class BenchEuAiActCommand
             // Response is produced per scenario by the live agent (see AgentScenarioEval);
             // this placeholder is never graded.
             agentResponse = "(driven per-scenario by the live agent under test)";
+            var agentSource = agentOverride is not null ? "--sut" : "--azure-from-env";
             Console.Error.WriteLine(
-                $"[bench eu-ai-act] Driving live agent '{subject}' per scenario via --azure-from-env; " +
+                $"[bench eu-ai-act] Driving live agent '{subject}' per scenario via {agentSource}; " +
                 "each scenario's own prompt is sent to the agent and its real answer is graded.");
         }
         else if (!string.IsNullOrWhiteSpace(responseText))

--- a/src/AgentEval.Cli/Commands/BenchEuAiActCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchEuAiActCommand.cs
@@ -34,7 +34,7 @@ public static class BenchEuAiActCommand
         string? responseText = null,
         bool azureFromEnv = false,
         CancellationToken ct = default) =>
-        RunAsync(preset, subject, rootOverride, inputText, evaluatorOverride: null, responseText: responseText, azureFromEnv: azureFromEnv, ct: ct);
+        RunAsync(preset, subject, rootOverride, inputText, evaluatorOverride: null, agentOverride: null, responseText: responseText, azureFromEnv: azureFromEnv, ct: ct);
 
     /// <summary>Runs the bench eu-ai-act command with optional overrides (used in tests).</summary>
     internal static async Task<int> RunAsync(
@@ -43,6 +43,7 @@ public static class BenchEuAiActCommand
         string? rootOverride,
         string? inputText,
         IEvaluator? evaluatorOverride,
+        IEvaluableAgent? agentOverride = null,
         string? responseText = null,
         bool azureFromEnv = false,
         CancellationToken ct = default)
@@ -83,11 +84,11 @@ public static class BenchEuAiActCommand
         IEvaluator judge = resolvedJudge;
 
         // ── Agent under test ─────────────────────────────────────────────────
-        // With --azure-from-env, drive the live agent (AZURE_OPENAI_*) per scenario; otherwise grade
-        // the single provided --response. The judge resolves AZURE_OPENAI_JUDGE_* first (see
-        // JudgeFactory) so agent and judge can point at different endpoints.
-        AgentEval.Core.IEvaluableAgent? agent = null;
-        if (azureFromEnv)
+        // Priority: --sut (agentOverride, e.g. copilot-studio) > --azure-from-env > grade the supplied
+        // --response as before. The judge resolves AZURE_OPENAI_JUDGE_* first (see JudgeFactory) so
+        // agent and judge can point at different endpoints.
+        AgentEval.Core.IEvaluableAgent? agent = agentOverride;
+        if (agent is null && azureFromEnv)
         {
             var (builtAgent, agentExit) = AzureChatAgentFactory.TryBuildFromEnv(subject);
             if (builtAgent is null) return agentExit;

--- a/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
+++ b/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
@@ -9,14 +9,20 @@ using AgentEval.Core;
 namespace AgentEval.Cli.Commands;
 
 /// <summary>
-/// Resolves an optional agent override for `bench owasp`/`mitre`/`nist` (Tier 1) from either the shared
-/// <c>--sut</c> seam (Track 2 PR3 — <c>strategy/CopilotStudio/Bench-Eval-Integration-and-Live-Connector-Plan.md</c>
-/// §3.4 "bench Tier 1") or a generic OpenAI-compatible <c>--endpoint</c>/<c>--model</c>/<c>--api-key</c> set
-/// (Part C — <c>strategy/CLI-Custom-Benchmarks-CopilotStudio-OpenAI-and-Metrics-Remediation-Design.md</c> §2).
-/// Pure/testable — kept out of <c>Program.cs</c>'s top-level statements (which aren't a unit-testable surface)
-/// on purpose. <c>BenchOwaspCommand</c>/<c>BenchMitreCommand</c>/<c>BenchNistCommand</c> are themselves
-/// untouched: their pre-existing <c>agentOverride</c> seam already wins over <c>--azure-from-env</c>/the stub,
-/// so this class only needs to decide WHAT (if anything) to pass as that override.
+/// Resolves an optional agent override for a <c>bench</c> subcommand from either the shared <c>--sut</c> seam
+/// (Track 2 PR3 — <c>strategy/CopilotStudio/Bench-Eval-Integration-and-Live-Connector-Plan.md</c> §3.4 "bench
+/// Tier 1") or a generic OpenAI-compatible <c>--endpoint</c>/<c>--model</c>/<c>--api-key</c> set (Part C —
+/// <c>strategy/CLI-Custom-Benchmarks-CopilotStudio-OpenAI-and-Metrics-Remediation-Design.md</c> §2). Despite
+/// the "Tier1" name (kept for history — it shipped for <c>bench owasp</c>/<c>mitre</c>/<c>nist</c> first), the
+/// <see cref="Resolve"/> logic itself is verb/tier-agnostic and is also reused verbatim by <c>bench gdpr</c>/
+/// <c>eu-ai-act</c> (Tier 2, §2.2 of <c>strategy/CopilotStudio/Remaining-Backlog-Implementation-Plan-2026-07-16.md</c>)
+/// with <c>endpoint</c>/<c>model</c>/<c>apiKey</c> passed as <see langword="null"/> — a separate
+/// <c>BenchTier2SutResolver</c> would have been byte-identical duplication. Pure/testable — kept out of
+/// <c>Program.cs</c>'s top-level statements (which aren't a unit-testable surface) on purpose.
+/// <c>BenchOwaspCommand</c>/<c>BenchMitreCommand</c>/<c>BenchNistCommand</c>/<c>BenchCommand</c>/
+/// <c>BenchEuAiActCommand</c> are themselves untouched by this resolver: each already has its own
+/// <c>agentOverride</c> seam that wins over <c>--azure-from-env</c>/the stub/the supplied response, so this
+/// class only needs to decide WHAT (if anything) to pass as that override.
 /// </summary>
 internal static class BenchTier1SutResolver
 {

--- a/src/AgentEval.Cli/Commands/RedTeamCommand.cs
+++ b/src/AgentEval.Cli/Commands/RedTeamCommand.cs
@@ -13,6 +13,7 @@ using AgentEval.Cli.Commands.RedTeamTargets;
 using AgentEval.Cli.CopilotStudio;
 using AgentEval.Cli.Infrastructure;
 using AgentEval.Core;
+using AgentEval.MAF.CopilotStudio;
 using AgentEval.RedTeam;
 using AgentEval.RedTeam.Attacks;
 using AgentEval.RedTeam.Baseline;
@@ -259,6 +260,13 @@ internal static class RedTeamCommand
             try
             {
                 return await ExecuteAsync(opts, ct);
+            }
+            catch (CopilotStudioBudgetExceededException ex)
+            {
+                // Distinct from RuntimeError (a crash) — this is the scan correctly stopping itself at a
+                // configured spend ceiling, not a failure. See ExitCodes.BudgetExceeded's own remarks.
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.BudgetExceeded;
             }
             catch (Exception ex)
             {

--- a/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
+++ b/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
@@ -87,7 +87,7 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
     private readonly Option<int> _maxCreditsOpt = new("--max-credits")
     {
         DefaultValueFactory = _ => 0,
-        Description = "Cap the Copilot Credits a live --sut copilot-studio scan may spend (0 = no cap). ENFORCED as an ESTIMATE — the SDK exposes no real credit-cost field, so this counts turns (1 estimated credit each), not actual metered spend; a turn that would reach or exceed the cap never fires, and the scan stops with exit 8 (BudgetExceeded). A real reasoning turn likely costs substantially more than this estimate assumes — set the cap conservatively.",
+        Description = "Cap the Copilot Credits a live --sut copilot-studio run may spend (0 = no cap). ENFORCED as an ESTIMATE — the SDK exposes no real credit-cost field, so this counts turns (1 estimated credit each), not actual metered spend, and a turn that would push spend past the cap never fires. The run then stops (redteam: exit 8/BudgetExceeded; eval/bench: their normal failure exit code). A real reasoning turn likely costs substantially MORE than this estimate counts — set the cap conservatively, and don't assume hitting it means the estimate overcounted.",
     };
 
     // P6 item A (config-fingerprint drift) — redteam-ONLY, registered by AddOptionsTo (IRedTeamBuiltInTarget)

--- a/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
+++ b/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
@@ -87,7 +87,7 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
     private readonly Option<int> _maxCreditsOpt = new("--max-credits")
     {
         DefaultValueFactory = _ => 0,
-        Description = "Cap the Copilot Credits a live --sut copilot-studio scan may spend (0 = no cap). NOT YET ENFORCED — the SDK exposes no credit-cost field to enforce against, so this is parsed/validated only; exit 8 (BudgetExceeded) stays reserved. Every turn burns credits, and a reasoning turn costs substantially more than a scripted one.",
+        Description = "Cap the Copilot Credits a live --sut copilot-studio scan may spend (0 = no cap). ENFORCED as an ESTIMATE — the SDK exposes no real credit-cost field, so this counts turns (1 estimated credit each), not actual metered spend; a turn that would reach or exceed the cap never fires, and the scan stops with exit 8 (BudgetExceeded). A real reasoning turn likely costs substantially more than this estimate assumes — set the cap conservatively.",
     };
 
     // P6 item A (config-fingerprint drift) — redteam-ONLY, registered by AddOptionsTo (IRedTeamBuiltInTarget)
@@ -253,7 +253,8 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
         // Live path: builds a real connector (see BuildLive's own XML doc for what's live-verified vs. not).
         // iUnderstandLiveSideEffects: true is safe here — Validate() (above, in this same class) already
         // enforced --i-understand-live-side-effects before RedTeamCommand ever reaches this Build call.
-        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true);
+        var maxCredits = (opts.TargetOptionsFor<CopilotStudioTargetOptions>(Sut) ?? new CopilotStudioTargetOptions()).MaxCredits;
+        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true, maxCredits);
     }
 
     public void WritePostScanSummary(RedTeamResult result, AgentTrace trace, TextWriter err)
@@ -360,8 +361,12 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
 
     // iUnderstandLiveSideEffects: true is safe here — ISutTarget.Validate (above, in this same class)
     // already enforced --i-understand-live-side-effects before SutTargetResolver ever reaches this Build call.
+    // `??` short-circuits, so the maxCredits lookup + BuildLive only run when sutOverride is null.
     IEvaluableAgent ISutTarget.Build(CommonTargetOptions common, ISutTargetOptions? own, IEvaluableAgent? sutOverride)
-        => sutOverride ?? CopilotStudioAgentFactory.BuildLive(EnsureSutConfig(common, own), iUnderstandLiveSideEffects: true);
+        => sutOverride ?? CopilotStudioAgentFactory.BuildLive(
+            EnsureSutConfig(common, own),
+            iUnderstandLiveSideEffects: true,
+            (own as CopilotStudioSutOptions ?? common.TargetOptionsFor<CopilotStudioSutOptions>(Sut))?.MaxCredits ?? 0);
 
     private CopilotStudioConfig EnsureSutConfig(CommonTargetOptions common, ISutTargetOptions? own)
     {

--- a/src/AgentEval.Cli/ExitCodes.cs
+++ b/src/AgentEval.Cli/ExitCodes.cs
@@ -85,9 +85,9 @@ public static class ExitCodes
     /// live Copilot Studio target burns Copilot Credits on every turn, so the scan is capped to a spend ceiling.
     /// Distinct from a policy/gate outcome (5/6/7) and from <see cref="RuntimeError"/> (3, a crash) so CI can tell
     /// "raise the budget / it cost more than expected" apart from a failure. Deliberately 8, not another overload of 2.
-    /// <b>Reserved</b>: a live scan now runs (<c>BuildLive</c> is wired), but <c>--max-credits</c> enforcement
-    /// itself is not implemented — the Copilot Studio SDK exposes no credit-cost field to enforce against — so
-    /// nothing returns this yet.
+    /// <b>Enforced as an estimate</b>: the Copilot Studio SDK exposes no real credit-cost field, so
+    /// <c>CopilotStudioChatClient</c> counts turns (1 estimated credit each) rather than metering actual spend — a
+    /// turn that would reach or exceed the cap never fires, and this exit code is returned instead.
     /// </summary>
     public const int BudgetExceeded = 8;
 }

--- a/src/AgentEval.Cli/ExitCodes.cs
+++ b/src/AgentEval.Cli/ExitCodes.cs
@@ -87,7 +87,14 @@ public static class ExitCodes
     /// "raise the budget / it cost more than expected" apart from a failure. Deliberately 8, not another overload of 2.
     /// <b>Enforced as an estimate</b>: the Copilot Studio SDK exposes no real credit-cost field, so
     /// <c>CopilotStudioChatClient</c> counts turns (1 estimated credit each) rather than metering actual spend — a
-    /// turn that would reach or exceed the cap never fires, and this exit code is returned instead.
+    /// turn that would push spend PAST the cap never fires (spend may legitimately reach exactly the cap).
+    /// <c>CopilotStudioBudgetExceededException</c> extends <c>AgentEval.Core.FatalEvaluationException</c> so the
+    /// probe loop lets it propagate (rather than swallowing it into a per-probe error, which would just repeat
+    /// the same root cause for every remaining probe) and this exit code is returned instead. <b>Scope note</b>:
+    /// this exit code is <c>redteam</c>-specific — <c>eval</c>/<c>bench gdpr</c>/<c>bench eu-ai-act</c> also
+    /// enforce and propagate the same condition (the scan/run stops rather than degrading), but return their own
+    /// existing generic failure codes (<see cref="RuntimeError"/> for <c>eval</c>, <c>1</c> for <c>bench</c>),
+    /// not this one.
     /// </summary>
     public const int BudgetExceeded = 8;
 }

--- a/src/AgentEval.Cli/Program.cs
+++ b/src/AgentEval.Cli/Program.cs
@@ -93,7 +93,7 @@ var benchResponseOpt = new Option<string?>("--response") { Description = "The ag
 var benchResponseFileOpt = new Option<string?>("--response-file") { Description = "Path to a file containing the agent's actual response to grade (alternative to --response, for multi-line output)." };
 var benchRunsOpt = new Option<int?>("--runs") { Description = "Number of stochastic runs (default: 1). When > 1, runs the benchmark N times and aggregates via MajorityVote." };
 var benchGdprAzureFromEnvOpt = new Option<bool>("--azure-from-env") { Description = "Drive a live Azure OpenAI agent (from AZURE_OPENAI_*) per scenario: each scenario's own prompt is sent to the agent and its real answer is graded, instead of grading a single --response. The judge resolves AZURE_OPENAI_JUDGE_* first (falling back to AZURE_OPENAI_*) so agent and judge can target different endpoints." };
-var benchGdprCmd = new Command("gdpr", "Run the GDPR compliance benchmark");
+var benchGdprCmd = new Command("gdpr", "Run the GDPR compliance benchmark. Grades the supplied --response by default; --sut or --azure-from-env drives a live agent per scenario instead.");
 benchGdprCmd.Add(benchPresetOpt);
 benchGdprCmd.Add(benchSubjectOpt);
 benchGdprCmd.Add(benchRootOpt);
@@ -102,6 +102,7 @@ benchGdprCmd.Add(benchResponseOpt);
 benchGdprCmd.Add(benchResponseFileOpt);
 benchGdprCmd.Add(benchRunsOpt);
 benchGdprCmd.Add(benchGdprAzureFromEnvOpt);
+var (benchGdprSutOpt, benchGdprSutTargets) = SutTargetResolver.AddOptionsTo(benchGdprCmd, "bench");
 benchGdprCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
 {
     var preset = parseResult.GetValue(benchPresetOpt) ?? "standard";
@@ -115,9 +116,27 @@ benchGdprCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
     var input = parseResult.GetValue(benchInputOpt);
     var runs = parseResult.GetValue(benchRunsOpt) ?? 1;
     var azureFromEnv = parseResult.GetValue(benchGdprAzureFromEnvOpt);
+
+    // Bench Tier 2 (§2.2): reuses BenchTier1SutResolver.Resolve verbatim — its logic is verb/tier-agnostic,
+    // nothing Tier-1-specific about it. Only --sut is exposed here (endpoint/model/apiKey null) — a generic
+    // OpenAI-compatible endpoint for bench gdpr/eu-ai-act was not requested; --sut copilot-studio is.
+    var (agentOverride, sutError) = BenchTier1SutResolver.Resolve(
+        parseResult.GetValue(benchGdprSutOpt),
+        benchGdprSutTargets.ToDictionary(t => t.Sut, t => t.BindOptions(parseResult), StringComparer.OrdinalIgnoreCase),
+        benchGdprSutTargets,
+        endpoint: null,
+        model: null,
+        apiKey: null,
+        subject);
+    if (sutError is not null)
+    {
+        Console.Error.WriteLine($"Error: {sutError}");
+        return 1;
+    }
+
     var response = await ResolveBenchResponseAsync(parseResult.GetValue(benchResponseOpt), parseResult.GetValue(benchResponseFileOpt), ct);
     if (response.Error) return 1;
-    return await BenchCommand.RunGdprAsync(preset, subject, root, input, runs: runs, responseText: response.Text, azureFromEnv: azureFromEnv, ct: ct);
+    return await BenchCommand.RunGdprAsync(preset, subject, root, input, evaluatorOverride: null, agentOverride: agentOverride, runs: runs, responseText: response.Text, azureFromEnv: azureFromEnv, ct: ct);
 });
 
 // bench gdpr calibrate
@@ -145,7 +164,7 @@ var benchEuAiActInputOpt = new Option<string?>("--input") { Description = "Agent
 var benchEuAiActResponseOpt = new Option<string?>("--response") { Description = "The agent's actual RESPONSE to grade. If omitted, a built-in fixture is graded and a warning is emitted (the evidence then reflects no real agent)." };
 var benchEuAiActResponseFileOpt = new Option<string?>("--response-file") { Description = "Path to a file containing the agent's actual response to grade (alternative to --response)." };
 var benchEuAiActAzureFromEnvOpt = new Option<bool>("--azure-from-env") { Description = "Drive a live Azure OpenAI agent (from AZURE_OPENAI_*) per scenario: each scenario's own prompt is sent to the agent and its real answer is graded, instead of grading a single --response. The judge resolves AZURE_OPENAI_JUDGE_* first (falling back to AZURE_OPENAI_*) so agent and judge can target different endpoints." };
-var benchEuAiActCmd = new Command("eu-ai-act", "Run the EU AI Act compliance benchmark");
+var benchEuAiActCmd = new Command("eu-ai-act", "Run the EU AI Act compliance benchmark. Grades the supplied --response by default; --sut or --azure-from-env drives a live agent per scenario instead.");
 benchEuAiActCmd.Add(benchEuAiActPresetOpt);
 benchEuAiActCmd.Add(benchEuAiActSubjectOpt);
 benchEuAiActCmd.Add(benchEuAiActRootOpt);
@@ -153,6 +172,7 @@ benchEuAiActCmd.Add(benchEuAiActInputOpt);
 benchEuAiActCmd.Add(benchEuAiActResponseOpt);
 benchEuAiActCmd.Add(benchEuAiActResponseFileOpt);
 benchEuAiActCmd.Add(benchEuAiActAzureFromEnvOpt);
+var (benchEuAiActSutOpt, benchEuAiActSutTargets) = SutTargetResolver.AddOptionsTo(benchEuAiActCmd, "bench");
 benchEuAiActCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
 {
     var preset = parseResult.GetValue(benchEuAiActPresetOpt) ?? "standard";
@@ -170,9 +190,25 @@ benchEuAiActCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) 
     }
     var root = parseResult.GetValue(benchEuAiActRootOpt);
     var azureFromEnv = parseResult.GetValue(benchEuAiActAzureFromEnvOpt);
+
+    // Bench Tier 2 (§2.2): same reasoning as bench gdpr above.
+    var (agentOverride, sutError) = BenchTier1SutResolver.Resolve(
+        parseResult.GetValue(benchEuAiActSutOpt),
+        benchEuAiActSutTargets.ToDictionary(t => t.Sut, t => t.BindOptions(parseResult), StringComparer.OrdinalIgnoreCase),
+        benchEuAiActSutTargets,
+        endpoint: null,
+        model: null,
+        apiKey: null,
+        subject);
+    if (sutError is not null)
+    {
+        Console.Error.WriteLine($"Error: {sutError}");
+        return 1;
+    }
+
     var response = await ResolveBenchResponseAsync(parseResult.GetValue(benchEuAiActResponseOpt), parseResult.GetValue(benchEuAiActResponseFileOpt), ct);
     if (response.Error) return 1;
-    return await BenchEuAiActCommand.RunAsync(preset, subject, root, input, responseText: response.Text, azureFromEnv: azureFromEnv, ct: ct);
+    return await BenchEuAiActCommand.RunAsync(preset, subject, root, input, evaluatorOverride: null, agentOverride: agentOverride, responseText: response.Text, azureFromEnv: azureFromEnv, ct: ct);
 });
 // bench eu-ai-act calibrate
 var euCalibrateRootOpt = new Option<string?>("--root") { Description = "Workspace root path (default: current directory)" };

--- a/src/AgentEval.Core/Core/FatalEvaluationException.cs
+++ b/src/AgentEval.Core/Core/FatalEvaluationException.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Core;
+
+/// <summary>
+/// Marker base for an exception representing a STRUCTURAL condition that will recur on every remaining
+/// item in a scan/benchmark/eval run — not a per-item transient failure. The generic exception handlers
+/// in <c>RedTeamRunner.ExecuteProbeAsync</c>, <c>AgentScenarioEval.EvaluateAsync</c>, and
+/// <c>MAFEvaluationHarness.RunEvaluationAsync</c> otherwise swallow any exception into a per-probe/
+/// per-scenario/per-test-case error result so a single transient fault doesn't abort an entire run — but
+/// they special-case this base type (the same way those same catch chains already special-case
+/// <see cref="OperationCanceledException"/>) and let it propagate instead, so a condition that can never
+/// resolve itself mid-run (e.g. an exhausted spend cap) stops the whole run once, rather than re-reporting
+/// the identical root cause as a separate "execution error" for every remaining item.
+/// </summary>
+public abstract class FatalEvaluationException : Exception
+{
+    /// <summary>Creates a new <see cref="FatalEvaluationException"/> with the given message.</summary>
+    protected FatalEvaluationException(string message) : base(message)
+    {
+    }
+
+    /// <summary>Creates a new <see cref="FatalEvaluationException"/> with the given message and inner exception.</summary>
+    protected FatalEvaluationException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/AgentEval.Core/Evals/AgentScenarioEval.cs
+++ b/src/AgentEval.Core/Evals/AgentScenarioEval.cs
@@ -94,6 +94,14 @@ public sealed class AgentScenarioEval : IEval
             // agent error. Let it propagate rather than recording an "error" leaf and continuing.
             throw;
         }
+        catch (FatalEvaluationException)
+        {
+            // A STRUCTURAL condition (e.g. an exhausted spend cap) that will recur identically for every
+            // remaining scenario, since it can never un-trip mid-run. Let it propagate — same rationale as
+            // the OperationCanceledException case above — instead of recording an "error" leaf per
+            // scenario that just repeats the same root cause across the whole remaining scenario list.
+            throw;
+        }
         catch (Exception ex)
         {
             // The agent-under-test could not be reached / errored for this scenario.

--- a/src/AgentEval.MAF.CopilotStudio/CopilotStudioAgentFactory.cs
+++ b/src/AgentEval.MAF.CopilotStudio/CopilotStudioAgentFactory.cs
@@ -61,6 +61,11 @@ public static class CopilotStudioAgentFactory
     /// <c>--i-understand-live-side-effects</c> flag before ever reaching this call), so the same explicit
     /// acknowledgment must be required of every caller, not just the CLI path.
     /// </param>
+    /// <param name="maxCredits">
+    /// Estimated Copilot Credit spend cap (0 = no cap, the default) — see
+    /// <see cref="CopilotStudioChatClient(ICopilotStudioConversationClient, int)"/>'s own remarks for what
+    /// "estimated" means here and why.
+    /// </param>
     /// <exception cref="InvalidOperationException"><paramref name="iUnderstandLiveSideEffects"/> is <see langword="false"/>.</exception>
     /// <remarks>
     /// Everything else this method does is local/offline — constructing <see cref="ConnectionSettings"/>, resolving
@@ -68,7 +73,7 @@ public static class CopilotStudioAgentFactory
     /// <see cref="CopilotStudioTokenProvider"/> callback it wires up is only invoked lazily, by
     /// <see cref="CopilotClient"/> itself, on the first real request the returned agent makes.
     /// </remarks>
-    public static IEvaluableAgent BuildLive(CopilotStudioConfig config, bool iUnderstandLiveSideEffects)
+    public static IEvaluableAgent BuildLive(CopilotStudioConfig config, bool iUnderstandLiveSideEffects, int maxCredits = 0)
     {
         ArgumentNullException.ThrowIfNull(config);
         if (!iUnderstandLiveSideEffects)
@@ -100,7 +105,7 @@ public static class CopilotStudioAgentFactory
             NullLogger.Instance,
             HttpClientName);
 
-        IChatClient chatClient = new CopilotStudioChatClient(new CopilotClientConversationAdapter(copilotClient));
+        IChatClient chatClient = new CopilotStudioChatClient(new CopilotClientConversationAdapter(copilotClient), maxCredits);
         AIAgent innerAgent = new ChatClientAgent(chatClient, new ChatClientAgentOptions { Name = config.DisplayName });
         return FromAgent(innerAgent);
     }

--- a/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
+++ b/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;
+using AgentEval.Core;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.AI;
 
@@ -72,9 +73,10 @@ public sealed class CopilotStudioChatClient : IChatClient
     /// <param name="client">The conversation client this bridges into <see cref="IChatClient"/>.</param>
     /// <param name="maxCredits">
     /// Estimated Copilot Credit spend cap (0 = no cap, the default). Checked BEFORE each turn — a turn that
-    /// would push estimated spend at or past this cap never fires; <see cref="CopilotStudioBudgetExceededException"/>
-    /// is thrown instead, so the scan never intentionally exceeds the estimate. Credits here are an ESTIMATE
-    /// (<see cref="EstimatedCreditsPerTurn"/> per turn), not a metered value — see the type's own remarks.
+    /// would push estimated spend PAST this cap never fires (spend may legitimately reach exactly the cap);
+    /// <see cref="CopilotStudioBudgetExceededException"/> is thrown instead, so the scan never intentionally
+    /// exceeds the estimate. Credits here are an ESTIMATE (<see cref="EstimatedCreditsPerTurn"/> per turn),
+    /// not a metered value — see the type's own remarks.
     /// </param>
     public CopilotStudioChatClient(ICopilotStudioConversationClient client, int maxCredits = 0)
     {
@@ -85,14 +87,16 @@ public sealed class CopilotStudioChatClient : IChatClient
     /// <summary>
     /// Synchronous validating wrapper — <c>async IAsyncEnumerable</c> methods do not run ANY of their body
     /// (including simple argument-validation lines at the top) until the caller's first
-    /// <c>MoveNextAsync()</c>, so putting <see cref="ArgumentNullException"/>/<see cref="ObjectDisposedException"/>
-    /// checks directly in an iterator method makes them surface during enumeration instead of at the call
-    /// site — surprising and easy to miss (e.g. a caller that only ever calls <c>GetResponseAsync</c>, which
-    /// awaits the enumerable, would still observe this correctly, but any caller that captures the
-    /// <see cref="IAsyncEnumerable{T}"/> without enumerating it immediately would not see the error until
-    /// much later, if at all). Validating here — before the real work moves into
-    /// <see cref="GetStreamingResponseCoreAsync"/> — makes these throw eagerly, at the call site, like any
-    /// other precondition check.
+    /// <c>MoveNextAsync()</c>, so putting <see cref="ArgumentNullException"/>/<see cref="ObjectDisposedException"/>/
+    /// <see cref="CopilotStudioBudgetExceededException"/> checks directly in an iterator method makes them
+    /// surface during enumeration instead of at the call site — surprising and easy to miss (e.g. a caller
+    /// that only ever calls <c>GetResponseAsync</c>, which awaits the enumerable, would still observe this
+    /// correctly, but any caller that captures the <see cref="IAsyncEnumerable{T}"/> without enumerating it
+    /// immediately would not see the error until much later, if at all). Validating here — before the real
+    /// work moves into <see cref="GetStreamingResponseCoreAsync"/> — makes these throw eagerly, at the call
+    /// site, like any other precondition check. The budget check reads <see cref="_estimatedCreditsUsed"/>
+    /// without <see cref="_turnLock"/> — safe given this type's own documented single-conversation-at-a-time
+    /// contract (not safe to call concurrently from multiple logical conversations to begin with).
     /// </summary>
     public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
         IEnumerable<ChatMessage> messages,
@@ -101,6 +105,13 @@ public sealed class CopilotStudioChatClient : IChatClient
     {
         ArgumentNullException.ThrowIfNull(messages);
         ObjectDisposedException.ThrowIf(_disposed, this);
+
+        // Budget gate (P6/§2.1), checked here (not just inside the iterator body below) so it throws
+        // eagerly at the call site like the other precondition checks above — see this method's own remarks.
+        if (_maxCredits > 0 && _estimatedCreditsUsed + EstimatedCreditsPerTurn > _maxCredits)
+        {
+            throw new CopilotStudioBudgetExceededException(_estimatedCreditsUsed, _maxCredits);
+        }
 
         var question = LastUserText(messages)
             ?? throw new InvalidOperationException(
@@ -139,13 +150,8 @@ public sealed class CopilotStudioChatClient : IChatClient
         await _turnLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // Budget gate (P6/§2.1): checked BEFORE this turn fires, under the same lock every turn takes —
-            // a turn that would push estimated spend at or past _maxCredits never reaches the network call.
-            // _maxCredits == 0 means no cap (the CLI's own "--max-credits 0 = no cap" convention).
-            if (_maxCredits > 0 && _estimatedCreditsUsed + EstimatedCreditsPerTurn > _maxCredits)
-            {
-                throw new CopilotStudioBudgetExceededException(_estimatedCreditsUsed, _maxCredits);
-            }
+            // Budget gate (P6/§2.1) already ran, eagerly, in GetStreamingResponseAsync (the only caller of
+            // this private method) before this iterator was even constructed — not re-checked here.
 
             if (!_started)
             {
@@ -346,11 +352,15 @@ public sealed class CopilotStudioChatClient : IChatClient
 /// <summary>
 /// A live Copilot Studio scan hit its <c>--max-credits</c> estimated-spend cap. The turn that would have
 /// crossed the cap never fired — this is thrown BEFORE the network call, not after, so estimated spend
-/// never intentionally exceeds <see cref="MaxCredits"/>. Credit cost is an ESTIMATE
+/// never EXCEEDS <see cref="MaxCredits"/> (spend may legitimately reach exactly the cap; only the turn that
+/// would push it past that is refused). Credit cost is an ESTIMATE
 /// (<see cref="CopilotStudioChatClient.EstimatedCreditsPerTurn"/> per turn), not a metered value — the SDK
-/// exposes no real per-turn cost field.
+/// exposes no real per-turn cost field. Extends <see cref="FatalEvaluationException"/> so the orchestration
+/// layers that drive this agent (redteam probe loop, benchmark scenario loop, eval dataset loop) let it
+/// propagate and stop the whole run, instead of swallowing it into a per-item error result that would just
+/// repeat identically for every remaining item — the cap, once hit, can never un-trip mid-run.
 /// </summary>
-public sealed class CopilotStudioBudgetExceededException : Exception
+public sealed class CopilotStudioBudgetExceededException : FatalEvaluationException
 {
     /// <summary>Estimated credits already spent (across prior turns) when this turn was refused.</summary>
     public int EstimatedCreditsUsed { get; }
@@ -361,10 +371,12 @@ public sealed class CopilotStudioBudgetExceededException : Exception
     /// <summary>Creates a new <see cref="CopilotStudioBudgetExceededException"/>.</summary>
     public CopilotStudioBudgetExceededException(int estimatedCreditsUsed, int maxCredits)
         : base(
-            $"Copilot Studio scan stopped: estimated credit spend ({estimatedCreditsUsed}) would reach or " +
-            $"exceed --max-credits ({maxCredits}) on the next turn. Credit cost is an ESTIMATE, not a metered " +
-            "value — the Copilot Studio SDK exposes no real per-turn cost field. Re-run with a higher " +
-            "--max-credits if this estimate is too conservative.")
+            $"Copilot Studio scan stopped: estimated credit spend ({estimatedCreditsUsed}) would exceed " +
+            $"--max-credits ({maxCredits}) on the next turn. Credit cost is an ESTIMATE, not a metered value " +
+            "— the Copilot Studio SDK exposes no real per-turn cost field, and a real reasoning turn likely " +
+            "costs substantially MORE than this estimate counts, so actual spend may already be ahead of " +
+            "this number. Don't reflexively raise --max-credits on seeing this — first confirm via Power " +
+            "Platform's own admin tooling what this scan actually spent before deciding the cap was too low.")
     {
         EstimatedCreditsUsed = estimatedCreditsUsed;
         MaxCredits = maxCredits;

--- a/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
+++ b/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
@@ -55,15 +55,31 @@ public sealed class CopilotStudioChatClient : IChatClient
     // enough that a genuinely hung call cannot hang disposal forever.
     private static readonly TimeSpan DisposeLockTimeout = TimeSpan.FromSeconds(10);
 
+    // P6/§2.1: the SDK exposes no real per-turn cost field (confirmed against the decompiled/reflected
+    // assembly — see CopilotStudioAgentFactory's remarks), so credit spend is an ESTIMATE, never a metered
+    // value. Fixed-constant path per the design doc's own recommendation: "ship the fixed-constant version
+    // first... revisit the heuristic path only if a real complaint about its coarseness shows up."
+    internal const int EstimatedCreditsPerTurn = 1;
+
     private readonly ICopilotStudioConversationClient _client;
     private readonly SemaphoreSlim _turnLock = new(1, 1);
+    private readonly int _maxCredits;
     private string? _conversationId;
     private bool _started;
     private bool _disposed;
+    private int _estimatedCreditsUsed;
 
-    public CopilotStudioChatClient(ICopilotStudioConversationClient client)
+    /// <param name="client">The conversation client this bridges into <see cref="IChatClient"/>.</param>
+    /// <param name="maxCredits">
+    /// Estimated Copilot Credit spend cap (0 = no cap, the default). Checked BEFORE each turn — a turn that
+    /// would push estimated spend at or past this cap never fires; <see cref="CopilotStudioBudgetExceededException"/>
+    /// is thrown instead, so the scan never intentionally exceeds the estimate. Credits here are an ESTIMATE
+    /// (<see cref="EstimatedCreditsPerTurn"/> per turn), not a metered value — see the type's own remarks.
+    /// </param>
+    public CopilotStudioChatClient(ICopilotStudioConversationClient client, int maxCredits = 0)
     {
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _maxCredits = maxCredits;
     }
 
     /// <summary>
@@ -123,6 +139,14 @@ public sealed class CopilotStudioChatClient : IChatClient
         await _turnLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            // Budget gate (P6/§2.1): checked BEFORE this turn fires, under the same lock every turn takes —
+            // a turn that would push estimated spend at or past _maxCredits never reaches the network call.
+            // _maxCredits == 0 means no cap (the CLI's own "--max-credits 0 = no cap" convention).
+            if (_maxCredits > 0 && _estimatedCreditsUsed + EstimatedCreditsPerTurn > _maxCredits)
+            {
+                throw new CopilotStudioBudgetExceededException(_estimatedCreditsUsed, _maxCredits);
+            }
+
             if (!_started)
             {
                 // Idempotency-safety gate (P6 item B, hardened): a live Copilot Studio agent can execute real
@@ -157,6 +181,7 @@ public sealed class CopilotStudioChatClient : IChatClient
             }
 
             materialized.AddRange(askActivities);
+            _estimatedCreditsUsed += EstimatedCreditsPerTurn;   // only after a fully successful turn
             turnConversationId = _conversationId;
         }
         finally
@@ -315,5 +340,33 @@ public sealed class CopilotStudioChatClient : IChatClient
         }
 
         return string.IsNullOrEmpty(last?.Text) ? null : last.Text;
+    }
+}
+
+/// <summary>
+/// A live Copilot Studio scan hit its <c>--max-credits</c> estimated-spend cap. The turn that would have
+/// crossed the cap never fired — this is thrown BEFORE the network call, not after, so estimated spend
+/// never intentionally exceeds <see cref="MaxCredits"/>. Credit cost is an ESTIMATE
+/// (<see cref="CopilotStudioChatClient.EstimatedCreditsPerTurn"/> per turn), not a metered value — the SDK
+/// exposes no real per-turn cost field.
+/// </summary>
+public sealed class CopilotStudioBudgetExceededException : Exception
+{
+    /// <summary>Estimated credits already spent (across prior turns) when this turn was refused.</summary>
+    public int EstimatedCreditsUsed { get; }
+
+    /// <summary>The configured <c>--max-credits</c> cap that was hit.</summary>
+    public int MaxCredits { get; }
+
+    /// <summary>Creates a new <see cref="CopilotStudioBudgetExceededException"/>.</summary>
+    public CopilotStudioBudgetExceededException(int estimatedCreditsUsed, int maxCredits)
+        : base(
+            $"Copilot Studio scan stopped: estimated credit spend ({estimatedCreditsUsed}) would reach or " +
+            $"exceed --max-credits ({maxCredits}) on the next turn. Credit cost is an ESTIMATE, not a metered " +
+            "value — the Copilot Studio SDK exposes no real per-turn cost field. Re-run with a higher " +
+            "--max-credits if this estimate is too conservative.")
+    {
+        EstimatedCreditsUsed = estimatedCreditsUsed;
+        MaxCredits = maxCredits;
     }
 }

--- a/src/AgentEval.MAF/MAF/MAFEvaluationHarness.cs
+++ b/src/AgentEval.MAF/MAF/MAFEvaluationHarness.cs
@@ -202,6 +202,14 @@ public class MAFEvaluationHarness : IStreamingEvaluationHarness, IBatchEvaluatio
                 LogFailure(result);
             }
         }
+        catch (FatalEvaluationException)
+        {
+            // A STRUCTURAL condition (e.g. an exhausted spend cap) that will recur identically for every
+            // remaining row in a RunBatchAsync loop, since it can never un-trip mid-run. Let it propagate
+            // instead of recording a per-test-case failure that just repeats the same root cause across
+            // the whole remaining dataset.
+            throw;
+        }
         catch (Exception ex)
         {
             result.Passed = false;
@@ -210,7 +218,7 @@ public class MAFEvaluationHarness : IStreamingEvaluationHarness, IBatchEvaluatio
             result.Error = ex;
             timeline.TotalDuration = DateTimeOffset.UtcNow - timeline.StartedAt;
             result.Timeline = timeline;
-            
+
             // Build failure report for exception
             result.Failure = BuildExceptionFailureReport(ex, testCase, timeline);
             LogFailure(result);

--- a/src/AgentEval.RedTeam/RedTeam/RedTeamRunner.cs
+++ b/src/AgentEval.RedTeam/RedTeam/RedTeamRunner.cs
@@ -551,6 +551,16 @@ public sealed class RedTeamRunner : IRedTeamRunner
                 Surface = probe.Surface
             };
         }
+        catch (FatalEvaluationException)
+        {
+            // A STRUCTURAL condition (e.g. CopilotStudioBudgetExceededException — an exhausted spend cap)
+            // that will recur identically on every remaining probe, since it can never un-trip mid-scan.
+            // Let it propagate instead of swallowing it into a per-probe "execution error" that would just
+            // repeat for the whole remaining probe list — matches the existing OperationCanceledException
+            // special-case immediately below, same rationale (a condition the per-probe retry loop can't
+            // recover from).
+            throw;
+        }
         catch (Exception ex) when (IsTransportError(ex))
         {
             // Expected transport/connectivity errors (network blip, socket reset, remote timeout).

--- a/tests/AgentEval.Tests/Cli/BenchCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/BenchCommandTests.cs
@@ -79,6 +79,16 @@ public class BenchCommandTests : IDisposable
         }
     }
 
+    /// <summary>Fixed-answer fake agent — simulates what a resolved --sut target would hand to RunGdprAsync's agentOverride parameter.</summary>
+    private sealed class FixedAnswerAgent : IEvaluableAgent
+    {
+        private readonly string _answer;
+        public string Name { get; }
+        public FixedAnswerAgent(string name, string answer) { Name = name; _answer = answer; }
+        public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken cancellationToken = default)
+            => Task.FromResult(new AgentResponse { Text = _answer });
+    }
+
     /// <summary>Stub evaluator that records the most recent graded output (the agent response).</summary>
     private sealed class CapturingStubEvaluator : IEvaluator
     {
@@ -122,6 +132,30 @@ public class BenchCommandTests : IDisposable
         Assert.True(exitCode == 0 || exitCode == 2);
         Assert.Equal(realResponse, capturing.LastOutput);
         Assert.DoesNotContain("privacy@example.com", capturing.LastOutput ?? ""); // not the fixture
+    }
+
+    [Fact]
+    public async Task BenchGdpr_WithAgentOverride_DrivesTheAgentPerScenario_NotAStaticResponse()
+    {
+        // Bench Tier 2 (§2.2): agentOverride is what a resolved --sut target's IEvaluableAgent flows in as.
+        // ScenarioToAtomicEval already accepted this parameter (pre-existing, generic) — this proves the CLI
+        // wiring actually reaches it, and that agentOverride wins even when --response text is also supplied.
+        InitWorkspace();
+        var capturing = new CapturingStubEvaluator();
+        const string agentAnswer = "AGENT-OVERRIDE-DROVE-THIS unique marker";
+        var agent = new FixedAnswerAgent("SutAgent", agentAnswer);
+
+        var exitCode = await BenchCommand.RunGdprAsync(
+            preset: "smoke",
+            subject: "SutAgent",
+            rootOverride: _root,
+            inputText: "What personal data do you store?",
+            evaluatorOverride: capturing,
+            agentOverride: agent,
+            responseText: "this static text should be ignored — agentOverride takes priority");
+
+        Assert.True(exitCode == 0 || exitCode == 2);
+        Assert.Equal(agentAnswer, capturing.LastOutput);
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/Cli/BenchEuAiActCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/BenchEuAiActCommandTests.cs
@@ -80,6 +80,36 @@ public class BenchEuAiActCommandTests : IDisposable
         }
     }
 
+    /// <summary>Stub evaluator that records the most recent graded output (the agent response) — mirrors BenchCommandTests' GDPR-side helper.</summary>
+    private sealed class CapturingStubEvaluator : IEvaluator
+    {
+        public string? LastOutput { get; private set; }
+
+        public Task<EvaluationResult> EvaluateAsync(
+            string input, string output, IEnumerable<string> criteria,
+            CancellationToken cancellationToken = default)
+        {
+            LastOutput = output;
+            var list = criteria.ToList();
+            return Task.FromResult(new EvaluationResult
+            {
+                OverallScore = 100,
+                Summary = "stub-capture",
+                CriteriaResults = list.Select(c => new CriterionResult { Criterion = c, Met = true, Explanation = "stub" }).ToList()
+            });
+        }
+    }
+
+    /// <summary>Fixed-answer fake agent — simulates what a resolved --sut target would hand to RunAsync's agentOverride parameter.</summary>
+    private sealed class FixedAnswerAgent : IEvaluableAgent
+    {
+        private readonly string _answer;
+        public string Name { get; }
+        public FixedAnswerAgent(string name, string answer) { Name = name; _answer = answer; }
+        public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken cancellationToken = default)
+            => Task.FromResult(new AgentResponse { Text = _answer });
+    }
+
     // ── Env-gate trio (Phase-4 gate-review follow-up) ────────────────────
 
     [Fact]
@@ -158,6 +188,30 @@ public class BenchEuAiActCommandTests : IDisposable
         Assert.True(File.Exists(Path.Combine(tsDir, "report.pdf")), "report.pdf should be generated");
         Assert.True(new FileInfo(Path.Combine(tsDir, "report.pdf")).Length > 0,
             "report.pdf should be non-empty");
+    }
+
+    [Fact]
+    public async Task BenchEuAiAct_WithAgentOverride_DrivesTheAgentPerScenario_NotAStaticResponse()
+    {
+        // Bench Tier 2 (§2.2): mirrors BenchCommandTests' GDPR-side equivalent — proves the CLI wiring
+        // actually reaches ScenarioToAtomicEval's pre-existing agent parameter for eu-ai-act too, and that
+        // agentOverride wins even when --response text is also supplied.
+        InitWorkspace();
+        var capturing = new CapturingStubEvaluator();
+        const string agentAnswer = "EU-AI-ACT-AGENT-OVERRIDE-DROVE-THIS unique marker";
+        var agent = new FixedAnswerAgent("EuAiActSutAgent", agentAnswer);
+
+        var exitCode = await BenchEuAiActCommand.RunAsync(
+            preset: "smoke",
+            subject: "EuAiActSutAgent",
+            rootOverride: _root,
+            inputText: "Sample EU AI Act bench probe for the smoke preset.",
+            evaluatorOverride: capturing,
+            agentOverride: agent,
+            responseText: "this static text should be ignored — agentOverride takes priority");
+
+        Assert.True(exitCode == 0 || exitCode == 2);
+        Assert.Equal(agentAnswer, capturing.LastOutput);
     }
 
     // ── Phase-2 / Task 2.2 regression — composite preset E2E ─────────────

--- a/tests/AgentEval.Tests/Compliance/Gdpr/GdprAgentErrorReportingTests.cs
+++ b/tests/AgentEval.Tests/Compliance/Gdpr/GdprAgentErrorReportingTests.cs
@@ -9,6 +9,7 @@ using AgentEval.Compliance.Gdpr.Articles;
 using AgentEval.Compliance.Gdpr.Articles.Building;
 using AgentEval.Compliance.Gdpr.Articles.Loading;
 using AgentEval.Compliance.Gdpr.Reporting;
+using AgentEval.MAF.CopilotStudio;
 using AgentEval.Output;
 using Xunit;
 
@@ -78,6 +79,39 @@ public class GdprAgentErrorReportingTests
             store, subject, runId, result, new GdprReportOptions(Preset: "smoke"));
 
         Assert.DoesNotContain(evidence.Recommendations, r => r.Severity == "none");
+    }
+
+    private sealed class FatalThrowingAgent : IEvaluableAgent
+    {
+        public string Name => "fatal-throwing-agent";
+
+        public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken cancellationToken = default) =>
+            throw new CopilotStudioBudgetExceededException(estimatedCreditsUsed: 1, maxCredits: 1);
+    }
+
+    [Fact]
+    public async Task RunAsync_AgentThrowsFatalEvaluationException_PropagatesRatherThanProducingErrorLeaves()
+    {
+        // Contrast with SaveReportAsync_AllScenariosAgentError_DoesNotThrowSchemaValidation above: a NORMAL
+        // exception (AlwaysThrowingAgent) correctly degrades into per-scenario "error" leaves so one bad
+        // scenario doesn't abort the whole benchmark. A FatalEvaluationException (e.g. an exhausted
+        // Copilot Studio spend cap) is different — it's structural and will recur identically on every
+        // remaining scenario, so AgentScenarioEval.EvaluateAsync lets it propagate instead, and the WHOLE
+        // run should stop rather than silently producing dozens of identical "error" leaves.
+        var loader = new ArticleScenarioYamlLoader();
+        var scenarioBuilder = new ScenarioToAtomicEval(
+            new StubJudge(), judgeModel: "stub", agent: new FatalThrowingAgent());
+        var articleBuilder = new ArticleCompositeBuilder(scenarioBuilder);
+        var registry = new ArticlesRegistry(loader, articleBuilder);
+
+        var store = new InMemoryOutputStore();
+        var subject = new SubjectIdentity(SubjectKind.Agent, "FatalPropagationTestAgent");
+        var benchmark = GdprBenchmark.Smoke(registry);
+        var runner = new GdprBenchmarkRunner();
+        var input = new EvalInput(Query: "test", Response: "unused — agent drives per scenario");
+
+        await Assert.ThrowsAsync<CopilotStudioBudgetExceededException>(
+            () => runner.RunAsync(store, subject, benchmark, input));
     }
 
     private static IEnumerable<EvalResult> EnumerateLeaves(EvalResult node)

--- a/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
+++ b/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
@@ -208,6 +208,28 @@ public class CopilotStudioChatClientTests
         Assert.Equal(2, fake.AskCallCount);   // the 3rd turn never reached the conversation client
     }
 
+    [Fact]
+    public async Task MaxCredits_Exceeded_ThrowsEagerlyFromGetStreamingResponseAsync_NotOnlyOnFirstEnumeration()
+    {
+        // Matches this class's own documented eager-throw contract for GetStreamingResponseAsync
+        // (ArgumentNullException/ObjectDisposedException throw at the call site, not on first
+        // MoveNextAsync) — the budget check must behave the same way, not just when driven through
+        // GetResponseAsync (which awaits immediately and would mask an iterator-body-only check).
+        var fake = new FakeCopilotStudioConversationClient();
+        fake.OnStart = (_, _) => Empty();
+        fake.OnAsk = (_, _, _) => One(Message("ok", "conv-1"));
+
+        using var client = new CopilotStudioChatClient(fake, maxCredits: 1);
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 1")]);   // estimated spend: 1 (== cap)
+
+        // The call itself — not enumeration of its result — must throw.
+        var ex = Assert.Throws<CopilotStudioBudgetExceededException>(
+            () => client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "turn 2")]));
+
+        Assert.Equal(1, ex.EstimatedCreditsUsed);
+        Assert.Equal(1, fake.AskCallCount);   // turn 2 never reached the conversation client
+    }
+
     // ── activity builders ──
 
     private static Activity Message(string? text, string conversationId) => new()

--- a/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
+++ b/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
@@ -172,6 +172,42 @@ public class CopilotStudioChatClientTests
             () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]));
     }
 
+    // ── --max-credits enforcement (P6/§2.1) ──
+
+    [Fact]
+    public async Task MaxCredits_Zero_NeverThrows_RegardlessOfTurnCount()
+    {
+        var fake = new FakeCopilotStudioConversationClient();
+        fake.OnStart = (_, _) => Empty();
+        fake.OnAsk = (_, _, _) => One(Message("ok", "conv-1"));
+
+        using var client = new CopilotStudioChatClient(fake, maxCredits: 0);
+        for (var i = 0; i < 5; i++)
+        {
+            var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, $"turn {i}")]);
+            Assert.Equal("ok", response.Text);
+        }
+    }
+
+    [Fact]
+    public async Task MaxCredits_ExceededOnThirdTurn_ThrowsBeforeTheNetworkCall()
+    {
+        var fake = new FakeCopilotStudioConversationClient();
+        fake.OnStart = (_, _) => Empty();
+        fake.OnAsk = (_, _, _) => One(Message("ok", "conv-1"));
+
+        using var client = new CopilotStudioChatClient(fake, maxCredits: 2);
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 1")]);   // estimated spend: 1
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 2")]);   // estimated spend: 2 (== cap)
+
+        var ex = await Assert.ThrowsAsync<CopilotStudioBudgetExceededException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 3")]));
+
+        Assert.Equal(2, ex.EstimatedCreditsUsed);
+        Assert.Equal(2, ex.MaxCredits);
+        Assert.Equal(2, fake.AskCallCount);   // the 3rd turn never reached the conversation client
+    }
+
     // ── activity builders ──
 
     private static Activity Message(string? text, string conversationId) => new()

--- a/tests/AgentEval.Tests/RedTeam/RedTeamRunnerTests.cs
+++ b/tests/AgentEval.Tests/RedTeam/RedTeamRunnerTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 // tests/AgentEval.Tests/RedTeam/RedTeamRunnerTests.cs
 using AgentEval.Core;
+using AgentEval.MAF.CopilotStudio;
 using AgentEval.RedTeam;
 using AgentEval.RedTeam.Attacks;
 
@@ -57,6 +58,27 @@ public class RedTeamRunnerTests
         };
         var result = await new RedTeamRunner().ScanAsync(new FakeResistantAgent(), options);
         Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task ScanAsync_AgentThrowsFatalEvaluationException_PropagatesRatherThanSwallowingIntoErrorResult()
+    {
+        // FatalEvaluationException (e.g. CopilotStudioBudgetExceededException — an exhausted spend cap) is a
+        // STRUCTURAL condition that will recur on every remaining probe, unlike a normal per-probe fault.
+        // ExecuteProbeAsync's catch chain special-cases it (mirroring the existing OperationCanceledException
+        // case) to let it propagate instead of converting it into a per-probe "execution error" result — this
+        // proves that propagation actually happens through the real probe loop, not just that the code compiles.
+        var options = new ScanOptions
+        {
+            Intensity = Intensity.Quick,
+            AttackTypes = [Attack.PromptInjection],
+        };
+
+        var ex = await Assert.ThrowsAsync<CopilotStudioBudgetExceededException>(
+            () => new RedTeamRunner().ScanAsync(new FatalThrowingAgent(), options));
+
+        Assert.Equal(1, ex.EstimatedCreditsUsed);
+        Assert.Equal(1, ex.MaxCredits);
     }
 
     [Fact]
@@ -596,6 +618,14 @@ public class RedTeamRunnerTests
             public Task<AgentEval.RedTeam.EvaluationResult> EvaluateAsync(AttackProbe probe, string response, CancellationToken cancellationToken = default)
                 => Task.FromResult(AgentEval.RedTeam.EvaluationResult.Resisted("resisted"));
         }
+    }
+
+    private class FatalThrowingAgent : IEvaluableAgent
+    {
+        public string Name => "FatalThrowingAgent";
+
+        public Task<AgentResponse> InvokeAsync(string prompt, CancellationToken ct = default)
+            => throw new CopilotStudioBudgetExceededException(estimatedCreditsUsed: 1, maxCredits: 1);
     }
 
     private class FakeResistantAgent : IEvaluableAgent


### PR DESCRIPTION
## Summary

Closes two of the three CLI-completeness gaps identified in today's Copilot Studio audit (the third, a `RedTeamCommand` → `SutTargetResolver` dedup, was investigated and deliberately skipped — see commit message for why).

- **`--max-credits` enforcement**: `CopilotStudioChatClient` tracks estimated credit spend (1 per turn, a fixed constant) and refuses a turn that would push spend past the cap, before any network call.
- **Bench Tier 2 `--sut` wiring**: `bench gdpr`/`bench eu-ai-act` now support `--sut copilot-studio`, reusing the existing generic `BenchTier1SutResolver` (confirmed fully verb-agnostic, not duplicated).

**A 7-angle review of the first commit found a critical gap** (second commit fixes it): the new budget-exceeded exception was silently swallowed by pre-existing generic exception handlers in all three orchestration layers (`RedTeamRunner`, `AgentScenarioEval`, `MAFEvaluationHarness`) — the scan/run never actually stopped, and `redteam`'s new exit-code-8 handler was dead code. Fixed with a new shared marker (`AgentEval.Core.FatalEvaluationException`) that these layers specifically let propagate — the same pattern already used for `OperationCanceledException` in the same catch chains, so this is zero-risk to any existing exception type. Verified with integration-level tests that prove propagation through the real orchestration code, not just unit tests of the exception type in isolation.

Also fixed in the review pass: an eager-throw contract violation (budget check moved to the sync wrapper), a boundary-wording mismatch, a one-sided/misleading exception message, an incorrect diagnostic message, and several stale doc claims — see the second commit message for the full list.

## Test plan
- [x] Full solution build: 0 errors across net8.0/9.0/10.0
- [x] Full net8.0 test suite: 7745 passed, 0 failed, 1 skipped
- [x] `bench gdpr --help` / `bench eu-ai-act --help` verified live to show `--sut` + the Copilot Studio flag set
- [x] `bench gdpr --sut bogus` verified to fail fast with a clear error before any network call
- [x] New integration-level tests prove the budget-exceeded exception propagates through the real `redteam` probe loop and the real `bench gdpr` scenario loop (not swallowed), contrasted directly against existing tests proving normal exceptions still correctly degrade to per-item error results

🤖 Generated with [Claude Code](https://claude.com/claude-code)