### PR TITLE
feat(agent-skills): Wave 2 — cross-location content drift + trust-on-first-use

### DIFF
--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -92,6 +92,24 @@ pattern). `agenteval skills baseline list|diff|history` inspects it. `--repo` sc
 skill-directory convention under a repo root (`AgentEval.Skills.AgentSkillDirectoryConventions`) and
 aggregates the results. See [CLI reference](cli.md#agenteval-skills-baseline) for the full command surface.
 
+**Cross-location drift + trust-on-first-use (Wave 2):** two governance signals built directly on Wave 1's
+content hashing, both surfaced as ordinary `SkillComplianceFinding`s (so they render in console/markdown/
+json output automatically, no new schema):
+- **Cross-location content drift** — always checked on a `--repo` scan (no extra flag; a single-directory
+  scan has only one location by definition). Groups every discovered skill by name across all conventions
+  found under the repo root; if the same name resolves to two or more DIFFERENT content hashes, that's
+  flagged (`Medium` severity — a governance signal to investigate, since the divergence may be deliberate
+  per-tool customization rather than drift or poisoning). `internal static SkillsScanCommand.DetectCrossLocationDrift`.
+- **Trust-on-first-use reputation matching** — opt-in via `--check-baseline`. Loads the baseline ledger's
+  full history (`ISkillBaselineStore.ListAsync`) and checks whether each scanned skill's current content hash
+  already appears in ANY prior snapshot for the same name; a match is reported as an informational (`Low`
+  severity) "✓ matches a previously-vetted copy" finding, naming the most recent match's capture date.
+  Meaningless on a first-ever scan — pair with `--write-baseline` on earlier runs to build the history it
+  reads. `internal static SkillsScanCommand.DetectPreviouslyVetted`.
+
+Neither feature is High severity — both are informational/governance signals, not automatic compliance
+failures, so `--fail-on-noncompliant` is unaffected by either.
+
 ## 3 — Skill-injection red-team attack + `run_skill_script` governance
 
 `AgentEval.RedTeam.Attacks.SkillInjectionAttack` (OWASP LLM01, in `Attack.All` — the framework now ships **14**
@@ -186,7 +204,9 @@ and would crash the whole scan, is caught and reported as one clean finding inst
 
 Phase 4c (skill fuzzing via the transform/codec pipeline, a canary-skill honeypot, skill-name typosquatting,
 load-storm-as-denial-of-wallet) was deprioritized this session in favor of shipping 4a/4b and the exclusion-
-detection fix (§5) with full rigor — see `strategy/TODO.md` (local-only) for the up-to-date backlog.
+detection fix (§5) with full rigor. Wave 3 (org-wide multi-repo scanning via a new GitHub/GitLab API client;
+live upstream verification against a skill's declared source) is gated on a security/credential-scope review
+not yet held — see `strategy/TODO.md` (local-only) for the up-to-date backlog.
 
 ## Related
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -418,7 +418,7 @@ suite ships, from the CLI.
 
 ```
 agenteval skills scan <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
-                              [--write-baseline] [--baseline-root <dir>] [--repo]
+                              [--write-baseline] [--baseline-root <dir>] [--repo] [--check-baseline]
 ```
 
 **What it does**
@@ -427,7 +427,9 @@ Walks `<path>` for `SKILL.md`-rooted skill folders (the same convention MAF's ow
 discovers by), checks each against the GA `SKILL.md` authoring rules (name/description/compatibility) plus
 governance flags (script-execution review, untrusted resource sources, experimental `allowed-tools`), and
 renders a report. v1 is compliance-only — the composite Skill Health & Security Index is library-only for now
-(see [Agent Skills](agent-skills.md)).
+(see [Agent Skills](agent-skills.md)). Two additional governance signals (Wave 2) ride along in the same
+report: cross-location content drift (`--repo` only, always on) and trust-on-first-use reputation matching
+(`--check-baseline`, opt-in) — see [Agent Skills](agent-skills.md#2--compliance-scanner) for how each works.
 
 **Options**
 
@@ -436,10 +438,11 @@ renders a report. v1 is compliance-only — the composite Skill Health & Securit
 | `<path>` | Required, positional. Directory containing one or more skill folders (a REPO ROOT when `--repo` is set). |
 | `--format <fmt>` | `console` (default), `markdown`, or `json`. |
 | `-o, --output <path>` | Write the rendered report to a file instead of stdout. |
-| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Default off (informational-only). |
+| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Default off (informational-only). Cross-location drift (Medium) and previously-vetted matches (Low) never trigger this — only High-severity findings do. |
 | `--write-baseline` | Capture a timestamped baseline snapshot (structural fingerprint + full file-content hash per skill) into the baseline ledger. See [`agenteval skills baseline`](#agenteval-skills-baseline) below. |
-| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. |
-| `--repo` | Treat `<path>` as a repo root: scan every known skill-directory convention found under it (`.claude/skills`, `.agents/skills`, `.windsurf/skills`, ...) and aggregate the results into ONE combined report, instead of treating `<path>` itself as one skill directory. Per-convention breakdown (found/not-present, skill/finding counts) prints to stderr. |
+| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. Used by both `--write-baseline` and `--check-baseline`. |
+| `--repo` | Treat `<path>` as a repo root: scan every known skill-directory convention found under it (`.claude/skills`, `.agents/skills`, `.windsurf/skills`, ...) and aggregate the results into ONE combined report, instead of treating `<path>` itself as one skill directory. Per-convention breakdown (found/not-present, skill/finding counts) prints to stderr. When two or more conventions define the same skill name with DIFFERENT content, a `CrossLocationContentDrift` finding is added automatically. |
+| `--check-baseline` | Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history. A match against any prior snapshot for the same name adds an informational `MatchesPreviouslyVettedCopy` finding. Meaningless on a first-ever scan (no history yet) — pair with `--write-baseline` on earlier runs. |
 
 **Exit codes**
 

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -49,7 +49,7 @@ internal static class SkillsScanCommand
         var writeBaselineOpt = new Option<bool>("--write-baseline")
             { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." };
         var repoOpt = new Option<bool>("--repo")
-            { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory." };
+            { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory. Always content-hashes every skill folder (real file I/O) to check for cross-location drift — the same name resolving to different content in two conventions — even without --write-baseline/--check-baseline." };
         var baselineRootOpt = new Option<string>("--baseline-root")
             { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." };
         var checkBaselineOpt = new Option<bool>("--check-baseline")
@@ -112,10 +112,15 @@ internal static class SkillsScanCommand
         SkillComplianceReport report;
         IReadOnlyList<SkillBaselineEntry> entries;
 
-        // Agent Skills Wave 2: entries (content hash + structural fingerprint per skill) are now built
-        // UNCONDITIONALLY — cross-location drift detection (--repo) and trust-on-first-use matching
-        // (--check-baseline) both need them regardless of whether --write-baseline is also set. Only
-        // PERSISTING a snapshot stays gated behind --write-baseline, below.
+        // Agent Skills Wave 2: entries (content hash + structural fingerprint per skill — real disk I/O,
+        // SkillContentHasher reads every byte of every file in every skill folder) are needed for
+        // cross-location drift detection, trust-on-first-use matching, and persisting a snapshot.
+        // --repo builds them unconditionally: drift detection has no opt-out flag, and a repo-wide
+        // governance scan is expected to cost more than a single-directory one (documented in the --repo
+        // option's own help text). A single-directory scan is NOT --repo-wide, though — a plain
+        // `skills scan <path>` with no flags must keep paying zero extra I/O, exactly like before Wave 2
+        // (previously this cost was gated behind --write-baseline only), so entries are built there ONLY
+        // when something will actually consume them.
         if (repo)
         {
             var (combinedReport, combinedEntries, conventionSummary) =
@@ -128,7 +133,9 @@ internal static class SkillsScanCommand
         {
             var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(path.FullName, noOpAgent, options: null, ct).ConfigureAwait(false);
             report = result.Report;
-            entries = result.Skills.Select(info => ToBaselineEntry(info, report.Findings, conventionPrefix: null)).ToList();
+            entries = (writeBaseline || checkBaseline)
+                ? result.Skills.Select(info => ToBaselineEntry(info, report.Findings, conventionPrefix: null)).ToList()
+                : [];
         }
 
         // Agent Skills Wave 2 (§4.2): --repo cross-location drift is always checked (no extra flag — a
@@ -253,16 +260,23 @@ internal static class SkillsScanCommand
     // ═══════════════════════════════ cross-location drift + trust-on-first-use (Wave 2) ═══════════════════════════════
 
     /// <summary>
-    /// Groups <paramref name="entries"/> by skill <see cref="SkillBaselineEntry.Name"/> and flags any name
-    /// present with 2+ DISTINCT <see cref="SkillBaselineEntry.ContentHash"/> values — the same skill name
-    /// resolves to different content depending on which convention/agent-tool reads it. Only meaningful for
-    /// a <c>--repo</c> scan (a single-directory scan has exactly one location by definition).
+    /// Groups <paramref name="entries"/> by skill <see cref="SkillBaselineEntry.Name"/> (case-insensitive —
+    /// GA requires lowercase-only names, so a name differing only by case across two conventions is the
+    /// SAME poisoning/drift scenario this rule targets, not two unrelated skills) and flags any name present
+    /// with 2+ DISTINCT <see cref="SkillBaselineEntry.ContentHash"/> values — the same skill name resolves
+    /// to different content depending on which convention/agent-tool reads it. Only meaningful for a
+    /// <c>--repo</c> scan (a single-directory scan has exactly one location by definition). Entries with an
+    /// empty/missing name are excluded from grouping entirely — two independently-malformed skills that both
+    /// lack a <c>name:</c> field are NOT "the same skill drifting," and grouping them by their shared empty
+    /// name would produce a misleading finding.
     /// </summary>
     internal static IReadOnlyList<SkillComplianceFinding> DetectCrossLocationDrift(IReadOnlyList<SkillBaselineEntry> entries)
     {
         var findings = new List<SkillComplianceFinding>();
 
-        foreach (var group in entries.Where(e => e.ContentHash is not null).GroupBy(e => e.Name, StringComparer.Ordinal))
+        foreach (var group in entries
+            .Where(e => e.ContentHash is not null && !string.IsNullOrEmpty(e.Name))
+            .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase))
         {
             var distinctHashes = group.Select(e => e.ContentHash!).Distinct(StringComparer.Ordinal).ToList();
             if (distinctHashes.Count <= 1)
@@ -294,22 +308,13 @@ internal static class SkillsScanCommand
     internal static IReadOnlyList<SkillComplianceFinding> DetectPreviouslyVetted(
         IReadOnlyList<SkillBaselineEntry> entries, IReadOnlyList<SkillBaselineSnapshot> history)
     {
-        var mostRecentMatchByNameAndHash = new Dictionary<(string Name, string Hash), DateTimeOffset>();
-        foreach (var snapshot in history.OrderByDescending(s => s.CapturedAt))
-        {
-            foreach (var historicalEntry in snapshot.Skills)
-            {
-                if (historicalEntry.ContentHash is null)
-                {
-                    continue;
-                }
-
-                var key = (historicalEntry.Name, historicalEntry.ContentHash);
-                // OrderByDescending above means the FIRST time a key is seen is already its most recent
-                // sighting — never overwrite with an older snapshot's date.
-                mostRecentMatchByNameAndHash.TryAdd(key, snapshot.CapturedAt);
-            }
-        }
+        // States the invariant directly (Max per key) instead of depending on an implicit
+        // "OrderByDescending + TryAdd keeps the first, which is the newest" ordering trick — a future edit
+        // reordering these calls can't silently start reporting the OLDEST match instead of the newest.
+        var mostRecentMatchByNameAndHash = history
+            .SelectMany(s => s.Skills.Where(e => e.ContentHash is not null).Select(e => (Key: (e.Name, e.ContentHash!), s.CapturedAt)))
+            .GroupBy(x => x.Key)
+            .ToDictionary(g => g.Key, g => g.Max(x => x.CapturedAt));
 
         var findings = new List<SkillComplianceFinding>();
         foreach (var entry in entries)
@@ -344,7 +349,20 @@ internal static class SkillsScanCommand
         string? contentHash = null;
         if (!string.IsNullOrWhiteSpace(info.AbsolutePath) && Directory.Exists(info.AbsolutePath))
         {
-            contentHash = SkillContentHasher.HashSkillFolder(info.AbsolutePath);
+            try
+            {
+                contentHash = SkillContentHasher.HashSkillFolder(info.AbsolutePath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // A locked/permission-denied file inside ONE skill's folder must not abort the whole scan
+                // for a reason unrelated to skill compliance (this call is now reachable from every --repo
+                // scan, not just --write-baseline — see this method's own callers). ContentHash stays null
+                // (same value a non-file-sourced skill already legitimately gets) — Wave 2's drift/TOFU
+                // detection already skip null-ContentHash entries, so this skill is simply excluded from
+                // those two checks rather than crashing the run. Surfaced to the operator, not swallowed.
+                Console.Error.WriteLine($"  Warning: could not compute content hash for skill '{manifest.Name}' ({info.AbsolutePath}): {ex.Message}");
+            }
         }
 
         var dirName = manifest.ParentDirectoryName ?? manifest.Name;
@@ -512,8 +530,14 @@ internal static class SkillsScanCommand
         Console.WriteLine($"Diffing {baseline.Id} ({baseline.CapturedAt:yyyy-MM-dd HH:mm:ss} UTC) -> {current.Id} ({current.CapturedAt:yyyy-MM-dd HH:mm:ss} UTC), hash={hashKind}");
         Console.WriteLine();
 
-        var baselineBySkill = baseline.Skills.ToDictionary(e => e.Name, StringComparer.Ordinal);
-        var currentBySkill = current.Skills.ToDictionary(e => e.Name, StringComparer.Ordinal);
+        // Wave 2: a --repo snapshot can legitimately contain 2+ entries with the SAME Name (the exact
+        // cross-location scenario CrossLocationContentDrift exists to surface) — plain ToDictionary(e =>
+        // e.Name) would throw ArgumentException ("same key already added") the first time that happens.
+        // GroupBy + First deterministically keeps the first-encountered location (KnownConventions'
+        // iteration order) instead of crashing; a true per-location diff is a real, larger feature this
+        // fix deliberately does not attempt — see DiffAsync/HistoryAsync's own remarks.
+        var baselineBySkill = baseline.Skills.GroupBy(e => e.Name, StringComparer.Ordinal).ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+        var currentBySkill = current.Skills.GroupBy(e => e.Name, StringComparer.Ordinal).ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
 
         foreach (var f in findings.OrderBy(f => f.Key, StringComparer.Ordinal))
         {
@@ -552,6 +576,11 @@ internal static class SkillsScanCommand
         return ExitCodes.Success;
     }
 
+    // Wave 2 known limitation: a --repo snapshot can contain 2+ entries sharing the same Name (the
+    // cross-location scenario CrossLocationContentDrift surfaces). HistoryAsync's FirstOrDefault below
+    // picks an arbitrary one of them per snapshot (stable within one run, since KnownConventions' order
+    // is fixed, but not a real per-location history) rather than crashing — a true per-location history
+    // view is a real, larger feature this fix deliberately does not attempt.
     internal static async Task<int> HistoryAsync(string baselineRoot, string skillName, CancellationToken ct)
     {
         var store = new JsonFileSkillBaselineStore(baselineRoot);
@@ -603,10 +632,13 @@ internal static class SkillsScanCommand
     // null for them (see SkillBaselineEntry's remarks). With --hash content (the default), such a skill is
     // silently OMITTED from the diff entirely rather than reported as New/Removed/Changed/Unchanged with a
     // fabricated hash — pass --hash structural to diff those skills too (their StructuralFingerprint always exists).
+    // Wave 2: GroupBy + First (not ToDictionary directly) — see baselineBySkill/currentBySkill's own
+    // comment above for why a --repo snapshot can contain duplicate Names and why ToDictionary would crash.
     private static Dictionary<string, string> HashesByName(SkillBaselineSnapshot snapshot, bool useContent) =>
         snapshot.Skills
             .Where(e => !useContent || e.ContentHash is not null)
-            .ToDictionary(e => e.Name, e => useContent ? e.ContentHash! : e.StructuralFingerprint, StringComparer.Ordinal);
+            .GroupBy(e => e.Name, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => useContent ? g.First().ContentHash! : g.First().StructuralFingerprint, StringComparer.Ordinal);
 
     private static string Truncate(string value, int maxLength) =>
         value.Length <= maxLength ? value : value[..(maxLength - 1)] + "…";

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -51,7 +51,9 @@ internal static class SkillsScanCommand
         var repoOpt = new Option<bool>("--repo")
             { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory." };
         var baselineRootOpt = new Option<string>("--baseline-root")
-            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline)." };
+            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." };
+        var checkBaselineOpt = new Option<bool>("--check-baseline")
+            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding. Meaningless on a first-ever scan (no history yet) — pair with --write-baseline on earlier runs." };
 
         scanCmd.Arguments.Add(pathArg);
         scanCmd.Options.Add(formatOpt);
@@ -60,6 +62,7 @@ internal static class SkillsScanCommand
         scanCmd.Options.Add(writeBaselineOpt);
         scanCmd.Options.Add(repoOpt);
         scanCmd.Options.Add(baselineRootOpt);
+        scanCmd.Options.Add(checkBaselineOpt);
 
         scanCmd.SetAction(async (parseResult, ct) =>
         {
@@ -73,6 +76,7 @@ internal static class SkillsScanCommand
                     parseResult.GetValue(writeBaselineOpt),
                     parseResult.GetValue(repoOpt),
                     parseResult.GetValue(baselineRootOpt)!,
+                    parseResult.GetValue(checkBaselineOpt),
                     ct);
             }
             catch (Exception ex)
@@ -95,7 +99,8 @@ internal static class SkillsScanCommand
     /// </summary>
     internal static async Task<int> ExecuteAsync(
         DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
-        bool writeBaseline = false, bool repo = false, string baselineRoot = DefaultBaselineRoot, CancellationToken ct = default)
+        bool writeBaseline = false, bool repo = false, string baselineRoot = DefaultBaselineRoot,
+        bool checkBaseline = false, CancellationToken ct = default)
     {
         if (!path.Exists)
         {
@@ -105,21 +110,46 @@ internal static class SkillsScanCommand
         AIAgent noOpAgent = new ChatClientAgent(new ScriptedChatClient(), new ChatClientAgentOptions { Name = "SkillsScanCommand" });
 
         SkillComplianceReport report;
-        SkillBaselineSnapshot? snapshot;
+        IReadOnlyList<SkillBaselineEntry> entries;
 
+        // Agent Skills Wave 2: entries (content hash + structural fingerprint per skill) are now built
+        // UNCONDITIONALLY — cross-location drift detection (--repo) and trust-on-first-use matching
+        // (--check-baseline) both need them regardless of whether --write-baseline is also set. Only
+        // PERSISTING a snapshot stays gated behind --write-baseline, below.
         if (repo)
         {
-            var (combinedReport, combinedSnapshot, conventionSummary) =
-                await ScanRepoWideAsync(path.FullName, noOpAgent, writeBaseline, ct).ConfigureAwait(false);
+            var (combinedReport, combinedEntries, conventionSummary) =
+                await ScanRepoWideAsync(path.FullName, noOpAgent, ct).ConfigureAwait(false);
             report = combinedReport;
-            snapshot = combinedSnapshot;
+            entries = combinedEntries;
             Console.Error.WriteLine(conventionSummary);
         }
         else
         {
             var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(path.FullName, noOpAgent, options: null, ct).ConfigureAwait(false);
             report = result.Report;
-            snapshot = writeBaseline ? BuildSnapshot(path.FullName, result.Skills, report.Findings) : null;
+            entries = result.Skills.Select(info => ToBaselineEntry(info, report.Findings, conventionPrefix: null)).ToList();
+        }
+
+        // Agent Skills Wave 2 (§4.2): --repo cross-location drift is always checked (no extra flag — a
+        // repo-wide scan is the only mode where "cross-location" is even meaningful); --check-baseline
+        // trust-on-first-use matching is opt-in (meaningless without prior baseline history).
+        var extraFindings = new List<SkillComplianceFinding>();
+        if (repo)
+        {
+            extraFindings.AddRange(DetectCrossLocationDrift(entries));
+        }
+
+        if (checkBaseline)
+        {
+            var historyStore = new JsonFileSkillBaselineStore(baselineRoot);
+            var history = await historyStore.ListAsync(ct).ConfigureAwait(false);
+            extraFindings.AddRange(DetectPreviouslyVetted(entries, history));
+        }
+
+        if (extraFindings.Count > 0)
+        {
+            report = report with { Findings = [.. report.Findings, .. extraFindings] };
         }
 
         var rendered = RenderReport(report, format);
@@ -134,8 +164,9 @@ internal static class SkillsScanCommand
             Console.WriteLine(rendered);
         }
 
-        if (snapshot is not null)
+        if (writeBaseline)
         {
+            var snapshot = new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, path.FullName, entries);
             var store = new JsonFileSkillBaselineStore(baselineRoot);
             var id = await store.SaveAsync(snapshot, ct).ConfigureAwait(false);
             Console.Error.WriteLine($"  Baseline snapshot saved: {id} ({snapshot.Skills.Count} skill(s) -> {baselineRoot})");
@@ -171,9 +202,12 @@ internal static class SkillsScanCommand
     /// like a single-root scan); the per-convention breakdown (which conventions existed, which didn't) is
     /// returned separately and printed to stderr — keeping stdout's shape (console/markdown/JSON) identical
     /// across <c>--repo</c> and non-<c>--repo</c> scans, rather than inventing a second JSON schema.
+    /// Entries (content hash + structural fingerprint per skill, tagged with which convention it came from
+    /// via <see cref="SkillBaselineEntry.RelativePath"/>) are now always built (Wave 2) — the caller decides
+    /// whether to persist them as a baseline snapshot and/or run cross-location drift detection over them.
     /// </summary>
-    private static async Task<(SkillComplianceReport Report, SkillBaselineSnapshot? Snapshot, string ConventionSummary)> ScanRepoWideAsync(
-        string repoRoot, AIAgent agent, bool writeBaseline, CancellationToken ct)
+    private static async Task<(SkillComplianceReport Report, IReadOnlyList<SkillBaselineEntry> Entries, string ConventionSummary)> ScanRepoWideAsync(
+        string repoRoot, AIAgent agent, CancellationToken ct)
     {
         var allFindings = new List<SkillComplianceFinding>();
         int skillCount = 0, withResources = 0, withScripts = 0, silentlyExcluded = 0;
@@ -204,32 +238,103 @@ internal static class SkillsScanCommand
                 histogram[stage] = histogram.GetValueOrDefault(stage) + count;
             }
 
-            if (writeBaseline)
+            foreach (var info in result.Skills)
             {
-                foreach (var info in result.Skills)
-                {
-                    entries.Add(ToBaselineEntry(info, result.Report.Findings, convention));
-                }
+                entries.Add(ToBaselineEntry(info, result.Report.Findings, convention));
             }
         }
 
         var combinedReport = new SkillComplianceReport(
             allFindings, new SkillCoverageSummary(skillCount, withResources, withScripts, histogram, silentlyExcluded));
-        var snapshot = writeBaseline
-            ? new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, repoRoot, entries)
-            : null;
 
-        return (combinedReport, snapshot, summary.ToString().TrimEnd());
+        return (combinedReport, entries, summary.ToString().TrimEnd());
+    }
+
+    // ═══════════════════════════════ cross-location drift + trust-on-first-use (Wave 2) ═══════════════════════════════
+
+    /// <summary>
+    /// Groups <paramref name="entries"/> by skill <see cref="SkillBaselineEntry.Name"/> and flags any name
+    /// present with 2+ DISTINCT <see cref="SkillBaselineEntry.ContentHash"/> values — the same skill name
+    /// resolves to different content depending on which convention/agent-tool reads it. Only meaningful for
+    /// a <c>--repo</c> scan (a single-directory scan has exactly one location by definition).
+    /// </summary>
+    internal static IReadOnlyList<SkillComplianceFinding> DetectCrossLocationDrift(IReadOnlyList<SkillBaselineEntry> entries)
+    {
+        var findings = new List<SkillComplianceFinding>();
+
+        foreach (var group in entries.Where(e => e.ContentHash is not null).GroupBy(e => e.Name, StringComparer.Ordinal))
+        {
+            var distinctHashes = group.Select(e => e.ContentHash!).Distinct(StringComparer.Ordinal).ToList();
+            if (distinctHashes.Count <= 1)
+            {
+                continue; // same content everywhere it was found — no drift
+            }
+
+            var locations = string.Join(", ", group.Select(e => $"{e.RelativePath} ({e.ContentHash![..Math.Min(8, e.ContentHash.Length)]}…)"));
+            findings.Add(new SkillComplianceFinding(
+                group.Key,
+                SkillComplianceRule.CrossLocationContentDrift,
+                Severity.Medium,
+                $"Skill '{group.Key}' has DIFFERENT content across {group.Count()} location(s): {locations} — " +
+                "the same skill name resolves to different content depending on which agent tool reads it. " +
+                "Verify this is intentional per-tool customization, not drift or poisoning.",
+                Field: null));
+        }
+
+        return findings;
+    }
+
+    /// <summary>
+    /// Trust-on-first-use: for each of <paramref name="entries"/> with a non-null
+    /// <see cref="SkillBaselineEntry.ContentHash"/>, checks whether that exact (name, hash) pair already
+    /// appears somewhere in <paramref name="history"/> — i.e. this exact copy was captured and vetted in a
+    /// prior <c>--write-baseline</c> run. Reports the MOST RECENT matching snapshot's capture date (not the
+    /// first ever seen) so the finding answers "when did I last confirm this," not "when did this first appear."
+    /// </summary>
+    internal static IReadOnlyList<SkillComplianceFinding> DetectPreviouslyVetted(
+        IReadOnlyList<SkillBaselineEntry> entries, IReadOnlyList<SkillBaselineSnapshot> history)
+    {
+        var mostRecentMatchByNameAndHash = new Dictionary<(string Name, string Hash), DateTimeOffset>();
+        foreach (var snapshot in history.OrderByDescending(s => s.CapturedAt))
+        {
+            foreach (var historicalEntry in snapshot.Skills)
+            {
+                if (historicalEntry.ContentHash is null)
+                {
+                    continue;
+                }
+
+                var key = (historicalEntry.Name, historicalEntry.ContentHash);
+                // OrderByDescending above means the FIRST time a key is seen is already its most recent
+                // sighting — never overwrite with an older snapshot's date.
+                mostRecentMatchByNameAndHash.TryAdd(key, snapshot.CapturedAt);
+            }
+        }
+
+        var findings = new List<SkillComplianceFinding>();
+        foreach (var entry in entries)
+        {
+            if (entry.ContentHash is null)
+            {
+                continue;
+            }
+
+            if (mostRecentMatchByNameAndHash.TryGetValue((entry.Name, entry.ContentHash), out var matchedAt))
+            {
+                findings.Add(new SkillComplianceFinding(
+                    entry.Name,
+                    SkillComplianceRule.MatchesPreviouslyVettedCopy,
+                    Severity.Low,
+                    $"✓ Skill '{entry.Name}' is byte-identical to a previously-captured baseline snapshot " +
+                    $"(most recent match: {matchedAt:yyyy-MM-dd}) — no content drift since it was last vetted.",
+                    Field: null));
+            }
+        }
+
+        return findings;
     }
 
     // ═══════════════════════════════ baseline entry building (§4.1) ═══════════════════════════════
-
-    private static SkillBaselineSnapshot BuildSnapshot(
-        string scannedRoot, IReadOnlyList<ScannedSkillInfo> skills, IReadOnlyList<SkillComplianceFinding> findings)
-    {
-        var entries = skills.Select(info => ToBaselineEntry(info, findings, conventionPrefix: null)).ToList();
-        return new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, scannedRoot, entries);
-    }
 
     private static SkillBaselineEntry ToBaselineEntry(
         ScannedSkillInfo info, IReadOnlyList<SkillComplianceFinding> allFindings, string? conventionPrefix)

--- a/src/AgentEval.Core/Skills/SkillComplianceModels.cs
+++ b/src/AgentEval.Core/Skills/SkillComplianceModels.cs
@@ -65,6 +65,26 @@ public enum SkillComplianceRule
     /// <c>strategy/FutureFeatures/Skills/Skill-Discovery-Exclusion-Detection-Design.md</c>.
     /// </summary>
     SkillExcludedFromDiscovery,
+
+    /// <summary>
+    /// Agent Skills Wave 2 — <c>agenteval skills scan --repo</c> found the SAME skill name present under two
+    /// or more different directory conventions (e.g. <c>.claude/skills/foo</c> and <c>.cursor/skills/foo</c>)
+    /// with DIFFERENT <see cref="SkillContentHasher.HashSkillFolder"/> content hashes. Which copy actually
+    /// loads depends on which agent tool reads it — could be intentional per-tool customization, or could be
+    /// one location silently drifting (or being poisoned) while another stays trusted. <see cref="Severity.Medium"/>,
+    /// not High — this is a governance signal to investigate, not automatically a defect (the divergence may
+    /// be deliberate).
+    /// </summary>
+    CrossLocationContentDrift,
+
+    /// <summary>
+    /// Agent Skills Wave 2, trust-on-first-use — <c>agenteval skills scan --check-baseline</c> found this
+    /// skill's current <see cref="SkillContentHasher.HashSkillFolder"/> content hash matches a hash already
+    /// present in the baseline ledger (<see cref="ISkillBaselineStore"/>) for the SAME skill name — i.e. this
+    /// exact copy was already captured and vetted in a prior scan. Purely informational
+    /// (<see cref="Severity.Low"/>) — a positive "no drift since last seen" signal, not a problem.
+    /// </summary>
+    MatchesPreviouslyVettedCopy,
 }
 
 /// <summary>One rule violation (or informational flag) found for one skill.</summary>

--- a/src/AgentEval.Core/Skills/SkillComplianceModels.cs
+++ b/src/AgentEval.Core/Skills/SkillComplianceModels.cs
@@ -71,9 +71,19 @@ public enum SkillComplianceRule
     /// or more different directory conventions (e.g. <c>.claude/skills/foo</c> and <c>.cursor/skills/foo</c>)
     /// with DIFFERENT <see cref="SkillContentHasher.HashSkillFolder"/> content hashes. Which copy actually
     /// loads depends on which agent tool reads it — could be intentional per-tool customization, or could be
-    /// one location silently drifting (or being poisoned) while another stays trusted. <see cref="Severity.Medium"/>,
-    /// not High — this is a governance signal to investigate, not automatically a defect (the divergence may
-    /// be deliberate).
+    /// one location silently drifting (or being poisoned) while another stays trusted.
+    /// <para><b>Deliberately <see cref="Severity.Medium"/>, not High</b> — a governance signal to
+    /// investigate, not automatically a defect: the divergence may be deliberate per-tool customization,
+    /// which is a legitimate, common pattern this rule must not punish. Matches this same file's own
+    /// precedent (<see cref="ResourceFromUntrustedSource"/> is also Medium despite naming an injection-surface
+    /// risk in its own doc comment) rather than <see cref="SkillExcludedFromDiscovery"/>'s High (which fires
+    /// only when a skill is provably non-functional, not merely ambiguous).</para>
+    /// <para><b>Known scoping limits, not yet closed:</b> the competing locations/hashes are reported only in
+    /// the finding's human-readable <see cref="SkillComplianceFinding.Message"/> (hashes truncated to 8 hex
+    /// chars for display) — a machine consumer (CI script, SARIF tool) cannot extract them without
+    /// string-parsing. A container-mode skill nested 2 directory levels deep under the SAME convention can
+    /// share a bare directory name with an unrelated sibling, producing an ambiguous location label. Both are
+    /// accepted, disclosed gaps for Wave 2, not silently-missed cases.</para>
     /// </summary>
     CrossLocationContentDrift,
 

--- a/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
@@ -374,6 +374,42 @@ public class SkillsBaselineCommandTests : IDisposable
         finally { Directory.Delete(repoRoot, recursive: true); }
     }
 
+    [Fact]
+    public async Task ExecuteAsync_RepoWriteBaseline_DuplicateSkillNameAcrossConventions_ThenDiffAndHistory_DoNotThrow()
+    {
+        // Regression: a --repo --write-baseline snapshot can legitimately contain 2+ entries with the SAME
+        // Name (the exact cross-location-drift scenario) — `baseline diff`/`baseline history` must not crash
+        // with an unhandled ArgumentException ("same key already added") when that happens.
+        var repoRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-dupname-test-" + Guid.NewGuid().ToString("N"));
+        var claudeDir = Path.Combine(repoRoot, ".claude", "skills", "shared-skill");
+        var cursorDir = Path.Combine(repoRoot, ".cursor", "skills", "shared-skill");
+        Directory.CreateDirectory(claudeDir);
+        Directory.CreateDirectory(cursorDir);
+        File.WriteAllText(Path.Combine(claudeDir, "SKILL.md"),
+            "---\nname: shared-skill\ndescription: Present under .claude/skills.\n---\n\nBody variant A.\n");
+        File.WriteAllText(Path.Combine(cursorDir, "SKILL.md"),
+            "---\nname: shared-skill\ndescription: Present under .claude/skills.\n---\n\nBody variant B — DIFFERENT.\n");
+
+        try
+        {
+            // Two --write-baseline runs so `diff`/`history` have real snapshot history to walk, each one
+            // containing the duplicate-Name pair that would previously crash HashesByName/baselineBySkill.
+            await SkillsScanCommand.ExecuteAsync(
+                new DirectoryInfo(repoRoot), "console", null, failOnNoncompliant: false,
+                writeBaseline: true, repo: true, baselineRoot: _baselineRoot, ct: default);
+            await SkillsScanCommand.ExecuteAsync(
+                new DirectoryInfo(repoRoot), "console", null, failOnNoncompliant: false,
+                writeBaseline: true, repo: true, baselineRoot: _baselineRoot, ct: default);
+
+            var diffExit = await SkillsScanCommand.DiffAsync(_baselineRoot, sinceId: null, skillFilter: null, hashKind: "content", default);
+            Assert.Equal(ExitCodes.Success, diffExit);
+
+            var historyExit = await SkillsScanCommand.HistoryAsync(_baselineRoot, "shared-skill", default);
+            Assert.Equal(ExitCodes.Success, historyExit);
+        }
+        finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
     // ── Wave 2 (§4.2): --check-baseline trust-on-first-use ──
 
     [Fact]

--- a/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
@@ -55,6 +55,14 @@ public class SkillsBaselineCommandTests : IDisposable
         Assert.Contains(scanCmd.Options, o => o.Name == "--baseline-root");
     }
 
+    [Fact]
+    public void Create_ScanSubcommand_HasCheckBaselineOption()
+    {
+        // Wave 2 (§4.2)
+        var scanCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--check-baseline");
+    }
+
     // ── --write-baseline: scan a real fixture, confirm a snapshot lands in the ledger ──
 
     [Fact]
@@ -296,6 +304,186 @@ public class SkillsBaselineCommandTests : IDisposable
             Assert.Equal(ExitCodes.Success, exit);
         }
         finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
+    // ── Wave 2 (§4.2): --repo cross-location content drift ──
+
+    [Fact]
+    public async Task ExecuteAsync_Repo_SameSkillName_DifferentContentAcrossConventions_FlagsCrossLocationDrift()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-drift-test-" + Guid.NewGuid().ToString("N"));
+        var claudeDir = Path.Combine(repoRoot, ".claude", "skills", "shared-skill");
+        var cursorDir = Path.Combine(repoRoot, ".cursor", "skills", "shared-skill");
+        Directory.CreateDirectory(claudeDir);
+        Directory.CreateDirectory(cursorDir);
+        // Same skill NAME, deliberately different body content -> different content hash.
+        File.WriteAllText(Path.Combine(claudeDir, "SKILL.md"),
+            "---\nname: shared-skill\ndescription: Present under .claude/skills.\n---\n\nBody variant A.\n");
+        File.WriteAllText(Path.Combine(cursorDir, "SKILL.md"),
+            "---\nname: shared-skill\ndescription: Present under .claude/skills.\n---\n\nBody variant B — DIFFERENT.\n");
+
+        try
+        {
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-drift-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteAsync(
+                    new DirectoryInfo(repoRoot), "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: false, repo: true, baselineRoot: _baselineRoot, ct: default);
+
+                // Medium severity, not High -> IsCompliant stays true, exit stays Success (informational-only default).
+                // Note: SkillComplianceReportRenderer's JSON has no JsonStringEnumConverter, so Rule serializes
+                // as its raw int value, not the enum name — assert on the human-readable Message text instead.
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("DIFFERENT content across", content, StringComparison.Ordinal);
+                Assert.Contains("shared-skill", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Repo_SameSkillName_SameContentAcrossConventions_NoDriftFinding()
+    {
+        // Regression guard: identical content in two locations must NOT be flagged as drift.
+        var repoRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-nodrift-test-" + Guid.NewGuid().ToString("N"));
+        var claudeDir = Path.Combine(repoRoot, ".claude", "skills", "identical-skill");
+        var cursorDir = Path.Combine(repoRoot, ".cursor", "skills", "identical-skill");
+        Directory.CreateDirectory(claudeDir);
+        Directory.CreateDirectory(cursorDir);
+        const string identicalBody = "---\nname: identical-skill\ndescription: Byte-identical in both locations.\n---\n\nSame body.\n";
+        File.WriteAllText(Path.Combine(claudeDir, "SKILL.md"), identicalBody);
+        File.WriteAllText(Path.Combine(cursorDir, "SKILL.md"), identicalBody);
+
+        try
+        {
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-nodrift-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                await SkillsScanCommand.ExecuteAsync(
+                    new DirectoryInfo(repoRoot), "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: false, repo: true, baselineRoot: _baselineRoot, ct: default);
+
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.DoesNotContain("DIFFERENT content across", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(repoRoot, recursive: true); }
+    }
+
+    // ── Wave 2 (§4.2): --check-baseline trust-on-first-use ──
+
+    [Fact]
+    public async Task ExecuteAsync_CheckBaseline_UnchangedSinceLastSnapshot_FlagsMatchesPreviouslyVettedCopy()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            // First run: capture a baseline snapshot.
+            await SkillsScanCommand.ExecuteAsync(
+                dir, "console", output: null, failOnNoncompliant: false,
+                writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            // Second run: unchanged fixture, --check-baseline (no --write-baseline this time).
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-tofu-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteAsync(
+                    dir, "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: false, repo: false, baselineRoot: _baselineRoot, checkBaseline: true, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("byte-identical to a previously-captured baseline snapshot", content, StringComparison.Ordinal);
+                Assert.Contains(skillName, content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CheckBaseline_NoPriorHistory_DoesNotThrow_NoFindingEmitted()
+    {
+        // First-ever scan: --check-baseline is meaningless (nothing to compare against) but must not crash.
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-tofu-empty-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteAsync(
+                    dir, "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: false, repo: false, baselineRoot: _baselineRoot, checkBaseline: true, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.DoesNotContain("byte-identical to a previously-captured baseline snapshot", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CheckBaseline_ContentChangedSincePriorSnapshot_NoMatchFinding()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(
+                dir, "console", output: null, failOnNoncompliant: false,
+                writeBaseline: true, repo: false, baselineRoot: _baselineRoot, ct: default);
+
+            // Mutate the skill's content after the baseline was captured.
+            var skillFile = Path.Combine(dir.FullName, skillName, "SKILL.md");
+            File.WriteAllText(skillFile, File.ReadAllText(skillFile) + "\nAn extra line changing the content hash.\n");
+
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-tofu-changed-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                await SkillsScanCommand.ExecuteAsync(
+                    dir, "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: false, repo: false, baselineRoot: _baselineRoot, checkBaseline: true, ct: default);
+
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.DoesNotContain("byte-identical to a previously-captured baseline snapshot", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    // ── Wave 2: direct unit coverage for the pure detection helpers ──
+
+    [Fact]
+    public void DetectCrossLocationDrift_EmptyEntries_ReturnsEmpty()
+    {
+        Assert.Empty(SkillsScanCommand.DetectCrossLocationDrift([]));
+    }
+
+    [Fact]
+    public void DetectCrossLocationDrift_SingleLocationPerName_ReturnsEmpty()
+    {
+        var entries = new[]
+        {
+            new SkillBaselineEntry("a", SkillSourceKind.File, ".claude/skills/a", "struct-a", "hash-a", null, null, null, []),
+            new SkillBaselineEntry("b", SkillSourceKind.File, ".claude/skills/b", "struct-b", "hash-b", null, null, null, []),
+        };
+        Assert.Empty(SkillsScanCommand.DetectCrossLocationDrift(entries));
+    }
+
+    [Fact]
+    public void DetectPreviouslyVetted_EmptyHistory_ReturnsEmpty()
+    {
+        var entries = new[]
+        {
+            new SkillBaselineEntry("a", SkillSourceKind.File, ".claude/skills/a", "struct-a", "hash-a", null, null, null, []),
+        };
+        Assert.Empty(SkillsScanCommand.DetectPreviouslyVetted(entries, []));
     }
 
     // ── helpers (mirrors SkillsScanCommandTests' fixture builder) ──


### PR DESCRIPTION
## Summary

Two new governance signals for `agenteval skills scan`, built on the existing Wave 1 baseline ledger:

- **Cross-location content drift** — always checked on a `--repo` scan (no extra flag). Flags any skill name that resolves to different content across two or more directory conventions (Medium severity — a governance signal, not an automatic failure, since the divergence may be deliberate per-tool customization).
- **Trust-on-first-use reputation matching** — opt-in via `--check-baseline`. Flags a skill whose current content hash matches any prior baseline snapshot for the same name (Low severity, informational "✓ matches a previously-vetted copy").

Both are ordinary `SkillComplianceFinding`s, so they render in console/markdown/json output automatically with zero renderer changes.

**A 7-angle review of the first commit found a critical bug** (independently confirmed by 3 reviewers): `baseline diff`/`baseline history` crashed with an unhandled `ArgumentException` the moment a `--repo --write-baseline` snapshot contained the same skill name at two locations — exactly Wave 2's own headline scenario. Fixed (second commit) along with several other real gaps: unconditional file I/O on the common no-flags scan path (independently confirmed by 4 reviewers), a new unguarded crash surface from an unreadable file, a false-positive collision for empty-named skills, and a case-sensitivity gap that silently defeated the exact poisoning scenario the drift check targets. See the second commit message for the full list.

## Test plan
- [x] Full solution build: 0 errors across net8.0/9.0/10.0
- [x] Full net8.0 test suite: 7755 passed, 0 failed, 1 skipped
- [x] `skills scan --help` verified live to show `--check-baseline`
- [x] New regression test reproduces the exact duplicate-name `--repo --write-baseline` scenario end-to-end (scan twice, then `diff` and `history`) and asserts neither throws
- [x] 11 total new tests: CLI wiring, cross-location-drift (positive + negative), trust-on-first-use (match/no-history/changed), direct unit tests for the pure detection helpers, and the crash regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)