### PR TITLE
feat(skills): Wave 3a — filesystem multi-repo scan (scan-workspace)

### DIFF
--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -110,6 +110,28 @@ json output automatically, no new schema):
 Neither feature is High severity — both are informational/governance signals, not automatic compliance
 failures, so `--fail-on-noncompliant` is unaffected by either.
 
+**Filesystem multi-repo scan (Wave 3a):** `agenteval skills scan-workspace <path>` treats `<path>` as a folder
+of *already-cloned* repos — each immediate subdirectory is one repo — and runs the existing `--repo` pipeline
+against every one of them, combining the results into one report. Zero new discovery code: it's a fan-out loop
+over the same pipeline `--repo` already uses, per repo. Filesystem-only — no network, no credentials, no new
+trust surface; the operator's own clone step (`git clone` / `gh repo clone`, their own access, their own
+tooling) is what decides which repos are visible here, deliberately kept outside this verb's scope. Every
+entry is tagged with a `{repoFolder}/{conventionPath}` location, so the *existing*, unchanged
+`DetectCrossLocationDrift` (it only ever groups by skill name, never by location) also catches drift **across
+repos** for free — the same "skill X is byte-identical across N repos except M outliers" signal Wave 2 gives
+you within one repo, now at workspace scale:
+
+```bash
+# clone the repos you want to audit yourself first, e.g.:
+#   gh repo clone myorg/service-a ~/audit/service-a
+#   gh repo clone myorg/service-b ~/audit/service-b
+agenteval skills scan-workspace ~/audit --write-baseline --format json -o report.json
+```
+
+Same option surface as `scan --repo` (`--format`, `--fail-on-noncompliant`, `--write-baseline`,
+`--baseline-root`, `--check-baseline`) — deliberately a separate verb rather than a `--workspace` flag bolted
+onto `scan`, to avoid colliding with Mission Control's own, unrelated `--workspace` concept.
+
 ## 3 — Skill-injection red-team attack + `run_skill_script` governance
 
 `AgentEval.RedTeam.Attacks.SkillInjectionAttack` (OWASP LLM01, in `Attack.All` — the framework now ships **14**
@@ -204,9 +226,11 @@ and would crash the whole scan, is caught and reported as one clean finding inst
 
 Phase 4c (skill fuzzing via the transform/codec pipeline, a canary-skill honeypot, skill-name typosquatting,
 load-storm-as-denial-of-wallet) was deprioritized this session in favor of shipping 4a/4b and the exclusion-
-detection fix (§5) with full rigor. Wave 3 (org-wide multi-repo scanning via a new GitHub/GitLab API client;
-live upstream verification against a skill's declared source) is gated on a security/credential-scope review
-not yet held — see `strategy/TODO.md` (local-only) for the up-to-date backlog.
+detection fix (§5) with full rigor. Wave 3a (filesystem multi-repo scan, `scan-workspace`) shipped — see §2
+above. **Wave 3b** (a live, API-driven org-wide scan reaching repos you haven't cloned — `scan-org` — plus live
+upstream verification against a skill's declared source URL) is still gated on a security/credential-scope
+review not yet held, since it needs a real GitHub/GitLab API client and token handling that `scan-workspace`
+deliberately avoids — see `strategy/TODO.md` (local-only) for the up-to-date backlog.
 
 ## Related
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -130,7 +130,25 @@ agenteval skills scan-workspace ~/audit --write-baseline --format json -o report
 
 Same option surface as `scan --repo` (`--format`, `--fail-on-noncompliant`, `--write-baseline`,
 `--baseline-root`, `--check-baseline`) — deliberately a separate verb rather than a `--workspace` flag bolted
-onto `scan`, to avoid colliding with Mission Control's own, unrelated `--workspace` concept.
+onto `scan`, to avoid colliding with Mission Control's own, unrelated `--workspace` concept. Defaults to its
+own baseline root (`.agenteval/skills-baselines-workspace`, not `scan`'s `.agenteval/skills-baselines`) so a
+later plain `scan --write-baseline` can't accidentally get diffed against a wildly larger workspace-scale
+snapshot (or vice versa) — pass `--baseline-root` explicitly if you genuinely want one shared ledger.
+
+**Two known limitations, disclosed here rather than discovered the hard way:**
+- **`baseline diff`/`history` track only one location per skill name, even when the SAME scan legitimately
+  produced several** (Wave 2's own pre-existing shortcut, `GroupBy(Name).First()`, chosen to avoid crashing on
+  duplicate names rather than to build a full per-location history — see the code's own remarks). At `--repo`
+  scale this rarely bites; at workspace scale, where the same skill name in N repos is the expected case, it
+  means `baseline diff`/`history` can silently miss drift in every repo except whichever one sorts first. The
+  live scan-time `CrossLocationContentDrift` finding (re-run each time) does NOT have this limitation — it
+  checks every location, every scan. For genuine per-repo longitudinal tracking, treat each repo's own
+  baseline separately (`scan --repo <one-repo> --write-baseline`) rather than relying on the workspace ledger.
+- **A skill name shared by two unrelated repos looks identical to real drift.** `DetectCrossLocationDrift` has
+  no concept of "these repos are unrelated" — two different teams both naming a skill `code-review` with
+  legitimately different content will produce the same `Medium`-severity finding as an actual rug-pull. The
+  severity and "verify this is intentional" wording already account for this ambiguity; expect more such
+  findings to triage as workspace size grows.
 
 ## 3 — Skill-injection red-team attack + `run_skill_script` governance
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -491,10 +491,16 @@ agenteval skills scan-workspace ~/audit --write-baseline --format json -o report
 | `<path>` | Required, positional. A folder whose immediate subdirectories are repo roots. |
 | `--format <fmt>` | `console` (default), `markdown`, or `json`. |
 | `-o, --output <path>` | Write the rendered report to a file instead of stdout. |
-| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. |
+| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Cross-location drift (Medium) and previously-vetted matches (Low) never trigger this — only High-severity findings do. |
 | `--write-baseline` | Capture a timestamped baseline snapshot across all scanned repos into the baseline ledger. |
-| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. |
+| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines-workspace` — deliberately DIFFERENT from `scan`'s `.agenteval/skills-baselines` default, so a plain `scan --write-baseline` can't accidentally get diffed against a much larger workspace-scale snapshot. Pass the same root to both verbs explicitly if you want one shared ledger. |
 | `--check-baseline` | Trust-on-first-use across the whole workspace — see `scan`'s `--check-baseline` above. |
+
+**Known limitation:** `skills baseline diff`/`history` track only one location per skill name even when a
+single snapshot legitimately has several (a pre-existing Wave 2 shortcut) — at workspace scale, where the
+same name across many repos is the expected case, this means the persisted ledger's diff/history can miss
+drift in every repo except whichever sorts first. The live scan-time `CrossLocationContentDrift` finding does
+NOT have this limitation. See [Agent Skills](agent-skills.md#2--compliance-scanner) for the full explanation.
 
 **Exit codes:** same as `scan` above.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -454,6 +454,52 @@ report: cross-location content drift (`--repo` only, always on) and trust-on-fir
 
 ---
 
+### `agenteval skills scan-workspace`
+
+Agent Skills Wave 3a — filesystem-only, credential-free scan across a folder of **already-cloned** repos.
+Every immediate (non-hidden) subdirectory of `<path>` is treated as one repo and scanned with the same
+pipeline `scan --repo` uses, then combined into one report. No GitHub/GitLab API, no token — the operator's own
+clone step is what already decides which repos are visible; that access-control question is deliberately kept
+outside this verb's trust boundary (contrast with the still-gated, API-driven `scan-org`, Wave 3b).
+
+**Synopsis**
+
+```
+agenteval skills scan-workspace <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
+                                        [--write-baseline] [--baseline-root <dir>] [--check-baseline]
+```
+
+**What it does**
+
+Fans out `scan --repo`'s existing per-repo pipeline over every immediate subdirectory of `<path>`, combining
+findings/coverage into one report (per-repo skill/finding counts print to stderr). Every entry's location is
+tagged `{repoFolder}/{conventionPath}`, so cross-location content drift — the same detector `scan --repo`
+already uses, unchanged — now also fires **across repos**, not just across conventions within one repo: the
+same skill name with different content in two different cloned repos is exactly the drift/poisoning signal
+this is for.
+
+```bash
+gh repo clone myorg/service-a ~/audit/service-a
+gh repo clone myorg/service-b ~/audit/service-b
+agenteval skills scan-workspace ~/audit --write-baseline --format json -o report.json
+```
+
+**Options**
+
+| Option | Description |
+|--------|-------------|
+| `<path>` | Required, positional. A folder whose immediate subdirectories are repo roots. |
+| `--format <fmt>` | `console` (default), `markdown`, or `json`. |
+| `-o, --output <path>` | Write the rendered report to a file instead of stdout. |
+| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. |
+| `--write-baseline` | Capture a timestamped baseline snapshot across all scanned repos into the baseline ledger. |
+| `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. |
+| `--check-baseline` | Trust-on-first-use across the whole workspace — see `scan`'s `--check-baseline` above. |
+
+**Exit codes:** same as `scan` above.
+
+---
+
 ### `agenteval skills baseline`
 
 Inspects the multi-snapshot skill baseline ledger `agenteval skills scan --write-baseline` writes to. Each

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -25,6 +25,17 @@ internal static class SkillsScanCommand
 {
     private const string DefaultBaselineRoot = ".agenteval/skills-baselines";
 
+    // A DIFFERENT default from `scan`/`scan --repo`'s DefaultBaselineRoot, deliberately — `skills baseline
+    // diff`/`history` (unchanged, pre-existing code) always compare "the two most recent snapshots" with no
+    // concept of which verb/scope produced a given snapshot. Sharing one default root across scan-workspace
+    // (which can capture hundreds of skills across dozens of repos) and a plain `scan`/`scan --repo` (a
+    // handful of skills) would let an operator's next `scan` silently get diffed against a wildly
+    // different-scoped workspace snapshot, or vice versa — most of the "diff" would be spurious [new]/
+    // [removed] noise from scope mismatch, not real drift. Separate defaults prevent that footgun for anyone
+    // who doesn't pass --baseline-root explicitly; passing the SAME root to both verbs is still possible if
+    // an operator genuinely wants a unified ledger.
+    private const string DefaultWorkspaceBaselineRoot = ".agenteval/skills-baselines-workspace";
+
     public static Command Create()
     {
         var skillsCmd = new Command("skills", "MAF Agent Skills utilities");
@@ -36,25 +47,35 @@ internal static class SkillsScanCommand
 
     // ═══════════════════════════════════════════ scan ═══════════════════════════════════════════
 
+    /// <summary>
+    /// The 5 options <c>scan</c> and <c>scan-workspace</c> share verbatim (everything except <c>--repo</c>,
+    /// which only <c>scan</c> has, and each command's own default <c>--baseline-root</c>). Built ONCE here so
+    /// the two commands' help text cannot silently drift apart the way it already had before this helper
+    /// existed (the two copies' <c>--check-baseline</c> descriptions had gone out of sync).
+    /// </summary>
+    private static (Option<string> Format, Option<FileInfo?> Output, Option<bool> FailOnNoncompliant,
+        Option<bool> WriteBaseline, Option<string> BaselineRoot, Option<bool> CheckBaseline) BuildCommonScanOptions(
+        string defaultBaselineRoot) => (
+        new Option<string>("--format") { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" },
+        new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" },
+        new Option<bool>("--fail-on-noncompliant")
+            { Description = "Exit non-zero (1) when the scan finds a High-severity finding (report.IsCompliant == false). Default off (informational-only)." },
+        new Option<bool>("--write-baseline")
+            { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." },
+        new Option<string>("--baseline-root")
+            { DefaultValueFactory = _ => defaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." },
+        new Option<bool>("--check-baseline")
+            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding. Meaningless on a first-ever scan (no history yet) — pair with --write-baseline on earlier runs." });
+
     private static Command BuildScanCommand()
     {
         var scanCmd = new Command("scan", "Scan a directory of MAF Agent Skills for GA compliance + governance findings");
 
         var pathArg = new Argument<DirectoryInfo>("path")
             { Description = "Directory containing one or more SKILL.md-rooted skill folders (a repo root when --repo is set)" };
-        var formatOpt = new Option<string>("--format")
-            { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" };
-        var outputOpt = new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" };
-        var failOnOpt = new Option<bool>("--fail-on-noncompliant")
-            { Description = "Exit non-zero (1) when the scan finds a High-severity finding (report.IsCompliant == false). Default off (informational-only)." };
-        var writeBaselineOpt = new Option<bool>("--write-baseline")
-            { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." };
+        var (formatOpt, outputOpt, failOnOpt, writeBaselineOpt, baselineRootOpt, checkBaselineOpt) = BuildCommonScanOptions(DefaultBaselineRoot);
         var repoOpt = new Option<bool>("--repo")
             { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory. Always content-hashes every skill folder (real file I/O) to check for cross-location drift — the same name resolving to different content in two conventions — even without --write-baseline/--check-baseline." };
-        var baselineRootOpt = new Option<string>("--baseline-root")
-            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." };
-        var checkBaselineOpt = new Option<bool>("--check-baseline")
-            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding. Meaningless on a first-ever scan (no history yet) — pair with --write-baseline on earlier runs." };
 
         scanCmd.Arguments.Add(pathArg);
         scanCmd.Options.Add(formatOpt);
@@ -225,17 +246,7 @@ internal static class SkillsScanCommand
 
         var pathArg = new Argument<DirectoryInfo>("path")
             { Description = "A folder whose immediate subdirectories are repo roots (e.g. where you 'gh repo clone'd your org's repos)" };
-        var formatOpt = new Option<string>("--format")
-            { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" };
-        var outputOpt = new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" };
-        var failOnOpt = new Option<bool>("--fail-on-noncompliant")
-            { Description = "Exit non-zero (1) when the scan finds a High-severity finding (report.IsCompliant == false). Default off (informational-only)." };
-        var writeBaselineOpt = new Option<bool>("--write-baseline")
-            { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." };
-        var baselineRootOpt = new Option<string>("--baseline-root")
-            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." };
-        var checkBaselineOpt = new Option<bool>("--check-baseline")
-            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding." };
+        var (formatOpt, outputOpt, failOnOpt, writeBaselineOpt, baselineRootOpt, checkBaselineOpt) = BuildCommonScanOptions(DefaultWorkspaceBaselineRoot);
 
         scanWorkspaceCmd.Arguments.Add(pathArg);
         scanWorkspaceCmd.Options.Add(formatOpt);
@@ -278,7 +289,7 @@ internal static class SkillsScanCommand
     /// </summary>
     internal static async Task<int> ExecuteWorkspaceAsync(
         DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
-        bool writeBaseline = false, string baselineRoot = DefaultBaselineRoot, bool checkBaseline = false,
+        bool writeBaseline = false, string baselineRoot = DefaultWorkspaceBaselineRoot, bool checkBaseline = false,
         CancellationToken ct = default)
     {
         if (!path.Exists)
@@ -300,6 +311,12 @@ internal static class SkillsScanCommand
             writeBaseline, baselineRoot, checkBaseline, path.FullName, ct).ConfigureAwait(false);
     }
 
+    // Bounded so a workspace of many repos doesn't open unbounded concurrent file handles; matches the same
+    // "cap it, don't leave it unbounded" discipline GateCalibrationHarness's MaxConcurrency already uses
+    // elsewhere in this codebase. Each repo's scan is independent I/O (its own directory tree, its own
+    // content hashing) — safe to run concurrently.
+    private const int MaxConcurrentRepoScans = 4;
+
     /// <summary>
     /// Wave 3a (filesystem multi-repo scan): treats <paramref name="workspaceRoot"/> as a folder of
     /// already-cloned repos — every immediate, non-hidden subdirectory is one repo — and runs the EXISTING
@@ -314,52 +331,121 @@ internal static class SkillsScanCommand
     /// operator's own clone step (their own credentials, their own tooling) is what decides which repos are
     /// visible here — that access-control question is intentionally kept OUTSIDE this verb's trust boundary,
     /// unlike the live, API-driven org-wide scan a security/credential-scope review is still pending for.</para>
+    /// <para><b>Fault-isolated per repo.</b> One repo whose skill folder contains a permission-denied file
+    /// (MafSkillScanner's own file enumeration has no guard against this — a pre-existing gap in shared
+    /// scanning code, not something this method can safely patch without touching every other caller of that
+    /// pipeline) must not lose every OTHER repo's already-computed results — a real risk at workspace scale
+    /// that a single-repo <c>--repo</c> scan rarely hits. Caught, reported as a per-repo "SKIPPED" line plus a
+    /// stderr warning, and the scan continues with the remaining repos.</para>
+    /// <para><b>Known scoping limit, disclosed not hidden:</b> a skill name shared by two UNRELATED repos
+    /// (different teams, coincidentally the same name) is indistinguishable from real drift/poisoning to
+    /// <see cref="DetectCrossLocationDrift"/> — it groups by name only, with no concept of "these repos are
+    /// unrelated." At org scale this is more likely to fire than within one repo's own conventions; the
+    /// finding's <c>Medium</c> severity and "verify this is intentional" wording already account for that
+    /// ambiguity, so this is not a bug, but expect more such findings to review as workspace size grows.</para>
     /// </summary>
     private static async Task<(SkillComplianceReport Report, IReadOnlyList<SkillBaselineEntry> Entries, string WorkspaceSummary)> ScanWorkspaceAsync(
         string workspaceRoot, AIAgent agent, CancellationToken ct)
     {
+        var allSubdirs = Directory.GetDirectories(workspaceRoot);
+        var repoDirs = allSubdirs
+            .Where(d => !Path.GetFileName(d).StartsWith('.'))   // skip .git and similar tooling folders, not repo clones
+            .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var hiddenSkipped = allSubdirs.Length - repoDirs.Count;
+
+        var summary = new StringBuilder();
+        summary.AppendLine("  Workspace repos scanned:");
+
+        if (allSubdirs.Length == 0)
+        {
+            summary.AppendLine("    (no subdirectories found)");
+        }
+        else if (repoDirs.Count == 0)
+        {
+            summary.AppendLine($"    (no non-hidden subdirectories — {hiddenSkipped} hidden folder(s) skipped)");
+        }
+
+        // Collect-then-reduce: each task writes only to its own array slot (no shared mutable state during
+        // the parallel phase), and the reduce step below walks repoDirs' own sorted order — so the combined
+        // report/summary is deterministic regardless of which repo's scan actually finished first.
+        var results = new (string RepoName, SkillComplianceReport Report, IReadOnlyList<SkillBaselineEntry> Entries, string? Error)[repoDirs.Count];
+        using var throttle = new SemaphoreSlim(Math.Min(MaxConcurrentRepoScans, Math.Max(1, repoDirs.Count)));
+
+        var scanTasks = repoDirs.Select(async (repoPath, i) =>
+        {
+            var repoName = Path.GetFileName(repoPath);
+            await throttle.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var (repoReport, repoEntries, _) = await ScanRepoWideAsync(repoPath, agent, ct).ConfigureAwait(false);
+                results[i] = (repoName, repoReport, repoEntries, null);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                results[i] = (repoName, EmptyReport, [], ex.Message);
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        });
+
+        await Task.WhenAll(scanTasks).ConfigureAwait(false);
+
         var allFindings = new List<SkillComplianceFinding>();
         int skillCount = 0, withResources = 0, withScripts = 0, silentlyExcluded = 0;
         var histogram = new Dictionary<string, int>(StringComparer.Ordinal);
         var entries = new List<SkillBaselineEntry>();
-        var summary = new StringBuilder();
-        summary.AppendLine("  Workspace repos scanned:");
 
-        var repoDirs = Directory.GetDirectories(workspaceRoot)
-            .Where(d => !Path.GetFileName(d).StartsWith('.'))   // skip .git and similar tooling folders, not repo clones
-            .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        if (repoDirs.Count == 0)
+        foreach (var (repoName, repoReport, repoEntries, error) in results)
         {
-            summary.AppendLine("    (no subdirectories found)");
-        }
-
-        foreach (var repoPath in repoDirs)
-        {
-            ct.ThrowIfCancellationRequested();
-            var repoName = Path.GetFileName(repoPath);
-            var (repoReport, repoEntries, _) = await ScanRepoWideAsync(repoPath, agent, ct).ConfigureAwait(false);
+            if (error is not null)
+            {
+                summary.AppendLine($"    {repoName}: SKIPPED — could not scan ({error})");
+                Console.Error.WriteLine($"  Warning: could not scan repo '{repoName}': {error}");
+                continue;
+            }
 
             summary.AppendLine($"    {repoName}: {repoReport.Coverage.SkillCount} skill(s), {repoReport.Findings.Count} finding(s)");
 
             allFindings.AddRange(repoReport.Findings);
-            skillCount += repoReport.Coverage.SkillCount;
-            withResources += repoReport.Coverage.WithResources;
-            withScripts += repoReport.Coverage.WithScripts;
-            silentlyExcluded += repoReport.Coverage.SilentlyExcludedCount;
-            foreach (var (stage, count) in repoReport.Coverage.StageHistogram)
-            {
-                histogram[stage] = histogram.GetValueOrDefault(stage) + count;
-            }
-
+            AccumulateCoverage(repoReport.Coverage, ref skillCount, ref withResources, ref withScripts, ref silentlyExcluded, histogram);
             entries.AddRange(repoEntries.Select(e => e with { RelativePath = $"{repoName}/{e.RelativePath}" }));
+        }
+
+        if (hiddenSkipped > 0)
+        {
+            summary.AppendLine($"    ({hiddenSkipped} hidden folder(s) skipped, e.g. .git)");
         }
 
         var combinedReport = new SkillComplianceReport(
             allFindings, new SkillCoverageSummary(skillCount, withResources, withScripts, histogram, silentlyExcluded));
 
         return (combinedReport, entries, summary.ToString().TrimEnd());
+    }
+
+    private static readonly SkillComplianceReport EmptyReport =
+        new([], new SkillCoverageSummary(0, 0, 0, new Dictionary<string, int>(StringComparer.Ordinal)));
+
+    /// <summary>
+    /// Folds one repo/convention's <see cref="SkillCoverageSummary"/> into the caller's running totals — the
+    /// ONE place this accumulation is defined, shared by <see cref="ScanRepoWideAsync"/> (across conventions)
+    /// and <see cref="ScanWorkspaceAsync"/> (across repos), so a future new <see cref="SkillCoverageSummary"/>
+    /// field only needs threading through here once, not into two independently-hand-rolled loops.
+    /// </summary>
+    private static void AccumulateCoverage(
+        SkillCoverageSummary from, ref int skillCount, ref int withResources, ref int withScripts,
+        ref int silentlyExcluded, Dictionary<string, int> histogram)
+    {
+        skillCount += from.SkillCount;
+        withResources += from.WithResources;
+        withScripts += from.WithScripts;
+        silentlyExcluded += from.SilentlyExcludedCount;
+        foreach (var (stage, count) in from.StageHistogram)
+        {
+            histogram[stage] = histogram.GetValueOrDefault(stage) + count;
+        }
     }
 
     // ═══════════════════════════════ --repo multi-convention discovery (§4.3) ═══════════════════════════════
@@ -400,14 +486,7 @@ internal static class SkillsScanCommand
             summary.AppendLine($"    {convention}: {result.Skills.Count} skill(s), {result.Report.Findings.Count} finding(s)");
 
             allFindings.AddRange(result.Report.Findings);
-            skillCount += result.Report.Coverage.SkillCount;
-            withResources += result.Report.Coverage.WithResources;
-            withScripts += result.Report.Coverage.WithScripts;
-            silentlyExcluded += result.Report.Coverage.SilentlyExcludedCount;
-            foreach (var (stage, count) in result.Report.Coverage.StageHistogram)
-            {
-                histogram[stage] = histogram.GetValueOrDefault(stage) + count;
-            }
+            AccumulateCoverage(result.Report.Coverage, ref skillCount, ref withResources, ref withScripts, ref silentlyExcluded, histogram);
 
             foreach (var info in result.Skills)
             {
@@ -428,11 +507,19 @@ internal static class SkillsScanCommand
     /// GA requires lowercase-only names, so a name differing only by case across two conventions is the
     /// SAME poisoning/drift scenario this rule targets, not two unrelated skills) and flags any name present
     /// with 2+ DISTINCT <see cref="SkillBaselineEntry.ContentHash"/> values — the same skill name resolves
-    /// to different content depending on which convention/agent-tool reads it. Only meaningful for a
-    /// <c>--repo</c> scan (a single-directory scan has exactly one location by definition). Entries with an
-    /// empty/missing name are excluded from grouping entirely — two independently-malformed skills that both
-    /// lack a <c>name:</c> field are NOT "the same skill drifting," and grouping them by their shared empty
-    /// name would produce a misleading finding.
+    /// to different content depending on which convention/agent-tool (or, since Wave 3a, which REPO) reads
+    /// it. Only meaningful when <paramref name="entries"/> spans 2+ locations — a single-directory scan has
+    /// exactly one location by definition, so it never fires there. Location granularity is entirely a
+    /// function of how the caller populated <see cref="SkillBaselineEntry.RelativePath"/>: <c>--repo</c>
+    /// tags by convention, <c>scan-workspace</c> additionally tags by repo folder — this method itself never
+    /// inspects <c>RelativePath</c> for grouping, only for the finding's human-readable location list, so it
+    /// needs no change to work at either granularity. A name shared by two genuinely UNRELATED
+    /// repos/conventions is indistinguishable from real drift to this method (no "these are unrelated"
+    /// signal exists) — the <c>Medium</c> severity and "verify this is intentional" wording below already
+    /// account for that ambiguity, more likely to matter at workspace scale than within one repo. Entries
+    /// with an empty/missing name are excluded from grouping entirely — two independently-malformed skills
+    /// that both lack a <c>name:</c> field are NOT "the same skill drifting," and grouping them by their
+    /// shared empty name would produce a misleading finding.
     /// </summary>
     internal static IReadOnlyList<SkillComplianceFinding> DetectCrossLocationDrift(IReadOnlyList<SkillBaselineEntry> entries)
     {

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -29,6 +29,7 @@ internal static class SkillsScanCommand
     {
         var skillsCmd = new Command("skills", "MAF Agent Skills utilities");
         skillsCmd.Subcommands.Add(BuildScanCommand());
+        skillsCmd.Subcommands.Add(BuildScanWorkspaceCommand());
         skillsCmd.Subcommands.Add(BuildBaselineCommand());
         return skillsCmd;
     }
@@ -139,10 +140,26 @@ internal static class SkillsScanCommand
         }
 
         // Agent Skills Wave 2 (§4.2): --repo cross-location drift is always checked (no extra flag — a
-        // repo-wide scan is the only mode where "cross-location" is even meaningful); --check-baseline
-        // trust-on-first-use matching is opt-in (meaningless without prior baseline history).
+        // repo-wide scan is the only mode where "cross-location" is even meaningful for a single repo).
+        return await FinishScanAsync(
+            report, entries, checkCrossLocationDrift: repo, format, output, failOnNoncompliant,
+            writeBaseline, baselineRoot, checkBaseline, path.FullName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The tail shared by every scan mode (single-directory, <c>--repo</c>, and Wave 3a's
+    /// <c>scan-workspace</c>) once discovery has produced a <see cref="SkillComplianceReport"/> and its
+    /// matching <see cref="SkillBaselineEntry"/> list: merge in cross-location-drift / trust-on-first-use
+    /// findings, render, write the output, persist a baseline snapshot if asked, and compute the exit code.
+    /// </summary>
+    private static async Task<int> FinishScanAsync(
+        SkillComplianceReport report, IReadOnlyList<SkillBaselineEntry> entries, bool checkCrossLocationDrift,
+        string format, FileInfo? output, bool failOnNoncompliant, bool writeBaseline, string baselineRoot,
+        bool checkBaseline, string scannedRoot, CancellationToken ct)
+    {
+        // --check-baseline trust-on-first-use matching is opt-in (meaningless without prior baseline history).
         var extraFindings = new List<SkillComplianceFinding>();
-        if (repo)
+        if (checkCrossLocationDrift)
         {
             extraFindings.AddRange(DetectCrossLocationDrift(entries));
         }
@@ -173,7 +190,7 @@ internal static class SkillsScanCommand
 
         if (writeBaseline)
         {
-            var snapshot = new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, path.FullName, entries);
+            var snapshot = new SkillBaselineSnapshot(Guid.NewGuid().ToString("N"), DateTimeOffset.UtcNow, scannedRoot, entries);
             var store = new JsonFileSkillBaselineStore(baselineRoot);
             var id = await store.SaveAsync(snapshot, ct).ConfigureAwait(false);
             Console.Error.WriteLine($"  Baseline snapshot saved: {id} ({snapshot.Skills.Count} skill(s) -> {baselineRoot})");
@@ -197,6 +214,153 @@ internal static class SkillsScanCommand
     /// </summary>
     internal static int ComputeExitCode(SkillComplianceReport report, bool failOnNoncompliant)
         => (failOnNoncompliant && !report.IsCompliant) ? ExitCodes.TestFailure : ExitCodes.Success;
+
+    // ═══════════════════════════════ scan-workspace: filesystem multi-repo scan (Wave 3a) ═══════════════════════════════
+
+    private static Command BuildScanWorkspaceCommand()
+    {
+        var scanWorkspaceCmd = new Command(
+            "scan-workspace",
+            "Scan a folder of ALREADY-CLONED repos (each immediate subdirectory is one repo) for MAF Agent Skills compliance + cross-repo drift. Filesystem-only — no network, no credentials; the operator's own clone step is what already handles repo access.");
+
+        var pathArg = new Argument<DirectoryInfo>("path")
+            { Description = "A folder whose immediate subdirectories are repo roots (e.g. where you 'gh repo clone'd your org's repos)" };
+        var formatOpt = new Option<string>("--format")
+            { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" };
+        var outputOpt = new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" };
+        var failOnOpt = new Option<bool>("--fail-on-noncompliant")
+            { Description = "Exit non-zero (1) when the scan finds a High-severity finding (report.IsCompliant == false). Default off (informational-only)." };
+        var writeBaselineOpt = new Option<bool>("--write-baseline")
+            { Description = "After scanning, capture a timestamped baseline snapshot (content hash + structural fingerprint per skill) into the baseline ledger. See 'skills baseline list|diff|history'." };
+        var baselineRootOpt = new Option<string>("--baseline-root")
+            { DefaultValueFactory = _ => DefaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." };
+        var checkBaselineOpt = new Option<bool>("--check-baseline")
+            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding." };
+
+        scanWorkspaceCmd.Arguments.Add(pathArg);
+        scanWorkspaceCmd.Options.Add(formatOpt);
+        scanWorkspaceCmd.Options.Add(outputOpt);
+        scanWorkspaceCmd.Options.Add(failOnOpt);
+        scanWorkspaceCmd.Options.Add(writeBaselineOpt);
+        scanWorkspaceCmd.Options.Add(baselineRootOpt);
+        scanWorkspaceCmd.Options.Add(checkBaselineOpt);
+
+        scanWorkspaceCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await ExecuteWorkspaceAsync(
+                    parseResult.GetValue(pathArg)!,
+                    parseResult.GetValue(formatOpt)!,
+                    parseResult.GetValue(outputOpt),
+                    parseResult.GetValue(failOnOpt),
+                    parseResult.GetValue(writeBaselineOpt),
+                    parseResult.GetValue(baselineRootOpt)!,
+                    parseResult.GetValue(checkBaselineOpt),
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
+        return scanWorkspaceCmd;
+    }
+
+    /// <summary>
+    /// Core execution logic for <c>scan-workspace</c> — separated from command wiring for testability, mirroring
+    /// <see cref="ExecuteAsync"/>. Deliberately a SEPARATE verb from <c>scan --repo</c> rather than a bolted-on
+    /// flag on it (naming a flag <c>--workspace</c> would collide with Mission Control's unrelated
+    /// <c>--workspace</c> concept and its own honesty history — see <c>strategy/AgentEval-Status-and-Plan-Forward.md</c>
+    /// Front D) — so this verb's own name states plainly what it does, without borrowing an already-loaded word.
+    /// </summary>
+    internal static async Task<int> ExecuteWorkspaceAsync(
+        DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
+        bool writeBaseline = false, string baselineRoot = DefaultBaselineRoot, bool checkBaseline = false,
+        CancellationToken ct = default)
+    {
+        if (!path.Exists)
+        {
+            throw new DirectoryNotFoundException($"Workspace directory not found: {path.FullName}");
+        }
+
+        AIAgent noOpAgent = new ChatClientAgent(new ScriptedChatClient(), new ChatClientAgentOptions { Name = "SkillsScanCommand" });
+
+        var (report, entries, workspaceSummary) = await ScanWorkspaceAsync(path.FullName, noOpAgent, ct).ConfigureAwait(false);
+        Console.Error.WriteLine(workspaceSummary);
+
+        // Cross-location drift is always checked, same as --repo — a multi-repo workspace scan is exactly
+        // the scenario "skill X is byte-identical across 45 repos except 3 outliers" describes; cross-REPO
+        // drift IS cross-location drift, just at one more directory level (see ScanWorkspaceAsync's remarks
+        // for how entries are re-tagged to make this fall out of the EXISTING DetectCrossLocationDrift as-is).
+        return await FinishScanAsync(
+            report, entries, checkCrossLocationDrift: true, format, output, failOnNoncompliant,
+            writeBaseline, baselineRoot, checkBaseline, path.FullName, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Wave 3a (filesystem multi-repo scan): treats <paramref name="workspaceRoot"/> as a folder of
+    /// already-cloned repos — every immediate, non-hidden subdirectory is one repo — and runs the EXISTING
+    /// <see cref="ScanRepoWideAsync"/> (the <c>--repo</c> pipeline, unchanged) against each one, combining
+    /// every repo's findings/entries into one report. Zero new discovery/compliance code: this is a fan-out
+    /// loop over an already-shipped pipeline, not a reimplementation. Entries are re-tagged with a
+    /// <c>"{repoFolderName}/{conventionRelativePath}"</c> <see cref="SkillBaselineEntry.RelativePath"/> so the
+    /// UNCHANGED <see cref="DetectCrossLocationDrift"/> — which only ever groups by
+    /// <see cref="SkillBaselineEntry.Name"/>, never by <c>RelativePath</c> — also catches drift ACROSS repos
+    /// for free, exactly as it already does across conventions within one repo.
+    /// <para>Deliberately filesystem-only: no GitHub/GitLab API client, no token, no network call. The
+    /// operator's own clone step (their own credentials, their own tooling) is what decides which repos are
+    /// visible here — that access-control question is intentionally kept OUTSIDE this verb's trust boundary,
+    /// unlike the live, API-driven org-wide scan a security/credential-scope review is still pending for.</para>
+    /// </summary>
+    private static async Task<(SkillComplianceReport Report, IReadOnlyList<SkillBaselineEntry> Entries, string WorkspaceSummary)> ScanWorkspaceAsync(
+        string workspaceRoot, AIAgent agent, CancellationToken ct)
+    {
+        var allFindings = new List<SkillComplianceFinding>();
+        int skillCount = 0, withResources = 0, withScripts = 0, silentlyExcluded = 0;
+        var histogram = new Dictionary<string, int>(StringComparer.Ordinal);
+        var entries = new List<SkillBaselineEntry>();
+        var summary = new StringBuilder();
+        summary.AppendLine("  Workspace repos scanned:");
+
+        var repoDirs = Directory.GetDirectories(workspaceRoot)
+            .Where(d => !Path.GetFileName(d).StartsWith('.'))   // skip .git and similar tooling folders, not repo clones
+            .OrderBy(d => d, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (repoDirs.Count == 0)
+        {
+            summary.AppendLine("    (no subdirectories found)");
+        }
+
+        foreach (var repoPath in repoDirs)
+        {
+            ct.ThrowIfCancellationRequested();
+            var repoName = Path.GetFileName(repoPath);
+            var (repoReport, repoEntries, _) = await ScanRepoWideAsync(repoPath, agent, ct).ConfigureAwait(false);
+
+            summary.AppendLine($"    {repoName}: {repoReport.Coverage.SkillCount} skill(s), {repoReport.Findings.Count} finding(s)");
+
+            allFindings.AddRange(repoReport.Findings);
+            skillCount += repoReport.Coverage.SkillCount;
+            withResources += repoReport.Coverage.WithResources;
+            withScripts += repoReport.Coverage.WithScripts;
+            silentlyExcluded += repoReport.Coverage.SilentlyExcludedCount;
+            foreach (var (stage, count) in repoReport.Coverage.StageHistogram)
+            {
+                histogram[stage] = histogram.GetValueOrDefault(stage) + count;
+            }
+
+            entries.AddRange(repoEntries.Select(e => e with { RelativePath = $"{repoName}/{e.RelativePath}" }));
+        }
+
+        var combinedReport = new SkillComplianceReport(
+            allFindings, new SkillCoverageSummary(skillCount, withResources, withScripts, histogram, silentlyExcluded));
+
+        return (combinedReport, entries, summary.ToString().TrimEnd());
+    }
 
     // ═══════════════════════════════ --repo multi-convention discovery (§4.3) ═══════════════════════════════
 

--- a/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli;
+using AgentEval.Cli.Commands;
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Cli;
+
+/// <summary>
+/// Agent Skills Wave 3a — <c>skills scan-workspace</c>: a filesystem-only, credential-free multi-repo scan
+/// over a folder of already-cloned repos. Reuses the EXISTING <c>--repo</c> pipeline per subdirectory (no
+/// new discovery/compliance code), so these tests focus on the fan-out/rollup/cross-repo-drift behavior
+/// specific to this verb, not re-testing what <see cref="SkillsBaselineCommandTests"/> already covers for
+/// <c>--repo</c> itself.
+/// </summary>
+public class SkillsScanWorkspaceCommandTests : IDisposable
+{
+    private readonly string _baselineRoot;
+
+    public SkillsScanWorkspaceCommandTests()
+    {
+        _baselineRoot = Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-cmd-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_baselineRoot, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // ── command wiring ──
+
+    [Fact]
+    public void Create_ReturnsSkillsCommand_WithScanWorkspaceSubcommand()
+    {
+        var command = SkillsScanCommand.Create();
+        Assert.Contains(command.Subcommands, c => c.Name == "scan-workspace");
+    }
+
+    [Fact]
+    public void Create_ScanWorkspaceSubcommand_HasExpectedOptions()
+    {
+        var cmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan-workspace");
+        Assert.Contains(cmd.Arguments, a => a.Name == "path");
+        Assert.Contains(cmd.Options, o => o.Name == "--format");
+        Assert.Contains(cmd.Options, o => o.Name == "--output" || o.Aliases.Contains("--output"));
+        Assert.Contains(cmd.Options, o => o.Name == "--fail-on-noncompliant");
+        Assert.Contains(cmd.Options, o => o.Name == "--write-baseline");
+        Assert.Contains(cmd.Options, o => o.Name == "--baseline-root");
+        Assert.Contains(cmd.Options, o => o.Name == "--check-baseline");
+        // Deliberately NOT --workspace or --repo — see ExecuteWorkspaceAsync's own remarks on the naming choice.
+        Assert.DoesNotContain(cmd.Options, o => o.Name == "--repo");
+    }
+
+    // ── ExecuteWorkspaceAsync: real, offline, credential-free multi-repo scan ──
+
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_NonexistentDirectory_Throws()
+    {
+        var missing = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-missing-" + Guid.NewGuid().ToString("N")));
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(
+            () => SkillsScanCommand.ExecuteWorkspaceAsync(missing, "console", null, false, ct: default));
+    }
+
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_EmptyWorkspace_Succeeds_ZeroSkills()
+    {
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            var outFile = NewTempOutputFile();
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                    new DirectoryInfo(workspaceRoot), "json", outFile, failOnNoncompliant: false, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("\"SkillCount\": 0", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_TwoRepos_AggregatesAcrossThem()
+    {
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            CreateRepoWithSkill(workspaceRoot, "repo-a", "skill-a", "Present in repo-a.");
+            CreateRepoWithSkill(workspaceRoot, "repo-b", "skill-b", "Present in repo-b.");
+
+            var outFile = NewTempOutputFile();
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                    new DirectoryInfo(workspaceRoot), "json", outFile, failOnNoncompliant: false,
+                    writeBaseline: true, baselineRoot: _baselineRoot, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("\"SkillCount\": 2", content, StringComparison.Ordinal);
+
+                var store = new JsonFileSkillBaselineStore(_baselineRoot);
+                var snapshots = await store.ListAsync();
+                var snapshot = Assert.Single(snapshots);
+                Assert.Equal(2, snapshot.Skills.Count);
+                Assert.Contains(snapshot.Skills, s => s.RelativePath.StartsWith("repo-a/", StringComparison.Ordinal));
+                Assert.Contains(snapshot.Skills, s => s.RelativePath.StartsWith("repo-b/", StringComparison.Ordinal));
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_SameSkillNameDifferentContentAcrossRepos_FlagsCrossLocationDrift()
+    {
+        // The headline Wave 3a scenario: "skill X is byte-identical across N repos except M outliers" — proven
+        // here by reusing the UNCHANGED DetectCrossLocationDrift (it groups by Name only, never by
+        // RelativePath), fed entries re-tagged with a repo-prefixed RelativePath.
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            CreateRepoWithSkill(workspaceRoot, "repo-a", "shared-skill", "Variant A.");
+            CreateRepoWithSkill(workspaceRoot, "repo-b", "shared-skill", "Variant B — DIFFERENT.");
+
+            var outFile = NewTempOutputFile();
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                    new DirectoryInfo(workspaceRoot), "json", outFile, failOnNoncompliant: false, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("shared-skill", content, StringComparison.Ordinal);
+                Assert.Contains("DIFFERENT content across", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_HiddenSubdirectory_NotTreatedAsARepo()
+    {
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            // A stray .git (or similar tooling) folder at the workspace root must not be scanned as a "repo" —
+            // it has no known skill-directory convention under it, but it also shouldn't even be attempted.
+            Directory.CreateDirectory(Path.Combine(workspaceRoot, ".git"));
+            CreateRepoWithSkill(workspaceRoot, "repo-a", "skill-a", "Present in repo-a.");
+
+            var outFile = NewTempOutputFile();
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                    new DirectoryInfo(workspaceRoot), "json", outFile, failOnNoncompliant: false, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("\"SkillCount\": 1", content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    private static string CreateWorkspaceRoot() =>
+        Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-test-" + Guid.NewGuid().ToString("N"))).FullName;
+
+    private static void CreateRepoWithSkill(string workspaceRoot, string repoName, string skillName, string description)
+    {
+        var skillDir = Path.Combine(workspaceRoot, repoName, ".claude", "skills", skillName);
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), $"---\nname: {skillName}\ndescription: {description}\n---\n\nBody.\n");
+    }
+
+    private static FileInfo NewTempOutputFile() =>
+        new(Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-out-" + Guid.NewGuid().ToString("N") + ".txt"));
+}

--- a/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
@@ -171,6 +171,47 @@ public class SkillsScanWorkspaceCommandTests : IDisposable
         finally { Directory.Delete(workspaceRoot, recursive: true); }
     }
 
+    [Fact]
+    public async Task ExecuteWorkspaceAsync_OnlyHiddenSubdirectories_DiscloseSkipCount_NotMisreportedAsEmpty()
+    {
+        // Distinguishes "truly no subdirectories" from "subdirectories exist but were all filtered as
+        // hidden" — an operator pointing scan-workspace at one already-cloned repo (which itself has a
+        // .git folder and no other subdirectory) by mistake must see WHY nothing was scanned, not a message
+        // that reads identically to a genuinely empty folder.
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(workspaceRoot, ".git"));
+
+            var outFile = NewTempOutputFile();
+            try
+            {
+                var exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                    new DirectoryInfo(workspaceRoot), "console", outFile, failOnNoncompliant: false, ct: default);
+
+                Assert.Equal(ExitCodes.Success, exit);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    [Fact]
+    public void DefaultBaselineRoot_DiffersBetweenScanAndScanWorkspace_PreventsScopeMismatchInDiff()
+    {
+        // scan-workspace's own default baseline root must NOT equal scan's default — sharing one root by
+        // default would let `skills baseline diff` (which always compares "the two most recent snapshots"
+        // with no scope awareness) silently compare a handful-of-skills single-repo snapshot against a
+        // hundreds-of-skills workspace snapshot. Reflection on the two private const fields directly, since
+        // that's the actual single source of truth both ExecuteAsync's and ExecuteWorkspaceAsync's own
+        // default parameter values are compiled from.
+        const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static;
+        var scanDefault = (string)typeof(SkillsScanCommand).GetField("DefaultBaselineRoot", flags)!.GetValue(null)!;
+        var workspaceDefault = (string)typeof(SkillsScanCommand).GetField("DefaultWorkspaceBaselineRoot", flags)!.GetValue(null)!;
+
+        Assert.NotEqual(scanDefault, workspaceDefault);
+    }
+
     private static string CreateWorkspaceRoot() =>
         Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-test-" + Guid.NewGuid().ToString("N"))).FullName;
 


### PR DESCRIPTION
## Summary
- New `agenteval skills scan-workspace <path>`: treats `<path>` as a folder of ALREADY-CLONED repos (each immediate, non-hidden subdirectory is one repo) and fans out the EXISTING `scan --repo` pipeline over each one, combining findings/coverage into one report. Zero new discovery/compliance code — pure reuse.
- Filesystem-only, no network, no credentials — the operator's own clone step is what decides which repos are visible, deliberately kept outside this verb's trust boundary. This is Wave 3a of the org-wide-scan backlog; the live, API-driven version (`scan-org`, Wave 3b) stays gated on a security/credential-scope review not yet held.
- Every entry is re-tagged with a `{repoFolder}/{conventionPath}` location, so the UNCHANGED `DetectCrossLocationDrift` (groups by name only, never by location) also catches drift ACROSS repos for free — live-verified end-to-end against a real 3-repo fixture: the same skill name with different content in two repos correctly produced a `CrossLocationContentDrift` finding naming both repo-prefixed locations.
- Deliberately a separate verb, not a `--workspace` flag on `scan --repo` — avoids colliding with Mission Control's own, unrelated `--workspace` concept.

## Review
7-angle adversarial review (parallel subagents) found and fixed:
- **Fault isolation**: `MafSkillScanner`'s file enumeration has no guard against a permission-denied file — without a fix, one bad repo would crash the entire multi-repo scan and lose every other repo's already-computed results. Now caught per-repo, reported as SKIPPED, scan continues.
- **Bounded concurrency**: replaced sequential per-repo scanning with a bounded parallel fan-out (collect-then-reduce, deterministic output order) — the axis this verb is actually designed to scale on.
- **Hidden-folder disclosure**: a dot-prefixed repo folder (or a workspace containing only `.git`-like tooling folders) no longer silently vanishes with no trace.
- **Shared coverage-merge + shared CLI option builder**: fixed real duplication, including an already-drifted `--check-baseline` help text between `scan` and `scan-workspace`.
- **Separate default `--baseline-root`** for `scan-workspace` (`.agenteval/skills-baselines-workspace`) — prevents `skills baseline diff` (which always compares "the two most recent snapshots" with no scope awareness) from silently comparing a single-repo snapshot against a much larger workspace one.
- **Corrected a doc overclaim**: `baseline diff`/`history`'s pre-existing `GroupBy+First` shortcut tracks only one location per skill name — fine at `--repo` scale, a real gap at workspace scale. Disclosed, not silently left implied as solved.

## Test plan
- [x] `dotnet build` full solution — 0 errors, 0 new warnings
- [x] 9 tests (command wiring, aggregation, cross-repo drift, hidden-folder handling, default-root isolation)
- [x] Full net8.0 suite green: 7798 passed / 1 skipped (pre-existing) / 0 failed
- [x] Live end-to-end via the real CLI process: 3-repo fixture with a deliberately drifted skill + a hidden `.git` folder, confirmed correct aggregation, drift detection, and hidden-folder disclosure

🤖 Generated with [Claude Code](https://claude.com/claude-code)