### PR TITLE
test(skills): cover scan-workspace's real fault-isolation guarantee

### DIFF
--- a/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsScanWorkspaceCommandTests.cs
@@ -197,6 +197,49 @@ public class SkillsScanWorkspaceCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task ExecuteWorkspaceAsync_LockedFileInOneRepo_OtherRepoResultsStillSurvive()
+    {
+        // The real, user-facing fault-isolation guarantee: a permission-denied/locked file in one repo's
+        // skill folder must not lose every OTHER repo's already-computed results. Empirically confirmed
+        // (Windows-only lock semantics — File.OpenRead of an exclusively-locked file throws IOException
+        // cross-platform via .NET's own FileStream, but POSIX doesn't enforce FileShare.None the same way,
+        // so this is skipped on non-Windows) that a locked SKILL.md makes MAF's own GetSkillsAsync() throw —
+        // caught by MafSkillScanner's OWN broad catch-all (never reaching ScanWorkspaceAsync's outer
+        // IOException/UnauthorizedAccessException handler at all) and turned into a "(discovery failure)"
+        // finding for that repo specifically. The end-to-end multi-repo isolation this test asserts on holds
+        // regardless of WHICH layer catches it — that's the guarantee that actually matters to an operator.
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var workspaceRoot = CreateWorkspaceRoot();
+        try
+        {
+            CreateRepoWithSkill(workspaceRoot, "repo-a", "skill-a", "Present in repo-a.");
+            var lockedFile = CreateRepoWithSkill(workspaceRoot, "repo-b", "skill-b", "Present in repo-b.");
+
+            var outFile = NewTempOutputFile();
+            try
+            {
+                int exit;
+                using (new FileStream(lockedFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                    exit = await SkillsScanCommand.ExecuteWorkspaceAsync(
+                        new DirectoryInfo(workspaceRoot), "json", outFile, failOnNoncompliant: false, ct: default);
+                }
+
+                Assert.Equal(ExitCodes.Success, exit);   // the WORKSPACE call itself never crashes
+                var content = await File.ReadAllTextAsync(outFile.FullName);
+                Assert.Contains("\"SkillCount\": 1", content, StringComparison.Ordinal);   // repo-a's skill still counted
+                Assert.Contains("discovery failure", content, StringComparison.Ordinal);   // repo-b's failure surfaced, not silently dropped
+            }
+            finally { if (outFile.Exists) outFile.Delete(); }
+        }
+        finally { Directory.Delete(workspaceRoot, recursive: true); }
+    }
+
+    [Fact]
     public void DefaultBaselineRoot_DiffersBetweenScanAndScanWorkspace_PreventsScopeMismatchInDiff()
     {
         // scan-workspace's own default baseline root must NOT equal scan's default — sharing one root by
@@ -215,11 +258,14 @@ public class SkillsScanWorkspaceCommandTests : IDisposable
     private static string CreateWorkspaceRoot() =>
         Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "agenteval-skills-workspace-test-" + Guid.NewGuid().ToString("N"))).FullName;
 
-    private static void CreateRepoWithSkill(string workspaceRoot, string repoName, string skillName, string description)
+    /// <summary>Creates a real skill folder + SKILL.md and returns the manifest file's full path.</summary>
+    private static string CreateRepoWithSkill(string workspaceRoot, string repoName, string skillName, string description)
     {
         var skillDir = Path.Combine(workspaceRoot, repoName, ".claude", "skills", skillName);
         Directory.CreateDirectory(skillDir);
-        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), $"---\nname: {skillName}\ndescription: {description}\n---\n\nBody.\n");
+        var skillMdPath = Path.Combine(skillDir, "SKILL.md");
+        File.WriteAllText(skillMdPath, $"---\nname: {skillName}\ndescription: {description}\n---\n\nBody.\n");
+        return skillMdPath;
     }
 
     private static FileInfo NewTempOutputFile() =>


### PR DESCRIPTION
## Summary
- PR #114's review flagged per-repo fault isolation in `scan-workspace` as its most important fix — one bad repo shouldn't lose every other repo's already-computed results — but it shipped with **zero test coverage**.
- Traced the mechanism empirically before writing a test (rather than assuming): a locked/permission-denied `SKILL.md` makes MAF's `AgentFileSkillsSource.GetSkillsAsync()` throw `IOException`, which `MafSkillScanner.ScanFileSkillsWithInfoAsync`'s own broad `catch (Exception ex)` absorbs *first*, converting it to a `"(discovery failure)"` finding for that repo. It never reaches `ScanWorkspaceAsync`'s own `IOException`/`UnauthorizedAccessException` handler in this common scenario — that outer catch is real, but narrower than its doc comment implies (it's defense-in-depth for a failure in the *raw-scanner reconciliation pass* specifically, reachable only when MAF's primary discovery silently excludes a folder that then fails the second pass — not general file-lock protection).
- Added a regression test for the guarantee that actually matters to an operator: **a locked file in one repo's skill folder doesn't crash the workspace scan, and the other repo's results still show up correctly** — regardless of which internal layer catches it.

## Test plan
- [x] New test verified failing-scenario behavior empirically first (temporary diagnostic, deleted before commit) before writing the permanent assertion
- [x] `dotnet test --filter SkillsScanWorkspaceCommandTests` — 10/10 pass
- [x] Full net8.0 regression suite green (7844 passed, 1 pre-existing skip)
- [x] Windows-only guard (`OperatingSystem.IsWindows()`) — `FileShare.None` lock semantics aren't portably testable on POSIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)