### PR TITLE
feat(skills): manifest-baseline hash-pin drift gate on skills scan

### DIFF
--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -231,13 +231,24 @@ a changed skill as a High-severity `ManifestChangedSinceBaseline` finding, gated
 `--write-baseline`'s multi-snapshot ledger above — commit it like the RedTeam CI baseline:
 
 ```bash
-agenteval skills scan ./skills --save-manifest-baseline skills-baseline.json --baseline-notes "reviewed 2026-07-17"
+agenteval skills scan ./skills --save-manifest-baseline skills-baseline.json --baseline-note "reviewed 2026-07-17"
 # ... later, in CI, before deploying an updated skill pack:
 agenteval skills scan ./skills --manifest-baseline skills-baseline.json --fail-on-noncompliant
 ```
 
 Works the same way with `--repo`/`scan-workspace` — a skill name shared across locations is deduplicated the
-same `GroupBy`-first way `baseline diff`/`history` already tolerate it (see §2's known limitations above).
+same `GroupBy`-first way `baseline diff`/`history` already tolerate it (see §2's known limitations above); the
+dictionary key is lowercased before grouping specifically so a rug-pull that also re-cases the skill's `name:`
+can't evade detection by looking like an unrelated new-skill-appeared / old-skill-vanished pair instead of a
+`Changed` skill.
+
+**Two more disclosed limitations:** (1) `--fail-on-noncompliant` is the only gate — there is no dedicated
+`--fail-on-manifest-drift` — so a repo carrying unrelated pre-existing High findings can't isolate "block only
+on a rug-pull" without also fixing/waiving those. (2) `--format json`'s `Rule`/`Severity` fields serialize as
+raw integers, not names (pre-existing behavior for every compliance rule, not new to this feature) — a CI
+script filtering JSON output by rule name (e.g. `jq 'select(.Rule=="ManifestChangedSinceBaseline")'`) will
+silently match nothing; key off the process exit code, or use `--format markdown`/`console` for
+human-readable rule names, until the shared renderer gains enum-name serialization.
 
 ## 5 — Detecting MAF's silent skill-discovery exclusions
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -223,6 +223,22 @@ This is trust-time drift detection (JSON-persisted, mirrors the RedTeam baseline
 runtime gate that scores every turn — it fires when you re-scan, e.g. in CI before deploying an updated skill
 pack.
 
+**Reachable from the CLI**, not library-only: `agenteval skills scan <path> --save-manifest-baseline
+<file>` captures the pin (reusing the compliance scan's already-computed structural fingerprint — no
+re-hashing); a later `agenteval skills scan <path> --manifest-baseline <file>` checks against it and reports
+a changed skill as a High-severity `ManifestChangedSinceBaseline` finding, gated by the existing
+`--fail-on-noncompliant` (no separate fail flag needed). A SINGLE pinned file, deliberately distinct from
+`--write-baseline`'s multi-snapshot ledger above — commit it like the RedTeam CI baseline:
+
+```bash
+agenteval skills scan ./skills --save-manifest-baseline skills-baseline.json --baseline-notes "reviewed 2026-07-17"
+# ... later, in CI, before deploying an updated skill pack:
+agenteval skills scan ./skills --manifest-baseline skills-baseline.json --fail-on-noncompliant
+```
+
+Works the same way with `--repo`/`scan-workspace` — a skill name shared across locations is deduplicated the
+same `GroupBy`-first way `baseline diff`/`history` already tolerate it (see §2's known limitations above).
+
 ## 5 — Detecting MAF's silent skill-discovery exclusions
 
 MAF's own `AgentFileSkillsSource.GetSkillsAsync()` silently **excludes** a skill folder from discovery

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,6 +419,7 @@ suite ships, from the CLI.
 ```
 agenteval skills scan <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
                               [--write-baseline] [--baseline-root <dir>] [--repo] [--check-baseline]
+                              [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-notes <text>]
 ```
 
 **What it does**
@@ -427,9 +428,10 @@ Walks `<path>` for `SKILL.md`-rooted skill folders (the same convention MAF's ow
 discovers by), checks each against the GA `SKILL.md` authoring rules (name/description/compatibility) plus
 governance flags (script-execution review, untrusted resource sources, experimental `allowed-tools`), and
 renders a report. v1 is compliance-only — the composite Skill Health & Security Index is library-only for now
-(see [Agent Skills](agent-skills.md)). Two additional governance signals (Wave 2) ride along in the same
-report: cross-location content drift (`--repo` only, always on) and trust-on-first-use reputation matching
-(`--check-baseline`, opt-in) — see [Agent Skills](agent-skills.md#2--compliance-scanner) for how each works.
+(see [Agent Skills](agent-skills.md)). Three additional governance signals ride along in the same report:
+cross-location content drift (`--repo`/`scan-workspace` only, always on), trust-on-first-use reputation
+matching (`--check-baseline`, opt-in), and manifest hash-pin drift against an explicit trust-time pin
+(`--manifest-baseline`, opt-in) — see [Agent Skills](agent-skills.md#2--compliance-scanner) for how each works.
 
 **Options**
 
@@ -438,11 +440,14 @@ report: cross-location content drift (`--repo` only, always on) and trust-on-fir
 | `<path>` | Required, positional. Directory containing one or more skill folders (a REPO ROOT when `--repo` is set). |
 | `--format <fmt>` | `console` (default), `markdown`, or `json`. |
 | `-o, --output <path>` | Write the rendered report to a file instead of stdout. |
-| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Default off (informational-only). Cross-location drift (Medium) and previously-vetted matches (Low) never trigger this — only High-severity findings do. |
+| `--fail-on-noncompliant` | Exit `1` when the scan finds a High-severity finding. Default off (informational-only). Cross-location drift (Medium) and previously-vetted matches (Low) never trigger this; a manifest-baseline drift finding (High) DOES. |
 | `--write-baseline` | Capture a timestamped baseline snapshot (structural fingerprint + full file-content hash per skill) into the baseline ledger. See [`agenteval skills baseline`](#agenteval-skills-baseline) below. |
 | `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines`. Used by both `--write-baseline` and `--check-baseline`. |
 | `--repo` | Treat `<path>` as a repo root: scan every known skill-directory convention found under it (`.claude/skills`, `.agents/skills`, `.windsurf/skills`, ...) and aggregate the results into ONE combined report, instead of treating `<path>` itself as one skill directory. Per-convention breakdown (found/not-present, skill/finding counts) prints to stderr. When two or more conventions define the same skill name with DIFFERENT content, a `CrossLocationContentDrift` finding is added automatically. |
 | `--check-baseline` | Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history. A match against any prior snapshot for the same name adds an informational `MatchesPreviouslyVettedCopy` finding. Meaningless on a first-ever scan (no history yet) — pair with `--write-baseline` on earlier runs. |
+| `--save-manifest-baseline <file>` | Capture a trust-time hash-pin of every scanned skill's manifest content (name, description, resource/script inventory, allowed-tools, compatibility) to this JSON file. A SINGLE pinned file, distinct from `--write-baseline`'s multi-snapshot ledger — mirrors the RedTeam baseline/diff CI pattern: commit this file, then re-check future scans against it. |
+| `--manifest-baseline <file>` | Check every scanned skill against a `--save-manifest-baseline` file. A skill whose manifest content changed since the pin was captured is reported as a High-severity `ManifestChangedSinceBaseline` finding — a possible rug-pull. |
+| `--baseline-notes <text>` | Optional human note saved alongside `--save-manifest-baseline` (e.g. who approved it, why). |
 
 **Exit codes**
 
@@ -467,6 +472,7 @@ outside this verb's trust boundary (contrast with the still-gated, API-driven `s
 ```
 agenteval skills scan-workspace <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
                                         [--write-baseline] [--baseline-root <dir>] [--check-baseline]
+                                        [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-notes <text>]
 ```
 
 **What it does**
@@ -495,6 +501,7 @@ agenteval skills scan-workspace ~/audit --write-baseline --format json -o report
 | `--write-baseline` | Capture a timestamped baseline snapshot across all scanned repos into the baseline ledger. |
 | `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines-workspace` — deliberately DIFFERENT from `scan`'s `.agenteval/skills-baselines` default, so a plain `scan --write-baseline` can't accidentally get diffed against a much larger workspace-scale snapshot. Pass the same root to both verbs explicitly if you want one shared ledger. |
 | `--check-baseline` | Trust-on-first-use across the whole workspace — see `scan`'s `--check-baseline` above. |
+| `--save-manifest-baseline <file>` / `--manifest-baseline <file>` / `--baseline-notes <text>` | Same single-pin manifest hash-drift gate as `scan` — see `scan`'s own rows above. A skill name duplicated across repos is deduplicated the same way `--repo` already tolerates it. |
 
 **Known limitation:** `skills baseline diff`/`history` track only one location per skill name even when a
 single snapshot legitimately has several (a pre-existing Wave 2 shortcut) — at workspace scale, where the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,7 +419,7 @@ suite ships, from the CLI.
 ```
 agenteval skills scan <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
                               [--write-baseline] [--baseline-root <dir>] [--repo] [--check-baseline]
-                              [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-notes <text>]
+                              [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-note <text>]
 ```
 
 **What it does**
@@ -447,7 +447,7 @@ matching (`--check-baseline`, opt-in), and manifest hash-pin drift against an ex
 | `--check-baseline` | Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history. A match against any prior snapshot for the same name adds an informational `MatchesPreviouslyVettedCopy` finding. Meaningless on a first-ever scan (no history yet) — pair with `--write-baseline` on earlier runs. |
 | `--save-manifest-baseline <file>` | Capture a trust-time hash-pin of every scanned skill's manifest content (name, description, resource/script inventory, allowed-tools, compatibility) to this JSON file. A SINGLE pinned file, distinct from `--write-baseline`'s multi-snapshot ledger — mirrors the RedTeam baseline/diff CI pattern: commit this file, then re-check future scans against it. |
 | `--manifest-baseline <file>` | Check every scanned skill against a `--save-manifest-baseline` file. A skill whose manifest content changed since the pin was captured is reported as a High-severity `ManifestChangedSinceBaseline` finding — a possible rug-pull. |
-| `--baseline-notes <text>` | Optional human note saved alongside `--save-manifest-baseline` (e.g. who approved it, why). |
+| `--baseline-note <text>` | Optional human note saved alongside `--save-manifest-baseline` (e.g. who approved it, why). |
 
 **Exit codes**
 
@@ -472,7 +472,7 @@ outside this verb's trust boundary (contrast with the still-gated, API-driven `s
 ```
 agenteval skills scan-workspace <path> [--format console|markdown|json] [-o|--output <file>] [--fail-on-noncompliant]
                                         [--write-baseline] [--baseline-root <dir>] [--check-baseline]
-                                        [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-notes <text>]
+                                        [--save-manifest-baseline <file>] [--manifest-baseline <file>] [--baseline-note <text>]
 ```
 
 **What it does**
@@ -501,7 +501,7 @@ agenteval skills scan-workspace ~/audit --write-baseline --format json -o report
 | `--write-baseline` | Capture a timestamped baseline snapshot across all scanned repos into the baseline ledger. |
 | `--baseline-root <dir>` | Baseline ledger root directory. Default `.agenteval/skills-baselines-workspace` — deliberately DIFFERENT from `scan`'s `.agenteval/skills-baselines` default, so a plain `scan --write-baseline` can't accidentally get diffed against a much larger workspace-scale snapshot. Pass the same root to both verbs explicitly if you want one shared ledger. |
 | `--check-baseline` | Trust-on-first-use across the whole workspace — see `scan`'s `--check-baseline` above. |
-| `--save-manifest-baseline <file>` / `--manifest-baseline <file>` / `--baseline-notes <text>` | Same single-pin manifest hash-drift gate as `scan` — see `scan`'s own rows above. A skill name duplicated across repos is deduplicated the same way `--repo` already tolerates it. |
+| `--save-manifest-baseline <file>` / `--manifest-baseline <file>` / `--baseline-note <text>` | Same single-pin manifest hash-drift gate as `scan` — see `scan`'s own rows above. A skill name duplicated across repos is deduplicated the same way `--repo` already tolerates it. |
 
 **Known limitation:** `skills baseline diff`/`history` track only one location per skill name even when a
 single snapshot legitimately has several (a pre-existing Wave 2 shortcut) — at workspace scale, where the

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -88,8 +88,8 @@ internal static class SkillsScanCommand
             { Description = "Capture a trust-time hash-pin of every scanned skill's manifest content (name, description, resource/script inventory, allowed-tools, compatibility) to this JSON file. A SINGLE pinned file, distinct from --write-baseline's multi-snapshot ledger — mirrors the RedTeam baseline/diff CI pattern: commit this file, then re-check future scans against it with --manifest-baseline." },
         new Option<FileInfo?>("--manifest-baseline")
             { Description = "Check every scanned skill's manifest content against a file captured by --save-manifest-baseline. A skill whose content changed since the pin was captured is reported as a High-severity ManifestChangedSinceBaseline finding — gated by --fail-on-noncompliant like any other High finding, no separate flag needed. A possible rug-pull: a previously-approved skill silently changing after approval." },
-        new Option<string?>("--baseline-notes")
-            { Description = "Optional human note saved alongside --save-manifest-baseline (e.g. who approved it, why)." });
+        new Option<string?>("--baseline-note")   // singular, matching RedTeamCommand's established --baseline-note precedent
+            { Description = "Optional human note saved alongside --save-manifest-baseline (e.g. who approved it, why). Has no effect without --save-manifest-baseline." });
 
     private static Command BuildScanCommand()
     {
@@ -159,7 +159,7 @@ internal static class SkillsScanCommand
 
         // Agent Skills Wave 2: entries (content hash + structural fingerprint per skill — real disk I/O,
         // SkillContentHasher reads every byte of every file in every skill folder) are needed for
-        // cross-location drift detection, trust-on-first-use matching, persisting a snapshot, and (Phase 3)
+        // cross-location drift detection, trust-on-first-use matching, persisting a snapshot, and
         // the manifest-baseline hash-pin drift gate — the latter reuses StructuralFingerprint (already
         // SkillManifestPoisoningGate.Fingerprint(manifest) under the hood), no raw manifest list needed.
         // --repo builds them unconditionally: drift detection has no opt-out flag, and a repo-wide
@@ -220,10 +220,43 @@ internal static class SkillsScanCommand
             extraFindings.AddRange(DetectPreviouslyVetted(entries, history));
         }
 
-        if (manifestBaseline is not null)
+        // NOT all extraFindings sources are equally severe: DetectCrossLocationDrift (Medium) and
+        // DetectPreviouslyVetted (Low) never trip --fail-on-noncompliant; DetectManifestDrift below is
+        // High and DOES. Don't assume a future addition here is non-blocking by pattern-matching these two
+        // — check the actual Severity you give it.
+
+        // Computed at most once, shared by the drift-check below AND the save block further down — avoids
+        // hashing every entry twice when --manifest-baseline and --save-manifest-baseline are both passed
+        // in the same run (a real workflow this feature explicitly mirrors from the RedTeam CI pattern:
+        // "verify the old pin, then re-pin the new baseline" in one command).
+        Dictionary<string, string>? currentManifestHashes = null;
+
+        // A Changed finding requires the same skill name present in BOTH the baseline and the current scan
+        // — with zero entries, that's mathematically impossible, so skip the file load entirely rather than
+        // risk a spurious error for a --manifest-baseline path that happens to be missing/corrupted on a
+        // scan that had nothing to check in the first place.
+        if (manifestBaseline is not null && entries.Count > 0)
         {
-            var baseline = await SkillManifestBaseline.LoadAsync(manifestBaseline.FullName, ct).ConfigureAwait(false);
-            extraFindings.AddRange(DetectManifestDrift(entries, baseline));
+            currentManifestHashes = ManifestFingerprintsByName(entries);
+            SkillManifestBaseline? baseline;
+            try
+            {
+                baseline = await SkillManifestBaseline.LoadAsync(manifestBaseline.FullName, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
+                // Same graceful "nothing to compare against yet" precedent --check-baseline already
+                // establishes for an empty ledger — a --manifest-baseline path that doesn't exist yet is not
+                // fatal, just uninformative. Lets `--save-manifest-baseline x.json --manifest-baseline x.json`
+                // work in ONE command on a first-ever run instead of requiring two separate invocations.
+                baseline = null;
+                Console.Error.WriteLine($"  Note: --manifest-baseline file not found ({manifestBaseline.FullName}) — nothing to compare against yet.");
+            }
+
+            if (baseline is not null)
+            {
+                extraFindings.AddRange(DetectManifestDrift(currentManifestHashes, baseline));
+            }
         }
 
         if (extraFindings.Count > 0)
@@ -253,10 +286,25 @@ internal static class SkillsScanCommand
 
         if (saveManifestBaseline is not null)
         {
-            var hashes = ManifestFingerprintsByName(entries);
+            var hashes = currentManifestHashes ?? ManifestFingerprintsByName(entries);
             var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, hashes, baselineNotes);
+            // Unlike --write-baseline's JsonFileSkillBaselineStore (whose constructor creates its root
+            // directory), SkillManifestBaseline.SaveAsync is a bare File.WriteAllTextAsync with no directory
+            // creation — create the parent directory first so a fresh ".agenteval/..."-style path (the same
+            // convention --baseline-root's own default already establishes) doesn't throw
+            // DirectoryNotFoundException on a repo that's never captured a manifest baseline before.
+            var parentDir = saveManifestBaseline.Directory;
+            if (parentDir is not null && !parentDir.Exists)
+            {
+                parentDir.Create();
+            }
+
             await baseline.SaveAsync(saveManifestBaseline.FullName, ct).ConfigureAwait(false);
             Console.Error.WriteLine($"  Manifest baseline saved: {saveManifestBaseline.FullName} ({hashes.Count} skill(s))");
+        }
+        else if (baselineNotes is not null)
+        {
+            Console.Error.WriteLine("  Warning: --baseline-note has no effect without --save-manifest-baseline — ignored.");
         }
 
         return ComputeExitCode(report, failOnNoncompliant);
@@ -632,7 +680,7 @@ internal static class SkillsScanCommand
         return findings;
     }
 
-    // ═══════════════════════════════ manifest-baseline hash-pin drift gate (Phase 3) ═══════════════════════════════
+    // ═══════════════════════════════ manifest-baseline hash-pin drift gate (Phase 4b CLI surface) ═══════════════════════════════
 
     /// <summary>
     /// <c>--manifest-baseline &lt;file&gt;</c>: compares every scanned skill's current
@@ -645,24 +693,39 @@ internal static class SkillsScanCommand
     /// </summary>
     internal static IReadOnlyList<SkillComplianceFinding> DetectManifestDrift(
         IReadOnlyList<SkillBaselineEntry> entries, SkillManifestBaseline baseline)
+        => DetectManifestDrift(ManifestFingerprintsByName(entries), baseline);
+
+    /// <summary>
+    /// Overload accepting an already-computed fingerprint map — lets <see cref="FinishScanAsync"/> compute
+    /// it at most ONCE and share it with the <c>--save-manifest-baseline</c> save block, instead of hashing
+    /// every entry twice when both flags are passed in the same run.
+    /// </summary>
+    internal static IReadOnlyList<SkillComplianceFinding> DetectManifestDrift(
+        IReadOnlyDictionary<string, string> currentHashesByName, SkillManifestBaseline baseline)
     {
-        var currentHashes = ManifestFingerprintsByName(entries);
-        var drift = ManifestDriftDetector.Detect(baseline.HashesBySkillName, currentHashes);
+        var drift = ManifestDriftDetector.Detect(baseline.HashesBySkillName, currentHashesByName);
 
         var findings = new List<SkillComplianceFinding>();
         foreach (var d in drift.Where(d => d.Kind == ManifestDriftKind.Changed))
         {
-            // Changed means both hashes exist (see ManifestDriftDetector.Detect) — non-null by construction.
-            var beforeHash = d.BaselineHash!;
-            var afterHash = d.CurrentHash!;
+            // ManifestDriftDetector.Detect only checks dictionary KEY presence via TryGetValue, not that the
+            // VALUE is non-null — a hand-edited/corrupted --manifest-baseline JSON file can deserialize a
+            // null hash for a present key (System.Text.Json's default options don't enforce NRT
+            // non-nullability at runtime), so "Changed" does NOT actually guarantee non-null hashes. Defend
+            // against that instead of trusting it and null-forgiving into a NullReferenceException.
+            var hashSummary = (d.BaselineHash, d.CurrentHash) switch
+            {
+                (string before, string after) =>
+                    $" (fingerprint {before[..Math.Min(8, before.Length)]}… -> {after[..Math.Min(8, after.Length)]}…)",
+                _ => " (the baseline file has a missing or malformed hash for this skill — re-capture it with --save-manifest-baseline)",
+            };
+
             findings.Add(new SkillComplianceFinding(
                 d.Key,
                 SkillComplianceRule.ManifestChangedSinceBaseline,
                 Severity.High,
-                $"Skill '{d.Key}' manifest content changed since the trust-time baseline was captured " +
-                $"(fingerprint {beforeHash[..Math.Min(8, beforeHash.Length)]}… -> " +
-                $"{afterHash[..Math.Min(8, afterHash.Length)]}…) — verify this change was reviewed " +
-                "and re-approved before trusting it again.",
+                $"Skill '{d.Key}' manifest content changed since the trust-time baseline was captured{hashSummary} — " +
+                "verify this change was reviewed and re-approved before trusting it again.",
                 Field: null));
         }
 
@@ -672,9 +735,18 @@ internal static class SkillsScanCommand
     // Wave 2: a --repo/scan-workspace entries list can legitimately contain 2+ entries sharing the same
     // Name (the exact cross-location-drift scenario) — GroupBy+First (not ToDictionary directly), same
     // tolerance DiffAsync's own baselineBySkill/currentBySkill already use, rather than crashing.
+    // Keys are lowercased, not just grouped with StringComparer.Ordinal — ManifestDriftDetector.Detect's own
+    // key union (ManifestFingerprint.cs) is hardcoded to StringComparer.Ordinal and can't be told to ignore
+    // case, so relying on THIS dictionary's comparer alone wouldn't actually make the comparison
+    // case-insensitive. Lowercasing the key here (both when capturing --save-manifest-baseline and when
+    // checking --manifest-baseline, since both paths call this same method) means the SAME skill differing
+    // only by name casing produces the SAME dictionary key either way, closing what would otherwise be a
+    // real detection bypass: DetectCrossLocationDrift already treats a case-only name difference as GA
+    // requires lowercase-only names, so it's the SAME skill, not two unrelated ones — a rug-pull that also
+    // re-cases the name must not be able to evade this gate by looking like an unrelated New+Removed pair.
     private static Dictionary<string, string> ManifestFingerprintsByName(IReadOnlyList<SkillBaselineEntry> entries) =>
         entries
-            .GroupBy(e => e.Name, StringComparer.Ordinal)
+            .GroupBy(e => e.Name.ToLowerInvariant(), StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.First().StructuralFingerprint, StringComparer.Ordinal);
 
     // ═══════════════════════════════ baseline entry building (§4.1) ═══════════════════════════════

--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -47,15 +47,33 @@ internal static class SkillsScanCommand
 
     // ═══════════════════════════════════════════ scan ═══════════════════════════════════════════
 
+    /// <summary>The options <c>scan</c> and <c>scan-workspace</c> share verbatim — see <see cref="BuildCommonScanOptions"/>.</summary>
+    private sealed record CommonScanOptions(
+        Option<string> Format, Option<FileInfo?> Output, Option<bool> FailOnNoncompliant,
+        Option<bool> WriteBaseline, Option<string> BaselineRoot, Option<bool> CheckBaseline,
+        Option<FileInfo?> SaveManifestBaseline, Option<FileInfo?> ManifestBaseline, Option<string?> BaselineNotes)
+    {
+        public void AddAllTo(Command command)
+        {
+            command.Options.Add(Format);
+            command.Options.Add(Output);
+            command.Options.Add(FailOnNoncompliant);
+            command.Options.Add(WriteBaseline);
+            command.Options.Add(BaselineRoot);
+            command.Options.Add(CheckBaseline);
+            command.Options.Add(SaveManifestBaseline);
+            command.Options.Add(ManifestBaseline);
+            command.Options.Add(BaselineNotes);
+        }
+    }
+
     /// <summary>
-    /// The 5 options <c>scan</c> and <c>scan-workspace</c> share verbatim (everything except <c>--repo</c>,
+    /// The options <c>scan</c> and <c>scan-workspace</c> share verbatim (everything except <c>--repo</c>,
     /// which only <c>scan</c> has, and each command's own default <c>--baseline-root</c>). Built ONCE here so
     /// the two commands' help text cannot silently drift apart the way it already had before this helper
     /// existed (the two copies' <c>--check-baseline</c> descriptions had gone out of sync).
     /// </summary>
-    private static (Option<string> Format, Option<FileInfo?> Output, Option<bool> FailOnNoncompliant,
-        Option<bool> WriteBaseline, Option<string> BaselineRoot, Option<bool> CheckBaseline) BuildCommonScanOptions(
-        string defaultBaselineRoot) => (
+    private static CommonScanOptions BuildCommonScanOptions(string defaultBaselineRoot) => new(
         new Option<string>("--format") { DefaultValueFactory = _ => "console", Description = "Output format: console | markdown | json" },
         new Option<FileInfo?>("-o", "--output") { Description = "Output file (default: stdout)" },
         new Option<bool>("--fail-on-noncompliant")
@@ -65,7 +83,13 @@ internal static class SkillsScanCommand
         new Option<string>("--baseline-root")
             { DefaultValueFactory = _ => defaultBaselineRoot, Description = "Baseline ledger root directory (used with --write-baseline / --check-baseline)." },
         new Option<bool>("--check-baseline")
-            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding. Meaningless on a first-ever scan (no history yet) — pair with --write-baseline on earlier runs." });
+            { Description = "Trust-on-first-use: compare each scanned skill's content hash against the baseline ledger's history (--baseline-root). A match against ANY prior snapshot for the same skill name is reported as an informational 'matches a previously-vetted copy' finding. Meaningless on a first-ever scan (no history yet) — pair with --write-baseline on earlier runs." },
+        new Option<FileInfo?>("--save-manifest-baseline")
+            { Description = "Capture a trust-time hash-pin of every scanned skill's manifest content (name, description, resource/script inventory, allowed-tools, compatibility) to this JSON file. A SINGLE pinned file, distinct from --write-baseline's multi-snapshot ledger — mirrors the RedTeam baseline/diff CI pattern: commit this file, then re-check future scans against it with --manifest-baseline." },
+        new Option<FileInfo?>("--manifest-baseline")
+            { Description = "Check every scanned skill's manifest content against a file captured by --save-manifest-baseline. A skill whose content changed since the pin was captured is reported as a High-severity ManifestChangedSinceBaseline finding — gated by --fail-on-noncompliant like any other High finding, no separate flag needed. A possible rug-pull: a previously-approved skill silently changing after approval." },
+        new Option<string?>("--baseline-notes")
+            { Description = "Optional human note saved alongside --save-manifest-baseline (e.g. who approved it, why)." });
 
     private static Command BuildScanCommand()
     {
@@ -73,18 +97,13 @@ internal static class SkillsScanCommand
 
         var pathArg = new Argument<DirectoryInfo>("path")
             { Description = "Directory containing one or more SKILL.md-rooted skill folders (a repo root when --repo is set)" };
-        var (formatOpt, outputOpt, failOnOpt, writeBaselineOpt, baselineRootOpt, checkBaselineOpt) = BuildCommonScanOptions(DefaultBaselineRoot);
+        var opts = BuildCommonScanOptions(DefaultBaselineRoot);
         var repoOpt = new Option<bool>("--repo")
             { Description = "Treat <path> as a REPO ROOT: scan every known skill-directory convention found under it (.claude/skills, .agents/skills, ...) and aggregate the results, instead of treating <path> itself as one skill directory. Always content-hashes every skill folder (real file I/O) to check for cross-location drift — the same name resolving to different content in two conventions — even without --write-baseline/--check-baseline." };
 
         scanCmd.Arguments.Add(pathArg);
-        scanCmd.Options.Add(formatOpt);
-        scanCmd.Options.Add(outputOpt);
-        scanCmd.Options.Add(failOnOpt);
-        scanCmd.Options.Add(writeBaselineOpt);
+        opts.AddAllTo(scanCmd);
         scanCmd.Options.Add(repoOpt);
-        scanCmd.Options.Add(baselineRootOpt);
-        scanCmd.Options.Add(checkBaselineOpt);
 
         scanCmd.SetAction(async (parseResult, ct) =>
         {
@@ -92,13 +111,16 @@ internal static class SkillsScanCommand
             {
                 return await ExecuteAsync(
                     parseResult.GetValue(pathArg)!,
-                    parseResult.GetValue(formatOpt)!,
-                    parseResult.GetValue(outputOpt),
-                    parseResult.GetValue(failOnOpt),
-                    parseResult.GetValue(writeBaselineOpt),
+                    parseResult.GetValue(opts.Format)!,
+                    parseResult.GetValue(opts.Output),
+                    parseResult.GetValue(opts.FailOnNoncompliant),
+                    parseResult.GetValue(opts.WriteBaseline),
                     parseResult.GetValue(repoOpt),
-                    parseResult.GetValue(baselineRootOpt)!,
-                    parseResult.GetValue(checkBaselineOpt),
+                    parseResult.GetValue(opts.BaselineRoot)!,
+                    parseResult.GetValue(opts.CheckBaseline),
+                    parseResult.GetValue(opts.SaveManifestBaseline),
+                    parseResult.GetValue(opts.ManifestBaseline),
+                    parseResult.GetValue(opts.BaselineNotes),
                     ct);
             }
             catch (Exception ex)
@@ -122,7 +144,8 @@ internal static class SkillsScanCommand
     internal static async Task<int> ExecuteAsync(
         DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
         bool writeBaseline = false, bool repo = false, string baselineRoot = DefaultBaselineRoot,
-        bool checkBaseline = false, CancellationToken ct = default)
+        bool checkBaseline = false, FileInfo? saveManifestBaseline = null, FileInfo? manifestBaseline = null,
+        string? baselineNotes = null, CancellationToken ct = default)
     {
         if (!path.Exists)
         {
@@ -136,7 +159,9 @@ internal static class SkillsScanCommand
 
         // Agent Skills Wave 2: entries (content hash + structural fingerprint per skill — real disk I/O,
         // SkillContentHasher reads every byte of every file in every skill folder) are needed for
-        // cross-location drift detection, trust-on-first-use matching, and persisting a snapshot.
+        // cross-location drift detection, trust-on-first-use matching, persisting a snapshot, and (Phase 3)
+        // the manifest-baseline hash-pin drift gate — the latter reuses StructuralFingerprint (already
+        // SkillManifestPoisoningGate.Fingerprint(manifest) under the hood), no raw manifest list needed.
         // --repo builds them unconditionally: drift detection has no opt-out flag, and a repo-wide
         // governance scan is expected to cost more than a single-directory one (documented in the --repo
         // option's own help text). A single-directory scan is NOT --repo-wide, though — a plain
@@ -155,7 +180,7 @@ internal static class SkillsScanCommand
         {
             var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(path.FullName, noOpAgent, options: null, ct).ConfigureAwait(false);
             report = result.Report;
-            entries = (writeBaseline || checkBaseline)
+            entries = (writeBaseline || checkBaseline || saveManifestBaseline is not null || manifestBaseline is not null)
                 ? result.Skills.Select(info => ToBaselineEntry(info, report.Findings, conventionPrefix: null)).ToList()
                 : [];
         }
@@ -164,19 +189,22 @@ internal static class SkillsScanCommand
         // repo-wide scan is the only mode where "cross-location" is even meaningful for a single repo).
         return await FinishScanAsync(
             report, entries, checkCrossLocationDrift: repo, format, output, failOnNoncompliant,
-            writeBaseline, baselineRoot, checkBaseline, path.FullName, ct).ConfigureAwait(false);
+            writeBaseline, baselineRoot, checkBaseline, saveManifestBaseline, manifestBaseline, baselineNotes,
+            path.FullName, ct).ConfigureAwait(false);
     }
 
     /// <summary>
     /// The tail shared by every scan mode (single-directory, <c>--repo</c>, and Wave 3a's
     /// <c>scan-workspace</c>) once discovery has produced a <see cref="SkillComplianceReport"/> and its
-    /// matching <see cref="SkillBaselineEntry"/> list: merge in cross-location-drift / trust-on-first-use
-    /// findings, render, write the output, persist a baseline snapshot if asked, and compute the exit code.
+    /// matching <see cref="SkillBaselineEntry"/> list: merge in cross-location-drift / trust-on-first-use /
+    /// manifest-baseline-drift findings, render, write the output, persist a baseline snapshot if asked, and
+    /// compute the exit code.
     /// </summary>
     private static async Task<int> FinishScanAsync(
         SkillComplianceReport report, IReadOnlyList<SkillBaselineEntry> entries, bool checkCrossLocationDrift,
         string format, FileInfo? output, bool failOnNoncompliant, bool writeBaseline, string baselineRoot,
-        bool checkBaseline, string scannedRoot, CancellationToken ct)
+        bool checkBaseline, FileInfo? saveManifestBaseline, FileInfo? manifestBaseline, string? baselineNotes,
+        string scannedRoot, CancellationToken ct)
     {
         // --check-baseline trust-on-first-use matching is opt-in (meaningless without prior baseline history).
         var extraFindings = new List<SkillComplianceFinding>();
@@ -190,6 +218,12 @@ internal static class SkillsScanCommand
             var historyStore = new JsonFileSkillBaselineStore(baselineRoot);
             var history = await historyStore.ListAsync(ct).ConfigureAwait(false);
             extraFindings.AddRange(DetectPreviouslyVetted(entries, history));
+        }
+
+        if (manifestBaseline is not null)
+        {
+            var baseline = await SkillManifestBaseline.LoadAsync(manifestBaseline.FullName, ct).ConfigureAwait(false);
+            extraFindings.AddRange(DetectManifestDrift(entries, baseline));
         }
 
         if (extraFindings.Count > 0)
@@ -215,6 +249,14 @@ internal static class SkillsScanCommand
             var store = new JsonFileSkillBaselineStore(baselineRoot);
             var id = await store.SaveAsync(snapshot, ct).ConfigureAwait(false);
             Console.Error.WriteLine($"  Baseline snapshot saved: {id} ({snapshot.Skills.Count} skill(s) -> {baselineRoot})");
+        }
+
+        if (saveManifestBaseline is not null)
+        {
+            var hashes = ManifestFingerprintsByName(entries);
+            var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, hashes, baselineNotes);
+            await baseline.SaveAsync(saveManifestBaseline.FullName, ct).ConfigureAwait(false);
+            Console.Error.WriteLine($"  Manifest baseline saved: {saveManifestBaseline.FullName} ({hashes.Count} skill(s))");
         }
 
         return ComputeExitCode(report, failOnNoncompliant);
@@ -246,15 +288,10 @@ internal static class SkillsScanCommand
 
         var pathArg = new Argument<DirectoryInfo>("path")
             { Description = "A folder whose immediate subdirectories are repo roots (e.g. where you 'gh repo clone'd your org's repos)" };
-        var (formatOpt, outputOpt, failOnOpt, writeBaselineOpt, baselineRootOpt, checkBaselineOpt) = BuildCommonScanOptions(DefaultWorkspaceBaselineRoot);
+        var opts = BuildCommonScanOptions(DefaultWorkspaceBaselineRoot);
 
         scanWorkspaceCmd.Arguments.Add(pathArg);
-        scanWorkspaceCmd.Options.Add(formatOpt);
-        scanWorkspaceCmd.Options.Add(outputOpt);
-        scanWorkspaceCmd.Options.Add(failOnOpt);
-        scanWorkspaceCmd.Options.Add(writeBaselineOpt);
-        scanWorkspaceCmd.Options.Add(baselineRootOpt);
-        scanWorkspaceCmd.Options.Add(checkBaselineOpt);
+        opts.AddAllTo(scanWorkspaceCmd);
 
         scanWorkspaceCmd.SetAction(async (parseResult, ct) =>
         {
@@ -262,12 +299,15 @@ internal static class SkillsScanCommand
             {
                 return await ExecuteWorkspaceAsync(
                     parseResult.GetValue(pathArg)!,
-                    parseResult.GetValue(formatOpt)!,
-                    parseResult.GetValue(outputOpt),
-                    parseResult.GetValue(failOnOpt),
-                    parseResult.GetValue(writeBaselineOpt),
-                    parseResult.GetValue(baselineRootOpt)!,
-                    parseResult.GetValue(checkBaselineOpt),
+                    parseResult.GetValue(opts.Format)!,
+                    parseResult.GetValue(opts.Output),
+                    parseResult.GetValue(opts.FailOnNoncompliant),
+                    parseResult.GetValue(opts.WriteBaseline),
+                    parseResult.GetValue(opts.BaselineRoot)!,
+                    parseResult.GetValue(opts.CheckBaseline),
+                    parseResult.GetValue(opts.SaveManifestBaseline),
+                    parseResult.GetValue(opts.ManifestBaseline),
+                    parseResult.GetValue(opts.BaselineNotes),
                     ct);
             }
             catch (Exception ex)
@@ -290,6 +330,7 @@ internal static class SkillsScanCommand
     internal static async Task<int> ExecuteWorkspaceAsync(
         DirectoryInfo path, string format, FileInfo? output, bool failOnNoncompliant,
         bool writeBaseline = false, string baselineRoot = DefaultWorkspaceBaselineRoot, bool checkBaseline = false,
+        FileInfo? saveManifestBaseline = null, FileInfo? manifestBaseline = null, string? baselineNotes = null,
         CancellationToken ct = default)
     {
         if (!path.Exists)
@@ -308,7 +349,8 @@ internal static class SkillsScanCommand
         // for how entries are re-tagged to make this fall out of the EXISTING DetectCrossLocationDrift as-is).
         return await FinishScanAsync(
             report, entries, checkCrossLocationDrift: true, format, output, failOnNoncompliant,
-            writeBaseline, baselineRoot, checkBaseline, path.FullName, ct).ConfigureAwait(false);
+            writeBaseline, baselineRoot, checkBaseline, saveManifestBaseline, manifestBaseline, baselineNotes,
+            path.FullName, ct).ConfigureAwait(false);
     }
 
     // Bounded so a workspace of many repos doesn't open unbounded concurrent file handles; matches the same
@@ -589,6 +631,51 @@ internal static class SkillsScanCommand
 
         return findings;
     }
+
+    // ═══════════════════════════════ manifest-baseline hash-pin drift gate (Phase 3) ═══════════════════════════════
+
+    /// <summary>
+    /// <c>--manifest-baseline &lt;file&gt;</c>: compares every scanned skill's current
+    /// <see cref="SkillManifestPoisoningGate.Fingerprint"/> (already computed once, into
+    /// <see cref="SkillBaselineEntry.StructuralFingerprint"/> — reused here verbatim, no re-hashing) against
+    /// a previously trust-time-pinned <see cref="SkillManifestBaseline"/>. Only a <see cref="ManifestDriftKind.Changed"/>
+    /// skill becomes a finding — the actual rug-pull signal; <see cref="ManifestDriftKind.New"/> (not yet
+    /// pinned) and <see cref="ManifestDriftKind.Removed"/> (no longer present) are housekeeping, not
+    /// poisoning, and are deliberately not surfaced here.
+    /// </summary>
+    internal static IReadOnlyList<SkillComplianceFinding> DetectManifestDrift(
+        IReadOnlyList<SkillBaselineEntry> entries, SkillManifestBaseline baseline)
+    {
+        var currentHashes = ManifestFingerprintsByName(entries);
+        var drift = ManifestDriftDetector.Detect(baseline.HashesBySkillName, currentHashes);
+
+        var findings = new List<SkillComplianceFinding>();
+        foreach (var d in drift.Where(d => d.Kind == ManifestDriftKind.Changed))
+        {
+            // Changed means both hashes exist (see ManifestDriftDetector.Detect) — non-null by construction.
+            var beforeHash = d.BaselineHash!;
+            var afterHash = d.CurrentHash!;
+            findings.Add(new SkillComplianceFinding(
+                d.Key,
+                SkillComplianceRule.ManifestChangedSinceBaseline,
+                Severity.High,
+                $"Skill '{d.Key}' manifest content changed since the trust-time baseline was captured " +
+                $"(fingerprint {beforeHash[..Math.Min(8, beforeHash.Length)]}… -> " +
+                $"{afterHash[..Math.Min(8, afterHash.Length)]}…) — verify this change was reviewed " +
+                "and re-approved before trusting it again.",
+                Field: null));
+        }
+
+        return findings;
+    }
+
+    // Wave 2: a --repo/scan-workspace entries list can legitimately contain 2+ entries sharing the same
+    // Name (the exact cross-location-drift scenario) — GroupBy+First (not ToDictionary directly), same
+    // tolerance DiffAsync's own baselineBySkill/currentBySkill already use, rather than crashing.
+    private static Dictionary<string, string> ManifestFingerprintsByName(IReadOnlyList<SkillBaselineEntry> entries) =>
+        entries
+            .GroupBy(e => e.Name, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First().StructuralFingerprint, StringComparer.Ordinal);
 
     // ═══════════════════════════════ baseline entry building (§4.1) ═══════════════════════════════
 

--- a/src/AgentEval.Core/Skills/SkillComplianceModels.cs
+++ b/src/AgentEval.Core/Skills/SkillComplianceModels.cs
@@ -95,6 +95,20 @@ public enum SkillComplianceRule
     /// (<see cref="Severity.Low"/>) — a positive "no drift since last seen" signal, not a problem.
     /// </summary>
     MatchesPreviouslyVettedCopy,
+
+    /// <summary>
+    /// <c>agenteval skills scan --manifest-baseline &lt;file&gt;</c> found this skill's current
+    /// <see cref="AgentEval.Skills.SkillManifestPoisoningGate.Fingerprint"/> differs from the pin captured
+    /// in a prior <c>--save-manifest-baseline</c> run — the skill's manifest content (name, description,
+    /// resource/script inventory, allowed-tools, compatibility) changed since it was reviewed and trust-time
+    /// pinned. A real rug-pull candidate: a previously-approved skill silently changing after approval is a
+    /// live trust-boundary breach, so this is <see cref="Severity.High"/> — the same severity
+    /// <see cref="AgentEval.Skills.SkillSecurityIndex"/>'s own <c>ChangedManifestPenalty</c> already treats a
+    /// changed manifest with. Distinct from <see cref="CrossLocationContentDrift"/> (compares the SAME scan's
+    /// multiple locations against each other) — this compares ONE scan against an earlier, deliberately
+    /// pinned trust-time snapshot, mirroring the RedTeam baseline/diff CI pattern.
+    /// </summary>
+    ManifestChangedSinceBaseline,
 }
 
 /// <summary>One rule violation (or informational flag) found for one skill.</summary>

--- a/tests/AgentEval.Tests/Cli/SkillsManifestBaselineDriftTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsManifestBaselineDriftTests.cs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli;
+using AgentEval.Cli.Commands;
+using AgentEval.Guardrails;
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.Cli;
+
+/// <summary>
+/// Agent Skills Phase 3 (v2 scan-verb CLI surface, the cheap half) — <c>skills scan --save-manifest-baseline</c>
+/// / <c>--manifest-baseline</c>: a SINGLE-PIN, JSON-file-backed hash-pin drift gate
+/// (<see cref="SkillManifestPoisoningGate"/>/<see cref="SkillManifestBaseline"/>), deliberately distinct from
+/// Wave 1/2's multi-snapshot <c>--write-baseline</c>/<c>--baseline-root</c>/<c>--check-baseline</c> ledger.
+/// </summary>
+public class SkillsManifestBaselineDriftTests : IDisposable
+{
+    private readonly string _baselineFile;
+
+    public SkillsManifestBaselineDriftTests()
+    {
+        _baselineFile = Path.Combine(Path.GetTempPath(), "agenteval-manifest-baseline-test-" + Guid.NewGuid().ToString("N") + ".json");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_baselineFile); } catch { /* best-effort cleanup */ }
+    }
+
+    // ── command wiring ──
+
+    [Fact]
+    public void Create_ScanSubcommand_HasManifestBaselineOptions()
+    {
+        var scanCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--save-manifest-baseline");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--manifest-baseline");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--baseline-notes");
+    }
+
+    [Fact]
+    public void Create_ScanWorkspaceSubcommand_HasManifestBaselineOptions()
+    {
+        var cmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan-workspace");
+        Assert.Contains(cmd.Options, o => o.Name == "--save-manifest-baseline");
+        Assert.Contains(cmd.Options, o => o.Name == "--manifest-baseline");
+        Assert.Contains(cmd.Options, o => o.Name == "--baseline-notes");
+    }
+
+    // ── DetectManifestDrift: pure unit tests ──
+
+    [Fact]
+    public void DetectManifestDrift_UnchangedFingerprint_NoFinding()
+    {
+        var entries = new[] { new SkillBaselineEntry("skill-a", SkillSourceKind.File, "skill-a", "fp-1", "content-hash", null, null, null, []) };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["skill-a"] = "fp-1" });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void DetectManifestDrift_ChangedFingerprint_ReturnsHighSeverityFinding()
+    {
+        var entries = new[] { new SkillBaselineEntry("skill-a", SkillSourceKind.File, "skill-a", "fp-2", "content-hash", null, null, null, []) };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["skill-a"] = "fp-1" });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal("skill-a", finding.SkillName);
+        Assert.Equal(SkillComplianceRule.ManifestChangedSinceBaseline, finding.Rule);
+        Assert.Equal(Severity.High, finding.Severity);
+    }
+
+    [Fact]
+    public void DetectManifestDrift_NewSkill_NotBaselined_NoFinding()
+    {
+        // New (not yet pinned) is housekeeping, not a poisoning signal — deliberately not surfaced.
+        var entries = new[] { new SkillBaselineEntry("skill-new", SkillSourceKind.File, "skill-new", "fp-1", "content-hash", null, null, null, []) };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string>());
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void DetectManifestDrift_RemovedSkill_NoFinding()
+    {
+        // Removed (baselined but no longer present) is housekeeping, not a poisoning signal.
+        var entries = Array.Empty<SkillBaselineEntry>();
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["skill-gone"] = "fp-1" });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        Assert.Empty(findings);
+    }
+
+    [Fact]
+    public void DetectManifestDrift_DuplicateNameAcrossLocations_DoesNotThrow_UsesFirstDeterministically()
+    {
+        // The exact --repo/scan-workspace cross-location scenario: 2 entries share a Name. Must not crash
+        // (a plain ToDictionary would) — GroupBy+First tolerance, same pattern DiffAsync's own
+        // baselineBySkill/currentBySkill already use.
+        var entries = new[]
+        {
+            new SkillBaselineEntry("shared", SkillSourceKind.File, "repo-a/shared", "fp-a", "hash-a", null, null, null, []),
+            new SkillBaselineEntry("shared", SkillSourceKind.File, "repo-b/shared", "fp-b", "hash-b", null, null, null, []),
+        };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["shared"] = "fp-a" });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        Assert.Empty(findings);   // "fp-a" (first-encountered) matches the baseline — no drift reported
+    }
+
+    // ── ExecuteAsync: real, offline, end-to-end save + drift-check ──
+
+    [Fact]
+    public async Task ExecuteAsync_SaveManifestBaseline_ThenManifestChanges_ManifestBaselineDetectsDrift()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        try
+        {
+            // Capture the baseline.
+            var exit1 = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, false, saveManifestBaseline: new FileInfo(_baselineFile), ct: default);
+            Assert.Equal(ExitCodes.Success, exit1);
+            Assert.True(File.Exists(_baselineFile));
+
+            // Change the skill's description (changes its structural fingerprint).
+            var skillDir = Path.Combine(dir.FullName, skillName);
+            File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+                $"---\nname: {skillName}\ndescription: CHANGED description for drift test.\n---\n\nBody.\n");
+
+            var outFile = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-manifest-drift-out-" + Guid.NewGuid().ToString("N") + ".json"));
+            try
+            {
+                var exit2 = await SkillsScanCommand.ExecuteAsync(
+                    dir, "json", outFile, failOnNoncompliant: true, manifestBaseline: new FileInfo(_baselineFile), ct: default);
+
+                // A High-severity finding now exists, so --fail-on-noncompliant fires.
+                Assert.Equal(ExitCodes.TestFailure, exit2);
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains(skillName, content, StringComparison.Ordinal);
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SaveManifestBaseline_ThenNoChange_ManifestBaselineFindsNoDrift()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            var exit1 = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, false, saveManifestBaseline: new FileInfo(_baselineFile), ct: default);
+            Assert.Equal(ExitCodes.Success, exit1);
+
+            var exit2 = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, failOnNoncompliant: true, manifestBaseline: new FileInfo(_baselineFile), ct: default);
+
+            Assert.Equal(ExitCodes.Success, exit2);   // no drift ⇒ still compliant
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SaveManifestBaseline_WithNotes_PersistsNotes()
+    {
+        var dir = CreateCompliantFixture(out _);
+        try
+        {
+            await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, false, saveManifestBaseline: new FileInfo(_baselineFile),
+                baselineNotes: "reviewed and approved for this test", ct: default);
+
+            var baseline = await SkillManifestBaseline.LoadAsync(_baselineFile);
+            Assert.Equal("reviewed and approved for this test", baseline.Notes);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    private static DirectoryInfo CreateCompliantFixture(out string skillName)
+    {
+        skillName = "manifest-baseline-skill-" + Guid.NewGuid().ToString("N")[..8];
+        var root = Path.Combine(Path.GetTempPath(), "agenteval-manifest-baseline-fixture-" + Guid.NewGuid().ToString("N"));
+        var skillDir = Path.Combine(root, skillName);
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"),
+            $"---\nname: {skillName}\ndescription: A compliant fixture skill for manifest-baseline tests.\n---\n\nBody.\n");
+        return new DirectoryInfo(root);
+    }
+}

--- a/tests/AgentEval.Tests/Cli/SkillsManifestBaselineDriftTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsManifestBaselineDriftTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace AgentEval.Tests.Cli;
 
 /// <summary>
-/// Agent Skills Phase 3 (v2 scan-verb CLI surface, the cheap half) — <c>skills scan --save-manifest-baseline</c>
+/// Agent Skills Phase 4b CLI surface (v2 scan-verb CLI surface, the cheap half) — <c>skills scan --save-manifest-baseline</c>
 /// / <c>--manifest-baseline</c>: a SINGLE-PIN, JSON-file-backed hash-pin drift gate
 /// (<see cref="SkillManifestPoisoningGate"/>/<see cref="SkillManifestBaseline"/>), deliberately distinct from
 /// Wave 1/2's multi-snapshot <c>--write-baseline</c>/<c>--baseline-root</c>/<c>--check-baseline</c> ledger.
@@ -38,7 +38,7 @@ public class SkillsManifestBaselineDriftTests : IDisposable
         var scanCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan");
         Assert.Contains(scanCmd.Options, o => o.Name == "--save-manifest-baseline");
         Assert.Contains(scanCmd.Options, o => o.Name == "--manifest-baseline");
-        Assert.Contains(scanCmd.Options, o => o.Name == "--baseline-notes");
+        Assert.Contains(scanCmd.Options, o => o.Name == "--baseline-note");
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class SkillsManifestBaselineDriftTests : IDisposable
         var cmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "scan-workspace");
         Assert.Contains(cmd.Options, o => o.Name == "--save-manifest-baseline");
         Assert.Contains(cmd.Options, o => o.Name == "--manifest-baseline");
-        Assert.Contains(cmd.Options, o => o.Name == "--baseline-notes");
+        Assert.Contains(cmd.Options, o => o.Name == "--baseline-note");
     }
 
     // ── DetectManifestDrift: pure unit tests ──
@@ -119,7 +119,77 @@ public class SkillsManifestBaselineDriftTests : IDisposable
         Assert.Empty(findings);   // "fp-a" (first-encountered) matches the baseline — no drift reported
     }
 
+    [Fact]
+    public void DetectManifestDrift_NameCaseDiffersFromBaseline_StillDetectsAsChanged()
+    {
+        // A rug-pull that ALSO re-cases the skill's name: name+content both changed. Without the
+        // lowercase-normalization fix, ManifestDriftDetector.Detect's own StringComparer.Ordinal key union
+        // would see this as an unrelated New+Removed pair (both filtered out as housekeeping) instead of a
+        // single Changed skill — a real detection bypass this test guards against.
+        var entries = new[] { new SkillBaselineEntry("My-Skill", SkillSourceKind.File, "My-Skill", "fp-2", "content-hash", null, null, null, []) };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["my-skill"] = "fp-1" });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(SkillComplianceRule.ManifestChangedSinceBaseline, finding.Rule);
+    }
+
+    [Fact]
+    public void DetectManifestDrift_NullHashInBaseline_DoesNotThrow_ReportsMalformedInstead()
+    {
+        // A hand-edited/corrupted --manifest-baseline JSON file can deserialize a null hash for a present
+        // key (System.Text.Json's default options don't enforce NRT non-nullability at runtime) — must
+        // degrade to a clear finding, not a NullReferenceException.
+        var entries = new[] { new SkillBaselineEntry("skill-a", SkillSourceKind.File, "skill-a", "fp-1", "content-hash", null, null, null, []) };
+        var baseline = new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string> { ["skill-a"] = null! });
+
+        var findings = SkillsScanCommand.DetectManifestDrift(entries, baseline);
+
+        var finding = Assert.Single(findings);
+        Assert.Equal(SkillComplianceRule.ManifestChangedSinceBaseline, finding.Rule);
+        Assert.Contains("malformed", finding.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     // ── ExecuteAsync: real, offline, end-to-end save + drift-check ──
+
+    [Fact]
+    public async Task ExecuteAsync_ManifestBaselineFileDoesNotExist_DoesNotCrash_ReportsCompliant()
+    {
+        // Graceful "nothing to compare against yet" — same precedent --check-baseline already establishes
+        // for an empty ledger — not a fatal error. Lets --save-manifest-baseline + --manifest-baseline point
+        // at the SAME not-yet-written path in one command on a first-ever run.
+        var dir = CreateCompliantFixture(out _);
+        var missingBaselinePath = Path.Combine(Path.GetTempPath(), "agenteval-missing-baseline-" + Guid.NewGuid().ToString("N") + ".json");
+        try
+        {
+            var exit = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, failOnNoncompliant: true, manifestBaseline: new FileInfo(missingBaselinePath), ct: default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SaveManifestBaseline_ParentDirectoryDoesNotExist_CreatesIt()
+    {
+        var dir = CreateCompliantFixture(out _);
+        var nestedPath = Path.Combine(Path.GetTempPath(), "agenteval-manifest-baseline-nested-" + Guid.NewGuid().ToString("N"), "sub", "pin.json");
+        try
+        {
+            var exit = await SkillsScanCommand.ExecuteAsync(
+                dir, "console", null, false, saveManifestBaseline: new FileInfo(nestedPath), ct: default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+            Assert.True(File.Exists(nestedPath));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+            try { Directory.Delete(Path.GetDirectoryName(Path.GetDirectoryName(nestedPath))!, recursive: true); } catch { /* best-effort */ }
+        }
+    }
 
     [Fact]
     public async Task ExecuteAsync_SaveManifestBaseline_ThenManifestChanges_ManifestBaselineDetectsDrift()


### PR DESCRIPTION
## Summary
- New `--save-manifest-baseline <file>` / `--manifest-baseline <file>` / `--baseline-note <text>` on both `scan` and `scan-workspace` — the cheap half of the "v2 scan-verb CLI surface" ask (`--include-security-index` deferred: it needs external efficiency/security inputs the credential-free scan verb doesn't have, a separate design decision flagged during scoping).
- Wires the existing `SkillManifestPoisoningGate`/`SkillManifestBaseline` library code (a SINGLE JSON-pinned hash-drift gate, mirroring the RedTeam baseline/diff CI pattern) into the CLI for the first time.
- Deliberately named `--save-manifest-baseline`/`--manifest-baseline`, NOT `--save-baseline`/`--baseline`, to avoid colliding with the EXISTING Wave 1/2 `--write-baseline`/`--baseline-root`/`--check-baseline` flags on the same command (a different mechanism — a multi-snapshot historical ledger vs. this single trust-time pin).
- Zero new hashing: reuses `SkillBaselineEntry.StructuralFingerprint` (the exact same `SkillManifestPoisoningGate.Fingerprint(manifest)` value `SkillManifestBaseline.Capture` computes internally) — composes directly with the existing `entries` pipeline for `scan`, `scan --repo`, and `scan-workspace` alike.
- A `Changed` skill is reported as a new `SkillComplianceRule.ManifestChangedSinceBaseline` (High severity, matching `SkillSecurityIndex`'s own `ChangedManifestPenalty` precedent) — gated by the existing `--fail-on-noncompliant`, no new fail flag needed.

## Review
7-angle adversarial review (parallel subagents) found and fixed:
- **CRITICAL** (independently flagged 3x): a null-forgiving operator assumed `Changed` guarantees non-null hashes, but `ManifestDriftDetector.Detect` only checks dictionary key presence — a corrupted `--manifest-baseline` file with a null hash value would throw a `NullReferenceException` mid-scan. Now degrades to a clear "malformed hash" finding.
- **CRITICAL**: a case-sensitivity mismatch with the pre-existing `DetectCrossLocationDrift` (which correctly uses `OrdinalIgnoreCase`, since GA requires lowercase-only names) meant a rug-pull that also re-cased a skill's name evaded detection entirely — reported as an unrelated New+Removed pair instead of Changed. Fixed by lowercasing the dictionary key.
- `--manifest-baseline` on a nonexistent file crashed the whole scan instead of degrading gracefully like `--check-baseline` already does for an empty ledger.
- `--save-manifest-baseline` crashed (live-reproduced `DirectoryNotFoundException`) on a fresh `.agenteval/...`-style path, unlike its sibling `--write-baseline`. Now creates the parent directory first.
- Avoided hashing every entry twice when both flags are passed in one run.
- Renamed `--baseline-notes` → `--baseline-note` to match the established `RedTeamCommand` precedent instead of a third divergent spelling for the same concept.
- Fixed a "Phase 3" mislabeling — the underlying library feature is already documented elsewhere as "Phase 4b."
- Documented (not silently accepted) two real, out-of-scope findings: no dedicated `--fail-on-manifest-drift` flag, and `--format json` serializes `Rule`/`Severity` as raw ints (pre-existing renderer behavior across every rule, not a regression).

## Test plan
- [x] `dotnet build` full solution — 0 errors, 0 new warnings
- [x] 14 tests (pure `DetectManifestDrift` unit tests incl. the case-sensitivity and null-hash fixes, end-to-end `ExecuteAsync` save+check flows, missing-file and nested-directory edge cases)
- [x] Full net8.0 suite green: 7812 passed / 1 skipped (pre-existing) / 0 failed
- [x] Live end-to-end via the real CLI process: save a baseline, re-scan with no change (clean), mutate a skill's description, re-scan again (correctly High-severity + exit 1), plus live verification of both crash fixes (missing baseline file, nested nonexistent save directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)