### PR TITLE
docs: fix Copilot Studio discoverability + stale package README claim

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -274,6 +274,10 @@ await result.ExportHtmlReportAsync("memory-report.html");
     
     Universal `IChatClient.AsEvaluableAgent()` one-liner + Semantic Kernel bridge
 
+-   **🎯 Copilot Studio**
+
+    Red-team or evaluate a live Microsoft Copilot Studio agent — via the CLI (`--sut copilot-studio`) or directly in code (`AgentEval.MAF.CopilotStudio`), no CLI required
+
 -   **📦 Dependency Injection**
     
     `services.AddAgentEval()` - interface-first architecture
@@ -368,7 +372,7 @@ agenteval mc serve                         # browse runs + evidence at http://lo
 |  | [Workflows](workflows.md) | [The .agenteval Workspace](agenteval-workspace.md) |
 |  | [GDPR Benchmark](benchmarks/gdpr/getting-started.md) | [Mission Control](missioncontrol/getting-started.md) |
 |  | [EU AI Act Benchmark](benchmarks/eu-ai-act/getting-started.md) | [Gatekeeper](gatekeeper/introduction.md) |
-|  | [Agentic Benchmark](benchmarks/agentic/getting-started.md) |  |
+|  | [Agentic Benchmark](benchmarks/agentic/getting-started.md) | [Copilot Studio Target](redteam/copilot-studio.md) |
 |  | [OWASP / MITRE Benchmarks](benchmarks/owasp/getting-started.md) |  |
 |  | [Performance / Memory / LongMemEval](benchmarks/perf/getting-started.md) |  |
 |  | [MAF Agent Skills Evaluation](agent-skills.md) |  |

--- a/src/AgentEval.MAF.CopilotStudio/README.md
+++ b/src/AgentEval.MAF.CopilotStudio/README.md
@@ -38,8 +38,9 @@ var config = new CopilotStudioConfig
 // an IEvaluableAgent — the same seam AgentEval's fluent assertions / stochastic runner / benchmarks use
 // for every other agent type. iUnderstandLiveSideEffects is required and has no default: this agent's
 // connectors/flows can fire REAL production actions and cannot be sandboxed — pass true only once you've
-// confirmed `config` points at a NON-PROD agent.
-IEvaluableAgent agent = CopilotStudioAgentFactory.BuildLive(config, iUnderstandLiveSideEffects: true);
+// confirmed `config` points at a NON-PROD agent. maxCredits (default 0 = no cap) enforces an ESTIMATED
+// spend cap — see "Credit-cost enforcement" below.
+IEvaluableAgent agent = CopilotStudioAgentFactory.BuildLive(config, iUnderstandLiveSideEffects: true, maxCredits: 100);
 
 var result = await agent.InvokeAsync("What's the status of order #12345?");
 ```
@@ -53,13 +54,21 @@ var result = await agent.InvokeAsync("What's the status of order #12345?");
 own scripted/fake conversation client to unit-test code that depends on this bridge without a live tenant
 or real credentials.
 
+## Credit-cost enforcement
+
+`maxCredits` **is enforced, as an ESTIMATE — not a metered value.** The Copilot Studio SDK exposes no real
+per-turn cost field, so the connector counts turns instead (1 estimated credit per turn, a fixed constant).
+A turn that would push estimated spend past the cap never fires — it throws
+`CopilotStudioBudgetExceededException` (extends `AgentEval.Core.FatalEvaluationException`) instead. Because
+this is an estimate, don't rely on it as your only spend guard for anything cost-sensitive — cross-check real
+Copilot Credit consumption through Power Platform's own admin tooling.
+
 ## What this does NOT do (yet)
 
 - **Tool-call evidence.** The Copilot Studio conversation channel is structurally text-only — server-side
   tool/connector/knowledge calls are never surfaced to the client. Evidence fidelity tops out at `Verbal`.
 - **Live-tenant verification.** The device-code prompt, silent-refresh, and persisted-cache round trip are
   unit-tested against a fake conversation client but have not been exercised against a real MCS agent.
-- **Credit-cost enforcement.** The underlying SDK exposes no per-turn cost field.
 
 See [`strategy/CopilotStudio/`](https://github.com/AgentEvalHQ/AgentEval) (local-only planning docs, not
 part of this package) in the main repo for the full backlog.


### PR DESCRIPTION
## Summary
Audited whether Copilot Studio's CLI + direct-code usage is documented (per user request). Verdict: `docs/redteam/copilot-studio.md` is already thorough — CLI walkthrough, config authoring, consent gate, `--max-credits` behavior, a dedicated "using it directly in code" section with a real sample, troubleshooting table — and `docs/cli.md` already cross-links it correctly. Two real gaps found and fixed:

- **`docs/index.md` had zero reference to Copilot Studio anywhere** — not in the Documentation table, not in the feature-highlights grid. The root `README.md` links it, but the docs *site* landing page didn't. Added to both.
- **The package README's "What this does NOT do (yet)" section was stale** — still listed credit-cost enforcement as unbuilt, though PR #111 made `--max-credits` genuinely enforced (as a labeled estimate). Replaced with an accurate section + added `maxCredits` to the code sample (verified against `BuildLive`'s actual current signature).

## Test plan
- [x] Docs-only change, no code/test impact
- [x] Verified `maxCredits` parameter name against `CopilotStudioAgentFactory.BuildLive`'s actual signature
- [x] Verified `docs/cli.md`'s eval/bench `--sut copilot-studio` coverage is already complete (no changes needed there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)