### PR TITLE
feat(cli): --log-file verbose troubleshooting trace, full LLM-call coverage

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,6 +71,23 @@ Honoured **only** when launching Mission Control directly (`dotnet run --project
 
 ---
 
+## Troubleshooting: `--log-file <path>`
+
+A global option — available on **every** command, not just the ones shown below. Writes a human-readable, plain-text log of every LLM round-trip (request + response, including tool calls, usage, and finish reason) to `<path>`, separate from the command's normal stdout/stderr. Also captures the full exception (type + message + stack trace) for any request that fails, not just the short one-line summary the CLI prints to stderr by default.
+
+```bash
+agenteval eval --dataset my-data.jsonl --azure --deployment-name gpt-4o-mini --log-file trace.log
+agenteval gatekeeper calibrate --gate judge:crescendo-trajectory-turn-shift --azure --deployment-name gpt-4o-mini --log-file calibrate-debug.log
+```
+
+Covers every LLM call the CLI makes for the invoked command — the agent/SUT under test, judge, attacker (RedTeam Crescendo/PAIR/TAP), and Copilot Studio's live connector all get logged when active.
+
+**⚠️ Contains raw, unredacted content.** The log file includes the full text of every prompt and response — which can carry secrets, PII, or anything else present in your data or the model's output. `--log-file` is opt-in specifically for troubleshooting: turning it on means you want to see exactly what was sent and received. **Never commit or share the resulting file.** The file is overwritten on each invocation, so a fresh run always starts clean.
+
+An unwritable `--log-file` path (missing parent directory, no permissions) never fails the command — it prints one warning to stderr and the invoked command runs exactly as it would without `--log-file` at all. Verbose logging is a debugging aid; it must never be why an otherwise-successful run fails.
+
+---
+
 ## Commands
 
 ### `agenteval init`

--- a/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
+++ b/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using AgentEval.Cli.Infrastructure;
 using AgentEval.Core;
 using Azure;
 using Azure.AI.OpenAI;
@@ -74,7 +75,7 @@ internal static class AzureChatAgentFactory
         try
         {
             var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!), BuildClientOptions());
-            IChatClient chatClient = azureClient.GetChatClient(deployment!).AsIChatClient();
+            IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
             IEvaluableAgent agent = new ChatClientAgentAdapter(
                 chatClient,
                 name: subject,
@@ -120,7 +121,7 @@ internal static class AzureChatAgentFactory
         try
         {
             var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!), BuildClientOptions());
-            IChatClient chatClient = azureClient.GetChatClient(deployment!).AsIChatClient();
+            IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
             return (chatClient, deployment, 0);
         }
         catch (Exception ex)

--- a/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
+++ b/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
@@ -89,5 +89,5 @@ internal static class BenchTier1SutResolver
     /// abstraction (Part C of the design doc).
     /// </summary>
     internal static IEvaluableAgent BuildFromOpenAiEndpoint(string endpoint, string model, string? apiKey, string subject)
-        => EndpointFactory.CreateOpenAICompatible(endpoint, model, apiKey).AsEvaluableAgent(name: subject);
+        => VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint, model, apiKey), "sut").AsEvaluableAgent(name: subject);
 }

--- a/src/AgentEval.Cli/Commands/EvalCommand.cs
+++ b/src/AgentEval.Cli/Commands/EvalCommand.cs
@@ -256,9 +256,9 @@ internal static class EvalCommand
                 systemPrompt = await File.ReadAllTextAsync(opts.SystemPromptFile.FullName, ct);
 
             // 3. Create IChatClient → IStreamableAgent
-            chatClient = opts.Azure
+            chatClient = VerboseLog.Wrap(opts.Azure
                 ? EndpointFactory.CreateAzure(opts.Endpoint, opts.DeploymentName!, opts.ApiKey)
-                : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey);
+                : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey), "agent");
 
             var chatOptions = new ChatOptions();
             if (opts.Temperature != 0f) chatOptions.Temperature = opts.Temperature;
@@ -277,8 +277,8 @@ internal static class EvalCommand
 
         // 5. Create harness (optionally with LLM judge)
         IChatClient? judgeClient = opts.JudgeEndpoint is not null
-            ? EndpointFactory.CreateOpenAICompatible(
-                opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.ApiKey)
+            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+                opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.ApiKey), "judge")
             : null;
         var harness = judgeClient is not null
             ? new MAFEvaluationHarness(judgeClient, verbose: opts.Verbose && !opts.Quiet)

--- a/src/AgentEval.Cli/Commands/Gatekeeper/GatekeeperModelResolver.cs
+++ b/src/AgentEval.Cli/Commands/Gatekeeper/GatekeeperModelResolver.cs
@@ -41,7 +41,7 @@ internal static class GatekeeperModelResolver
                     return new(null, null, ExitCodes.UsageError);
                 }
 
-                var c = EndpointFactory.CreateAzure(azEndpoint, deploymentName!, apiKey);
+                var c = VerboseLog.Wrap(EndpointFactory.CreateAzure(azEndpoint, deploymentName!, apiKey), "judge");
                 return new(c, Fingerprint("azure", azEndpoint, deploymentName!), ExitCodes.Success);
             }
 
@@ -53,7 +53,7 @@ internal static class GatekeeperModelResolver
                     return new(null, null, ExitCodes.UsageError);
                 }
 
-                var c = EndpointFactory.CreateOpenAICompatible(endpoint!, model!, apiKey);
+                var c = VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint!, model!, apiKey), "judge");
                 return new(c, Fingerprint("openai", endpoint, model!), ExitCodes.Success);
             }
 
@@ -66,7 +66,7 @@ internal static class GatekeeperModelResolver
             var envDeployment = Env("AZURE_OPENAI_DEPLOYMENT");
             if (!string.IsNullOrWhiteSpace(envEndpoint) && !string.IsNullOrWhiteSpace(envDeployment))
             {
-                var c = EndpointFactory.CreateAzure(envEndpoint!, envDeployment!, apiKey);   // apiKey ?? env key, resolved inside
+                var c = VerboseLog.Wrap(EndpointFactory.CreateAzure(envEndpoint!, envDeployment!, apiKey), "judge");   // apiKey ?? env key, resolved inside
                 return new(c, Fingerprint("azure", envEndpoint, envDeployment!), ExitCodes.Success);
             }
 

--- a/src/AgentEval.Cli/Commands/JudgeFactory.cs
+++ b/src/AgentEval.Cli/Commands/JudgeFactory.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using AgentEval.Cli.Infrastructure;
 using AgentEval.Core;
 using Azure;
 using Azure.AI.OpenAI;
@@ -83,7 +84,7 @@ internal static class JudgeFactory
             try
             {
                 var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!));
-                IChatClient chatClient = azureClient.GetChatClient(deployment!).AsIChatClient();
+                IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "judge");
                 IEvaluator real = new ChatClientEvaluator(chatClient, systemPrompt);
                 Console.Error.WriteLine(
                     $"✔ Azure OpenAI judge configured — endpoint={endpoint}, deployment={deployment} ({judgeKind})" +

--- a/src/AgentEval.Cli/Commands/RedTeamCommand.cs
+++ b/src/AgentEval.Cli/Commands/RedTeamCommand.cs
@@ -369,9 +369,9 @@ internal static class RedTeamCommand
         }
         else
         {
-            IChatClient chatClient = opts.Azure
+            IChatClient chatClient = VerboseLog.Wrap(opts.Azure
                 ? EndpointFactory.CreateAzure(opts.Endpoint, opts.DeploymentName!, opts.ApiKey)
-                : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey);
+                : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey), "sut");
 
             // System-prompt canary: embed the secret token into the SUT's system prompt so SystemPromptExtraction
             // can prove a leak (the exact token appearing in a response) rather than guessing from phrasing.
@@ -491,8 +491,8 @@ internal static class RedTeamCommand
         // 5. Create ScanOptions
         // Per-role keys fall back to the target --api-key so the common single-gateway case stays a one-flag setup.
         IChatClient? judgeClient = opts.JudgeEndpoint is not null
-            ? EndpointFactory.CreateOpenAICompatible(
-                opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.JudgeApiKey ?? opts.ApiKey)
+            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+                opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.JudgeApiKey ?? opts.ApiKey), "judge")
             : null;
 
         // --explain needs a judge (it's an LLM call). Surface the no-op honestly rather than silently ignoring the flag.
@@ -501,8 +501,8 @@ internal static class RedTeamCommand
 
         // Wave C′: the attacker LLM drives Crescendo/PAIR/TAP. Distinct from the judge (it generates, the judge scores).
         IChatClient? attackerClient = opts.AttackerEndpoint is not null
-            ? EndpointFactory.CreateOpenAICompatible(
-                opts.AttackerEndpoint, opts.AttackerModel ?? resolvedName, opts.AttackerApiKey ?? opts.ApiKey)
+            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+                opts.AttackerEndpoint, opts.AttackerModel ?? resolvedName, opts.AttackerApiKey ?? opts.ApiKey), "attacker")
             : null;
 
         // Fail fast: PAIR/TAP are fundamentally attacker-driven and would error mid-scan without an attacker.

--- a/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
+++ b/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
@@ -7,6 +7,7 @@ using System.CommandLine.Parsing;
 using AgentEval.Cli.Commands;
 using AgentEval.Cli.Commands.RedTeamTargets;
 using AgentEval.Cli.Commands.Targets;
+using AgentEval.Cli.Infrastructure;
 using AgentEval.Core;
 using AgentEval.Guardrails;
 using AgentEval.MAF.CopilotStudio;
@@ -254,7 +255,7 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
         // iUnderstandLiveSideEffects: true is safe here — Validate() (above, in this same class) already
         // enforced --i-understand-live-side-effects before RedTeamCommand ever reaches this Build call.
         var maxCredits = (opts.TargetOptionsFor<CopilotStudioTargetOptions>(Sut) ?? new CopilotStudioTargetOptions()).MaxCredits;
-        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true, maxCredits);
+        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true, maxCredits, c => VerboseLog.Wrap(c, "sut"));
     }
 
     public void WritePostScanSummary(RedTeamResult result, AgentTrace trace, TextWriter err)
@@ -366,7 +367,8 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
         => sutOverride ?? CopilotStudioAgentFactory.BuildLive(
             EnsureSutConfig(common, own),
             iUnderstandLiveSideEffects: true,
-            (own as CopilotStudioSutOptions ?? common.TargetOptionsFor<CopilotStudioSutOptions>(Sut))?.MaxCredits ?? 0);
+            (own as CopilotStudioSutOptions ?? common.TargetOptionsFor<CopilotStudioSutOptions>(Sut))?.MaxCredits ?? 0,
+            c => VerboseLog.Wrap(c, "sut"));
 
     private CopilotStudioConfig EnsureSutConfig(CommonTargetOptions common, ISutTargetOptions? own)
     {

--- a/src/AgentEval.Cli/Infrastructure/VerboseLog.cs
+++ b/src/AgentEval.Cli/Infrastructure/VerboseLog.cs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// The ambient hook every <c>IChatClient</c>-constructing call site in the CLI wraps its result through —
+/// <see cref="Wrap"/> is a no-op when <c>--log-file</c> was not passed, so call sites never need to know
+/// whether verbose logging is active. <see cref="Initialize"/> is called ONCE, in <c>Program.cs</c>, before
+/// the parsed command is invoked (no DI container exists in this CLI to do this more centrally).
+/// </summary>
+internal static class VerboseLog
+{
+    /// <summary>
+    /// The shared writer for this process, or <see langword="null"/> when <c>--log-file</c> was not passed.
+    /// Always <see cref="TextWriter.Synchronized(TextWriter)"/>-wrapped by <see cref="Initialize"/> — multiple
+    /// <see cref="VerboseLoggingChatClient"/> instances (a RedTeam scan's SUT/judge/attacker clients, all
+    /// distinct instances) can be writing through this SAME reference concurrently, and the BCL's own
+    /// synchronized wrapper is the correct, well-tested way to make that safe, rather than a hand-rolled
+    /// <c>lock</c> on this publicly-readable object (which a caller could also accidentally lock on).
+    /// </summary>
+    public static TextWriter? Writer { get; private set; }
+
+    /// <summary>
+    /// Opens <paramref name="logFilePath"/> for writing (overwriting any prior content — each CLI invocation
+    /// gets its own fresh log) and sets <see cref="Writer"/>. Returns the opened writer (or <see langword="null"/>
+    /// if no path was given, OR if the path couldn't be opened) so the caller can dispose/flush it once the
+    /// command finishes. Disposes any PREVIOUS <see cref="Writer"/> first — this method is meant to run once
+    /// per process, but nothing enforces that (tests call it repeatedly), and silently orphaning an open file
+    /// handle on a second call would leak it until GC finalizes the underlying <see cref="StreamWriter"/>.
+    /// </summary>
+    /// <remarks>
+    /// <b>A bad path degrades to "no verbose logging," it never fails the command.</b> <c>--log-file</c> is a
+    /// RECURSIVE option evaluated eagerly in <c>Program.cs</c> before any command dispatch — an unhandled
+    /// exception here would crash EVERY command, including ones with nothing to do with an LLM (e.g.
+    /// <c>agenteval doctor --log-file &lt;bad-path&gt;</c>), over what is purely an optional debugging aid. A
+    /// bad path (missing parent directory, no write permission, an invalid path shape) instead prints one clear
+    /// warning to stderr and proceeds with <see cref="Writer"/> left <see langword="null"/> — the invoked
+    /// command runs exactly as it would have without <c>--log-file</c> at all.
+    /// </remarks>
+    public static TextWriter? Initialize(string? logFilePath)
+    {
+        Writer?.Dispose();
+        Writer = null;
+
+        if (string.IsNullOrWhiteSpace(logFilePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            // AutoFlush: a CLI invocation that crashes or is killed mid-run should still leave a readable
+            // partial log — the whole point of this feature is troubleshooting a failure, including the
+            // failures that don't reach an orderly exit.
+            var raw = new StreamWriter(logFilePath, append: false) { AutoFlush = true };
+            var synchronized = TextWriter.Synchronized(raw);
+            Writer = synchronized;
+            return synchronized;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            Console.Error.WriteLine($"  Warning: could not open --log-file '{logFilePath}': {ex.Message}. Continuing without verbose logging.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="client"/> in a <see cref="VerboseLoggingChatClient"/> if verbose logging is
+    /// active; returns it unchanged otherwise.
+    /// </summary>
+    /// <param name="client">The chat client to wrap.</param>
+    /// <param name="label">
+    /// A short role label (e.g. <c>"sut"</c>/<c>"judge"</c>/<c>"attacker"</c>) printed in every log entry from
+    /// this client. Optional, but strongly recommended whenever a caller might construct MORE than one wrapped
+    /// client sharing this same log file (e.g. RedTeam's SUT + judge + attacker) — without it, entries from
+    /// different clients are indistinguishable beyond their (per-instance, independently-numbered) round-trip
+    /// index and timestamp.
+    /// </param>
+    public static IChatClient Wrap(IChatClient client, string? label = null) =>
+        Writer is null ? client : new VerboseLoggingChatClient(client, Writer, label);
+}

--- a/src/AgentEval.Cli/Infrastructure/VerboseLoggingChatClient.cs
+++ b/src/AgentEval.Cli/Infrastructure/VerboseLoggingChatClient.cs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// CLI-only troubleshooting decorator behind <c>--log-file &lt;path&gt;</c> — writes every LLM round-trip as
+/// human-readable plain text to a log file, separate from stdout/stderr. Unrelated to Glass Box's
+/// <c>AgentTrace</c>/<c>TraceRecordingChatClient</c>: this is a raw request/response dump for debugging a CLI
+/// invocation, not a structured evaluation artifact. See <see cref="VerboseLog"/> for how a command wires this in.
+/// </summary>
+/// <remarks>
+/// <b>Logs content RAW, with no redaction.</b> <c>--log-file</c> is opt-in and local-only by design — turning
+/// it on means the operator wants to see exactly what was sent/received while troubleshooting. The file can
+/// contain secrets or PII carried in prompts/responses; the CLI's own <c>--help</c> text and documentation
+/// disclose this so it is never shared or committed by mistake.
+/// <para><b>Thread safety.</b> This class does no locking of its own — it relies on <paramref name="log"/>
+/// (the <c>TextWriter</c> passed to the constructor) already being safe for concurrent writes when more than
+/// one <see cref="VerboseLoggingChatClient"/> instance might share it. <see cref="VerboseLog.Wrap"/> always
+/// supplies a <see cref="TextWriter.Synchronized(TextWriter)"/>-wrapped writer for exactly this reason — a
+/// caller constructing this class directly (e.g. in a test) with a plain, unsynchronized writer is responsible
+/// for either using it single-threaded or synchronizing it themselves.</para>
+/// </remarks>
+public sealed class VerboseLoggingChatClient : DelegatingChatClient
+{
+    private readonly TextWriter _log;
+    private readonly string? _label;
+    private int _index;
+    private bool _writeFailureReported;
+
+    /// <summary>Wraps <paramref name="inner"/>, writing every round-trip to <paramref name="log"/>.</summary>
+    /// <param name="inner">The chat client to observe.</param>
+    /// <param name="log">Where to write. See this class's remarks for the thread-safety contract.</param>
+    /// <param name="label">An optional short role label printed in every entry from this client (e.g. "judge").</param>
+    public VerboseLoggingChatClient(IChatClient inner, TextWriter log, string? label = null)
+        : base(inner)
+    {
+        _log = log ?? throw new ArgumentNullException(nameof(log));
+        _label = string.IsNullOrWhiteSpace(label) ? null : label;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var msgs = messages as IList<ChatMessage> ?? messages.ToList();
+        var i = Interlocked.Increment(ref _index) - 1;
+        WriteRequest(i, msgs, options);
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var resp = await base.GetResponseAsync(msgs, options, cancellationToken).ConfigureAwait(false);
+            sw.Stop();
+            WriteResponse(i, resp, sw.ElapsedMilliseconds);
+            return resp;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;   // the CALLER's own token fired — a deliberate cancellation, not diagnostically interesting
+        }
+        catch (Exception ex)
+        {
+            // Everything else, INCLUDING an OperationCanceledException/TaskCanceledException whose token is NOT
+            // the caller's own (e.g. an HttpClient/Azure SDK request-timeout) — arguably the single most common
+            // real reason someone reaches for --log-file, so it must never be filtered out here the way an
+            // `ex is not OperationCanceledException` guard would (TaskCanceledException IS an
+            // OperationCanceledException; a blanket type-based exclusion silently swallows real timeouts).
+            sw.Stop();
+            WriteError(i, ex, sw.ElapsedMilliseconds);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var msgs = messages as IList<ChatMessage> ?? messages.ToList();
+        var i = Interlocked.Increment(ref _index) - 1;
+        WriteRequest(i, msgs, options);
+
+        var sw = Stopwatch.StartNew();
+        var updates = new List<ChatResponseUpdate>();
+        var terminalEntryWritten = false;
+        await using var enumerator = base.GetStreamingResponseAsync(msgs, options, cancellationToken)
+            .GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (true)
+            {
+                ChatResponseUpdate current;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    current = enumerator.Current;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;   // the caller's own token fired — see GetResponseAsync's matching remark
+                }
+                catch (Exception ex)
+                {
+                    sw.Stop();
+                    WriteError(i, ex, sw.ElapsedMilliseconds);
+                    terminalEntryWritten = true;
+                    throw;
+                }
+
+                updates.Add(current);
+                yield return current;
+            }
+
+            sw.Stop();
+            var resp = updates.Count == 0 ? new ChatResponse() : updates.ToChatResponse();
+            WriteResponse(i, resp, sw.ElapsedMilliseconds);
+            terminalEntryWritten = true;
+        }
+        finally
+        {
+            // The consumer stopped enumerating early (a `break`/disposed enumerator, or a genuine cancellation)
+            // before either the natural-completion or the catch-block write above ran — the log would otherwise
+            // show a REQUEST with no matching RESPONSE/ERROR, silently breaking the pairing the format promises.
+            if (!terminalEntryWritten)
+            {
+                WriteAbandoned(i, sw.ElapsedMilliseconds);
+            }
+        }
+    }
+
+    private void WriteRequest(int index, IList<ChatMessage> messages, ChatOptions? options)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, index, "REQUEST", DateTimeOffset.UtcNow, elapsedMs: null);
+        if (!string.IsNullOrEmpty(options?.Instructions))
+        {
+            sb.Append("Instructions: ").AppendLine(options.Instructions);
+        }
+
+        if (options is not null)
+        {
+            sb.Append("Options: temperature=").Append(FormatOrDefault(options.Temperature))
+              .Append(", maxOutputTokens=").Append(FormatOrDefault(options.MaxOutputTokens))
+              .Append(", modelId=").AppendLine(options.ModelId ?? "(default)");
+        }
+
+        if (options?.Tools is { Count: > 0 })
+        {
+            sb.Append("Tools: ").AppendLine(string.Join(", ", options.Tools.Select(t => t.Name)));
+        }
+
+        // Full message history on every call would grow O(turn-count²) in any multi-turn scenario (the
+        // standard IChatClient contract resends growing history each round) — a 50-turn conversation would
+        // log ~1,275 mostly-duplicate lines instead of ~50, bloating the file and burying the turn that
+        // actually matters. Log the shape (counts by role) plus only the NEWEST message in full.
+        var byRole = messages.GroupBy(m => m.Role).Select(g => $"{g.Count()} {g.Key}");
+        sb.Append("Messages: ").Append(messages.Count).Append(" total (").Append(string.Join(", ", byRole)).AppendLine(")");
+        var last = messages.Count > 0 ? messages[^1] : null;
+        if (last is not null)
+        {
+            sb.Append("Newest [").Append(last.Role).Append("]: ").AppendLine(last.Text ?? "(no text content)");
+        }
+
+        Write(sb.ToString());
+    }
+
+    private void WriteResponse(int index, ChatResponse response, long elapsedMs)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, index, "RESPONSE", DateTimeOffset.UtcNow, elapsedMs);
+        sb.Append("Text: ").AppendLine(response.Text ?? "(empty)");
+
+        var toolCalls = (response.Messages ?? []).SelectMany(m => m.Contents).OfType<FunctionCallContent>().ToList();
+        if (toolCalls.Count > 0)
+        {
+            sb.Append("ToolCalls: ").AppendLine(string.Join(", ", toolCalls.Select(c => $"{c.Name}({FormatArgs(c.Arguments)})")));
+        }
+
+        sb.Append("FinishReason: ").AppendLine(response.FinishReason?.Value ?? "(none)");
+        if (response.Usage is not null)
+        {
+            sb.Append("Usage: prompt=").Append(response.Usage.InputTokenCount)
+              .Append(", completion=").AppendLine(response.Usage.OutputTokenCount?.ToString(CultureInfo.InvariantCulture) ?? "?");
+        }
+
+        Write(sb.ToString());
+    }
+
+    private void WriteError(int index, Exception ex, long elapsedMs)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, index, "ERROR", DateTimeOffset.UtcNow, elapsedMs);
+        sb.AppendLine(ex.ToString());   // full exception incl. stack trace, deliberately not just ex.Message
+        Write(sb.ToString());
+    }
+
+    private void WriteAbandoned(int index, long elapsedMs)
+    {
+        var sb = new StringBuilder();
+        AppendHeader(sb, index, "ABANDONED", DateTimeOffset.UtcNow, elapsedMs);
+        sb.AppendLine("Streaming enumeration stopped before completion (consumer broke out early, or the call " +
+                       "was cancelled) — no full response was captured for this round-trip.");
+        Write(sb.ToString());
+    }
+
+    private void AppendHeader(StringBuilder sb, int index, string kind, DateTimeOffset timestamp, long? elapsedMs)
+    {
+        sb.Append("=== [").Append(index).Append(']');
+        if (_label is not null)
+        {
+            sb.Append(' ').Append(_label);
+        }
+
+        sb.Append(' ').Append(kind).Append(' ').Append(timestamp.ToString("O", CultureInfo.InvariantCulture));
+        if (elapsedMs is not null)
+        {
+            sb.Append(" (").Append(elapsedMs.Value.ToString(CultureInfo.InvariantCulture)).Append("ms)");
+        }
+
+        sb.AppendLine(" ===");
+    }
+
+    private void Write(string block)
+    {
+        // A purely diagnostic, opt-in side channel must never break an otherwise-successful command — e.g. a
+        // full LLM response already returned successfully must not be discarded because the disk backing
+        // --log-file happened to fill up on the write that logs it. Report the failure ONCE (not on every
+        // subsequent call, which would spam stderr identically forever) and otherwise degrade silently.
+        try
+        {
+            _log.WriteLine(block);   // one call, not Write()+WriteLine() — halves flush-syscall count under AutoFlush
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or NotSupportedException or UnauthorizedAccessException)
+        {
+            if (!_writeFailureReported)
+            {
+                _writeFailureReported = true;
+                Console.Error.WriteLine($"  Warning: --log-file write failed ({ex.GetType().Name}: {ex.Message}) — further verbose-log entries from this client may be incomplete.");
+            }
+        }
+    }
+
+    private static string FormatOrDefault<T>(T? value) where T : struct, IFormattable =>
+        value?.ToString(null, CultureInfo.InvariantCulture) ?? "(default)";
+
+    private static string FormatArgs(IDictionary<string, object?>? args) =>
+        args is null || args.Count == 0 ? "{}" : string.Join(", ", args.Select(kv => $"{kv.Key}={kv.Value}"));
+}

--- a/src/AgentEval.Cli/Program.cs
+++ b/src/AgentEval.Cli/Program.cs
@@ -5,6 +5,7 @@
 using System.CommandLine;
 using AgentEval.Cli.Commands;
 using AgentEval.Cli.Commands.Targets;
+using AgentEval.Cli.Infrastructure;
 
 // ─── init (dataset scaffolder) ───────────────────────────────────────────────
 // v1.1 consolidation: the canonical `init` is the dataset-scaffolding command
@@ -693,6 +694,20 @@ mcCmd.Add(mcDoctorCmd);
 // ─── root ─────────────────────────────────────────────────────────────────────
 var rootCmd = new RootCommand("AgentEval CLI — evaluate AI agents, run benchmark suites, manage the .agenteval/ output store, and serve Mission Control.");
 
+// --log-file: a RECURSIVE (System.CommandLine 2.0's term for "global") option — visible to every subcommand's
+// own ParseResult without each command needing to redeclare it. Every IChatClient-constructing call site in
+// the CLI reads the ambient VerboseLog.Writer this sets (via VerboseLog.Wrap), not this option directly — see
+// VerboseLog's own remarks for why an ambient static, not threading the option through every command, is the
+// pragmatic choice here (no DI container exists to do this more centrally).
+var logFileOpt = new Option<string?>("--log-file")
+{
+    Description = "Write a human-readable, UNREDACTED log of every LLM request/response (and any judge/attacker/SUT " +
+                   "client) to this file, for troubleshooting. The file can contain secrets/PII carried in prompts " +
+                   "or responses — never share or commit it. Overwritten on each invocation.",
+    Recursive = true,
+};
+rootCmd.Options.Add(logFileOpt);
+
 // Legacy command surface ported from AgentEvalHQ/AgentEval.Cli v0.2.0-alpha
 // (documentation and CI pipelines depend on these exact names and flags):
 rootCmd.Add(datasetInitCmd);                  // init — scaffold an evaluation dataset
@@ -716,4 +731,6 @@ rootCmd.Add(AgentEval.Cli.Commands.Gatekeeper.GatekeeperCommand.Create());
 // (previously library-only; see Skills-Scan-CLI-Verb-Design.md). Credential-free, offline, static scan.
 rootCmd.Add(SkillsScanCommand.Create());
 
-return await rootCmd.Parse(args).InvokeAsync();
+var parseResult = rootCmd.Parse(args);
+using var logWriter = VerboseLog.Initialize(parseResult.GetValue(logFileOpt));
+return await parseResult.InvokeAsync();

--- a/src/AgentEval.MAF.CopilotStudio/CopilotStudioAgentFactory.cs
+++ b/src/AgentEval.MAF.CopilotStudio/CopilotStudioAgentFactory.cs
@@ -66,6 +66,13 @@ public static class CopilotStudioAgentFactory
     /// <see cref="CopilotStudioChatClient(ICopilotStudioConversationClient, int)"/>'s own remarks for what
     /// "estimated" means here and why.
     /// </param>
+    /// <param name="wrapChatClient">
+    /// Optional transform applied to the underlying <see cref="IChatClient"/> before it's wrapped in the
+    /// returned agent — e.g. a caller-side logging or retry decorator. Deliberately a generic
+    /// <see cref="Func{IChatClient,IChatClient}"/>, not a concrete decorator type: this package takes no
+    /// dependency on any particular consumer, so any caller-owned <c>IChatClient</c> middleware can be composed
+    /// in from the outside via this hook without this package needing to know it exists.
+    /// </param>
     /// <exception cref="InvalidOperationException"><paramref name="iUnderstandLiveSideEffects"/> is <see langword="false"/>.</exception>
     /// <remarks>
     /// Everything else this method does is local/offline — constructing <see cref="ConnectionSettings"/>, resolving
@@ -73,7 +80,8 @@ public static class CopilotStudioAgentFactory
     /// <see cref="CopilotStudioTokenProvider"/> callback it wires up is only invoked lazily, by
     /// <see cref="CopilotClient"/> itself, on the first real request the returned agent makes.
     /// </remarks>
-    public static IEvaluableAgent BuildLive(CopilotStudioConfig config, bool iUnderstandLiveSideEffects, int maxCredits = 0)
+    public static IEvaluableAgent BuildLive(
+        CopilotStudioConfig config, bool iUnderstandLiveSideEffects, int maxCredits = 0, Func<IChatClient, IChatClient>? wrapChatClient = null)
     {
         ArgumentNullException.ThrowIfNull(config);
         if (!iUnderstandLiveSideEffects)
@@ -106,6 +114,11 @@ public static class CopilotStudioAgentFactory
             HttpClientName);
 
         IChatClient chatClient = new CopilotStudioChatClient(new CopilotClientConversationAdapter(copilotClient), maxCredits);
+        if (wrapChatClient is not null)
+        {
+            chatClient = wrapChatClient(chatClient);
+        }
+
         AIAgent innerAgent = new ChatClientAgent(chatClient, new ChatClientAgentOptions { Name = config.DisplayName });
         return FromAgent(innerAgent);
     }

--- a/tests/AgentEval.Tests/Cli/AzureChatAgentFactoryTests.cs
+++ b/tests/AgentEval.Tests/Cli/AzureChatAgentFactoryTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using AgentEval.Cli.Commands;
+using AgentEval.Cli.Infrastructure;
 using Xunit;
 
 namespace AgentEval.Tests.Cli;
@@ -103,6 +104,37 @@ public class AzureChatAgentFactoryTests
         finally
         {
             Console.SetError(prev);
+        }
+    }
+
+    [Fact]
+    public void TryBuildChatClientFromEnv_LogFileActive_ReturnedClientIsVerboseLogWrapped()
+    {
+        // AzureOpenAIClient construction (and .GetChatClient(...).AsIChatClient()) makes no network call — same
+        // premise CopilotStudioAgentFactory's own credential-free construction tests rely on — so this proves
+        // the --log-file wiring at this specific call site without needing real Azure credentials or a live call.
+        using var _ = TempEnvVars(
+            ("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/"),
+            ("AZURE_OPENAI_API_KEY", "fake-key"),
+            ("AZURE_OPENAI_DEPLOYMENT", "fake-deployment"));
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-azurechatagentfactory-logtest-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using var logWriter = VerboseLog.Initialize(path);
+
+            var (chatClient, deployment, exitCode) = AzureChatAgentFactory.TryBuildChatClientFromEnv();
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("fake-deployment", deployment);
+            Assert.IsType<VerboseLoggingChatClient>(chatClient);
+        }
+        finally
+        {
+            VerboseLog.Initialize(null);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
         }
     }
 

--- a/tests/AgentEval.Tests/Cli/CopilotStudio/CopilotStudioScaffoldTests.cs
+++ b/tests/AgentEval.Tests/Cli/CopilotStudio/CopilotStudioScaffoldTests.cs
@@ -8,6 +8,7 @@ using AgentEval.MAF.CopilotStudio;
 using AgentEval.Testing;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.CopilotStudio.Client.Discovery;
+using Microsoft.Extensions.AI;
 using Xunit;
 
 namespace AgentEval.Tests.Cli.CopilotStudio;
@@ -196,6 +197,35 @@ public class CopilotStudioScaffoldTests
         var agent = CopilotStudioAgentFactory.BuildLive(ValidConfig(), iUnderstandLiveSideEffects: true);
         Assert.NotNull(agent);
         Assert.IsAssignableFrom<IEvaluableAgent>(agent);
+    }
+
+    [Fact]
+    public void Factory_BuildLive_WrapChatClient_TransformIsAppliedToTheRealUnderlyingClient()
+    {
+        // The --log-file seam (VerboseLog.Wrap in AgentEval.Cli) composes in from OUTSIDE this package via this
+        // generic hook — AgentEval.MAF.CopilotStudio must never depend on AgentEval.Cli. Proven here without
+        // referencing VerboseLoggingChatClient at all: a plain capturing delegate confirms BuildLive actually
+        // invokes the transform, with the REAL CopilotStudioChatClient instance it just constructed (not some
+        // placeholder), before wrapping it in the returned agent.
+        IChatClient? seen = null;
+        var wrapped = new ScriptedChatClient();
+        var agent = CopilotStudioAgentFactory.BuildLive(ValidConfig(), iUnderstandLiveSideEffects: true, wrapChatClient: c =>
+        {
+            seen = c;
+            return wrapped;   // swap in a sentinel so we can also prove the SWAPPED instance is what gets used
+        });
+
+        Assert.NotNull(agent);
+        Assert.IsType<CopilotStudioChatClient>(seen);
+    }
+
+    [Fact]
+    public void Factory_BuildLive_NoWrapChatClient_DefaultsToNoTransform()
+    {
+        // The optional parameter must be truly optional — every pre-existing call site (and every test above
+        // this one) omits it and must keep working unchanged.
+        var agent = CopilotStudioAgentFactory.BuildLive(ValidConfig(), iUnderstandLiveSideEffects: true);
+        Assert.NotNull(agent);
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/Cli/Gatekeeper/GatekeeperJudgeBridgeTests.cs
+++ b/tests/AgentEval.Tests/Cli/Gatekeeper/GatekeeperJudgeBridgeTests.cs
@@ -5,6 +5,7 @@
 using System.Text.Json;
 using AgentEval.Cli;
 using AgentEval.Cli.Commands.Gatekeeper;
+using AgentEval.Cli.Infrastructure;
 using AgentEval.Guardrails.Judges;
 using Microsoft.Extensions.AI;
 using Xunit;
@@ -17,6 +18,13 @@ namespace AgentEval.Tests.Cli.Gatekeeper;
 /// un-certified judge (exit 7) unless <c>--allow-uncalibrated</c>. The certificate-governed <c>inlineReady</c> is the
 /// moat carried across the wire — a judge is never "inline-ready" by omission.
 /// </summary>
+/// <remarks>
+/// Joined to the "ConsoleTests" collection (matches <c>AzureChatAgentFactoryTests</c>' own reasoning) because
+/// <see cref="GatekeeperModelResolver_LogFileActive_ResolvedClientIsVerboseLogWrapped"/> mutates the shared,
+/// process-global <see cref="VerboseLog.Writer"/> — it must not run concurrently with any other test class that
+/// also touches it.
+/// </remarks>
+[Collection("ConsoleTests")]
 public class GatekeeperJudgeBridgeTests
 {
     private static string TempDir() => Path.Combine(Path.GetTempPath(), "gk-cli-" + Guid.NewGuid().ToString("N"));
@@ -111,6 +119,33 @@ public class GatekeeperJudgeBridgeTests
         var r = GatekeeperModelResolver.Resolve(azure: false, endpoint: "not a url", deploymentName: null, model: "m", apiKey: "k", err);
         Assert.Null(r.Client);
         Assert.Equal(ExitCodes.UsageError, r.ExitCode);
+    }
+
+    [Fact]
+    public void Resolve_LogFileActive_ResolvedClientIsVerboseLogWrapped()
+    {
+        // EndpointFactory.CreateOpenAICompatible constructs an OpenAIClient (no network call at construction —
+        // same premise every other credential-free construction test in this repo relies on), so this proves
+        // GatekeeperModelResolver's --log-file wiring without needing a real endpoint or credentials.
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-gkmodelresolver-logtest-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using var logWriter = VerboseLog.Initialize(path);
+            using var err = new StringWriter();
+
+            var r = GatekeeperModelResolver.Resolve(azure: false, endpoint: "https://example.com/v1", deploymentName: null, model: "m", apiKey: "k", err);
+
+            Assert.NotNull(r.Client);
+            Assert.IsType<VerboseLoggingChatClient>(r.Client);
+        }
+        finally
+        {
+            VerboseLog.Initialize(null);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
     }
 
     // ── calibrate (fake model → report + certificate) ──

--- a/tests/AgentEval.Tests/Cli/Infrastructure/VerboseLogTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/VerboseLogTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// The ambient <c>--log-file</c> hook every IChatClient-constructing call site wraps its result through.
+/// Tests reset <see cref="VerboseLog.Writer"/> to null on both entry and exit so ordering against other tests
+/// in the same process (xUnit does not guarantee isolation between static state by default) can never leak.
+/// </summary>
+/// <remarks>
+/// Joined to the "ConsoleTests" collection (the reset-on-entry/exit pattern above only protects against
+/// SEQUENTIAL leakage within a single-threaded run; xUnit parallelizes across test CLASSES by default, so
+/// without this, a concurrently-running class that indirectly reads/writes <see cref="VerboseLog.Writer"/> —
+/// e.g. <c>AzureChatAgentFactoryTests</c>, already in this same collection — could race these tests).
+/// </remarks>
+[Collection("ConsoleTests")]
+public class VerboseLogTests : IDisposable
+{
+    public VerboseLogTests() => VerboseLog.Initialize(null);
+
+    public void Dispose() => VerboseLog.Initialize(null);
+
+    [Fact]
+    public void Initialize_NullPath_WriterStaysNull_AndReturnsNull()
+    {
+        var writer = VerboseLog.Initialize(null);
+
+        Assert.Null(writer);
+        Assert.Null(VerboseLog.Writer);
+    }
+
+    [Fact]
+    public void Initialize_EmptyOrWhitespacePath_TreatedAsNotSet()
+    {
+        var writer = VerboseLog.Initialize("   ");
+
+        Assert.Null(writer);
+        Assert.Null(VerboseLog.Writer);
+    }
+
+    [Fact]
+    public void Initialize_RealPath_OpensFileAndSetsWriter()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-verboselog-test-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            var writer = VerboseLog.Initialize(path);
+            Assert.NotNull(writer);
+            Assert.Same(writer, VerboseLog.Writer);
+            writer!.Write("hello");
+            writer.Dispose();   // close before reading back — matches how a user reads the log after the CLI exits
+
+            Assert.Equal("hello", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Initialize_ReRunOverwritesPriorContent()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-verboselog-test-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            var first = VerboseLog.Initialize(path);
+            first!.Write("first run content that should be gone");
+            first.Dispose();
+
+            var second = VerboseLog.Initialize(path);
+            second!.Write("second run");
+            second.Dispose();
+
+            Assert.DoesNotContain("first run", File.ReadAllText(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Wrap_NoWriterSet_ReturnsSameInstance_NoOp()
+    {
+        VerboseLog.Initialize(null);
+        var inner = new ScriptedChatClient();
+
+        var wrapped = VerboseLog.Wrap(inner);
+
+        Assert.Same(inner, wrapped);
+    }
+
+    [Fact]
+    public void Wrap_WriterSet_ReturnsVerboseLoggingChatClient()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-verboselog-test-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using var writer = VerboseLog.Initialize(path);
+            var inner = new ScriptedChatClient();
+
+            var wrapped = VerboseLog.Wrap(inner);
+
+            Assert.IsType<VerboseLoggingChatClient>(wrapped);
+            Assert.NotSame(inner, wrapped);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/AgentEval.Tests/Cli/Infrastructure/VerboseLoggingChatClientTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/VerboseLoggingChatClientTests.cs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// The <c>--log-file</c> troubleshooting decorator: writes every LLM round-trip as human-readable plain text.
+/// Unrelated to Glass Box's <c>TraceRecordingChatClient</c> — no structured trace, just a raw dump for
+/// debugging, verified here at the level a human reading the log file would care about (does the request
+/// text/options show up, does the response text/usage show up, does a failure show the FULL exception).
+/// </summary>
+public class VerboseLoggingChatClientTests
+{
+    private static IList<ChatMessage> Conversation() => new List<ChatMessage>
+    {
+        new(ChatRole.System, "You are a helpful travel agent."),
+        new(ChatRole.User, "Plan a trip to Tokyo."),
+    };
+
+    [Fact]
+    public async Task GetResponseAsync_WritesRequestAndResponseBlocks_WithExpectedContent()
+    {
+        var scripted = new ScriptedChatClient().AddText("Sure, here is a plan.", inTok: 42, outTok: 7);
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        await client.GetResponseAsync(Conversation(), new ChatOptions { Temperature = 0.2f, ModelId = "gpt-4o-mini" });
+
+        var text = log.ToString();
+        Assert.Contains("REQUEST", text, StringComparison.Ordinal);
+        Assert.Contains("Plan a trip to Tokyo.", text, StringComparison.Ordinal);
+        Assert.Contains("modelId=gpt-4o-mini", text, StringComparison.Ordinal);
+        Assert.Contains("RESPONSE", text, StringComparison.Ordinal);
+        Assert.Contains("Sure, here is a plan.", text, StringComparison.Ordinal);
+        Assert.Contains("FinishReason: stop", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ToolCall_LogsToolNameAndArguments()
+    {
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "SearchFlights", new Dictionary<string, object?> { ["to"] = "NRT" });
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        await client.GetResponseAsync(Conversation());
+
+        var text = log.ToString();
+        Assert.Contains("ToolCalls: SearchFlights", text, StringComparison.Ordinal);
+        Assert.Contains("to=NRT", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ModelThrows_LogsFullExceptionAndRethrows()
+    {
+        var scripted = new ScriptedChatClient().AddThrow("simulated provider outage");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync(Conversation()));
+
+        var text = log.ToString();
+        Assert.Contains("ERROR", text, StringComparison.Ordinal);
+        Assert.Contains("simulated provider outage", text, StringComparison.Ordinal);
+        Assert.Contains("InvalidOperationException", text, StringComparison.Ordinal);   // ex.ToString(), not just ex.Message
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_LogsRequestAndAccumulatedResponse()
+    {
+        var scripted = new ScriptedChatClient().AddText("Streamed answer.");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        var chunks = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(Conversation()))
+        {
+            chunks.Add(update);
+        }
+
+        Assert.NotEmpty(chunks);
+        var text = log.ToString();
+        Assert.Contains("REQUEST", text, StringComparison.Ordinal);
+        Assert.Contains("RESPONSE", text, StringComparison.Ordinal);
+        Assert.Contains("Streamed answer.", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TwoRoundTrips_UseDistinctIndices()
+    {
+        var scripted = new ScriptedChatClient().AddText("First.").AddText("Second.");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        await client.GetResponseAsync(Conversation());
+        await client.GetResponseAsync(Conversation());
+
+        var text = log.ToString();
+        Assert.Contains("[0] REQUEST", text, StringComparison.Ordinal);
+        Assert.Contains("[1] REQUEST", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Label_AppearsInEveryHeaderLine()
+    {
+        var scripted = new ScriptedChatClient().AddText("Answer.");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log, "judge");
+
+        await client.GetResponseAsync(Conversation());
+
+        var text = log.ToString();
+        Assert.Contains("[0] judge REQUEST", text, StringComparison.Ordinal);
+        Assert.Contains("[0] judge RESPONSE", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ModelThrowsMidStream_LogsFullExceptionAndRethrows()
+    {
+        var scripted = new ScriptedChatClient().AddThrow("simulated stream outage");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        async Task ConsumeAsync()
+        {
+            await foreach (var _ in client.GetStreamingResponseAsync(Conversation())) { }
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(ConsumeAsync);
+
+        var text = log.ToString();
+        Assert.Contains("ERROR", text, StringComparison.Ordinal);
+        Assert.Contains("simulated stream outage", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("ABANDONED", text, StringComparison.Ordinal);   // the ERROR entry is already terminal
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ConsumerBreaksEarly_LogsAbandonedEntry_NotASilentGap()
+    {
+        var scripted = new ScriptedChatClient().AddText("a streamed answer");
+        var log = new StringWriter();
+        var client = new VerboseLoggingChatClient(scripted, log);
+
+        await foreach (var _ in client.GetStreamingResponseAsync(Conversation()))
+        {
+            break;   // abandon before natural completion
+        }
+
+        var text = log.ToString();
+        Assert.Contains("REQUEST", text, StringComparison.Ordinal);
+        Assert.Contains("ABANDONED", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("RESPONSE", text, StringComparison.Ordinal);   // no full response was ever captured
+    }
+
+    [Fact]
+    public async Task TwoClientsSharingOneSynchronizedWriter_ConcurrentWrites_DoNotInterleaveOrCorrupt()
+    {
+        // The real-world shape this guards: a RedTeam scan's SUT/judge/attacker clients are separate
+        // VerboseLoggingChatClient instances that can all be active at once, sharing the ONE writer
+        // VerboseLog.Wrap hands out. TextWriter.Synchronized (what VerboseLog.Initialize actually uses in
+        // production) is what makes this safe — proven here directly rather than assumed.
+        var raw = new StringWriter();
+        var shared = TextWriter.Synchronized(raw);
+        var clientA = new VerboseLoggingChatClient(
+            new ScriptedChatClient().AddText("A0").AddText("A1").AddText("A2"), shared, "clientA");
+        var clientB = new VerboseLoggingChatClient(
+            new ScriptedChatClient().AddText("B0").AddText("B1").AddText("B2"), shared, "clientB");
+
+        await Task.WhenAll(
+            Task.Run(async () => { for (var i = 0; i < 3; i++) { await clientA.GetResponseAsync(Conversation()); } }),
+            Task.Run(async () => { for (var i = 0; i < 3; i++) { await clientB.GetResponseAsync(Conversation()); } }));
+
+        var lines = raw.ToString().Split('\n');
+        var headerLines = lines.Where(l => l.Contains("=== [", StringComparison.Ordinal)).ToList();
+        Assert.Equal(12, headerLines.Count);   // 3 round-trips × (1 REQUEST + 1 RESPONSE) × 2 clients
+        Assert.Equal(6, headerLines.Count(l => l.Contains("clientA", StringComparison.Ordinal)));
+        Assert.Equal(6, headerLines.Count(l => l.Contains("clientB", StringComparison.Ordinal)));
+        // Every header line is well-formed (a corrupted interleave would merge two headers onto one line,
+        // producing a line matching BOTH labels, or a line with an unexpected NUMBER of "=== [" markers).
+        Assert.All(headerLines, l => Assert.True(
+            l.Contains("clientA", StringComparison.Ordinal) ^ l.Contains("clientB", StringComparison.Ordinal),
+            $"header line belongs to exactly one client, got: {l}"));
+    }
+}


### PR DESCRIPTION
## Summary
- New global `--log-file <path>` option — writes every LLM request/response as human-readable plain text to a file, separate from stdout/stderr, for debugging. Available on every command via a System.CommandLine `Recursive=true` option.
- `VerboseLoggingChatClient` (a `DelegatingChatClient`, mirroring the shape of the existing `TraceRecordingChatClient`) wired into **every** `IChatClient`-construction path in the CLI: `EndpointFactory` (`eval`/`redteam`/`gatekeeper`/`bench`), `AzureChatAgentFactory` (`--azure-from-env`), `JudgeFactory` (the bench-family judge), and Copilot Studio's live connector (via a new generic `wrapChatClient` hook on `CopilotStudioAgentFactory.BuildLive` that keeps `AgentEval.MAF.CopilotStudio` decoupled from `AgentEval.Cli`).
- Content is logged **raw, with no redaction** — opt-in and local-only by design, disclosed in `--help` and `docs/cli.md`.

## Review findings fixed
Six parallel review angles caught and fixed 10+ real issues before merge:
- **A bad `--log-file` path crashed the entire CLI**, including commands with nothing to do with an LLM (e.g. `agenteval doctor --log-file <bad-path>`) — empirically reproduced by one review angle. Now degrades to a single warning and the command runs normally.
- **`JudgeFactory`'s construction site was missed entirely** — found independently by 3 separate review angles. Every `bench {gdpr,eu-ai-act,agentic,nist,owasp,mitre}` judge call would have been silently invisible to the log despite the feature's own `--help` text promising coverage.
- **Concurrent judge/attacker/SUT clients sharing one log file had colliding round-trip indices with no role label** — a RedTeam scan's 3 separate wrapped clients would each restart numbering at `[0]` with no way to tell which block came from which client. Fixed with an optional `label` parameter plus swapping a hand-rolled `lock` on a *publicly-reachable* object for .NET's own `TextWriter.Synchronized`.
- **A cancellation-exclusion filter accidentally swallowed HTTP-timeout exceptions** (`TaskCanceledException` is an `OperationCanceledException`) — the single most common real reason someone would reach for this feature. Fixed to only suppress the caller's *own* token firing.
- **An early-abandoned streaming enumeration silently orphaned its REQUEST entry** with no matching RESPONSE/ERROR. Fixed via `try/finally` + a new `ABANDONED` entry kind.
- **Full per-turn message history was logged on every round-trip**, growing O(turn-count²) in any multi-turn scenario (a 50-turn conversation would log ~1,275 mostly-duplicate lines). Fixed to log the conversation shape (counts by role) plus only the newest message.
- Plus: culture-invariant numeric formatting, a public-API doc comment leaking CLI-internal type names into the NuGet package's generated docs, write-failure resilience (a full disk must never discard an otherwise-successful LLM call), and test-isolation ([Collection]) for the new static ambient state.

## Test plan
- [x] 42 new/updated tests (decorator behavior, ambient wiring, concurrent-writer safety, streaming abandonment/mid-stream errors, 3 new "prove the wrap actually happened" tests for `GatekeeperModelResolver`/`AzureChatAgentFactory`/`CopilotStudioAgentFactory`)
- [x] Full net8.0 regression suite green (7863 passed, 1 pre-existing skip); targeted net9.0/net10.0 green
- [x] Live-verified end-to-end against real Azure OpenAI: full request/response captured correctly, role labels appear correctly, bad-path crash confirmed fixed
- [x] `MafApiSafety` checked on the new MAF/M.E.AI API usage — no issues (one flagged match was a false positive on an unrelated type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)