### PR TITLE
feat(gatekeeper): stop discarding judge confidence in CompositeJudgeGate

### DIFF
--- a/src/AgentEval.Core/Guardrails/GateVerdict.cs
+++ b/src/AgentEval.Core/Guardrails/GateVerdict.cs
@@ -23,12 +23,19 @@ public enum GateAction
 /// <param name="Reason">Human-readable reason (for <see cref="GateAction.Block"/>).</param>
 /// <param name="RedactedText">A masked replacement the client may apply under <see cref="EvalGatePolicy.Redact"/>; null when the finding is not maskable.</param>
 /// <param name="Matches">The offending matches found (e.g. PII categories / injection tokens), if any.</param>
+/// <param name="Confidence">
+/// 0..1 confidence behind this verdict, when the gate has one to report (e.g. a judge's own confidence). Null means
+/// the gate doesn't produce a soft signal (most deterministic/regex gates). Optional and additive — every existing
+/// <see cref="Allow"/>/<see cref="Block"/> call site is unaffected. Intended for cross-gate correlation (a fleet
+/// correlator reading verdicts across a session), not for enforcement by the gate itself.
+/// </param>
 public sealed record GateVerdict(
     GateAction Action,
     string PolicyName,
     string? Reason = null,
     string? RedactedText = null,
-    IReadOnlyList<string>? Matches = null)
+    IReadOnlyList<string>? Matches = null,
+    double? Confidence = null)
 {
     /// <summary>Allow verdict for <paramref name="policy"/>.</summary>
     public static GateVerdict Allow(string policy) => new(GateAction.Allow, policy);

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -72,7 +72,9 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate
                 GateVerdict.Block(PolicyName, verdict.Rationale ?? $"{_rubric.Axis} detected", verdict.Spans),
             JudgeDecision.Inconclusive when _options.FailClosedOnInconclusive =>
                 GateVerdict.Block(PolicyName, verdict.Rationale ?? $"{_rubric.Axis} judge inconclusive (fail-closed)"),
-            _ => GateVerdict.Allow(PolicyName),   // Allowed, low-confidence Blocked, or fail-open Inconclusive
+            // Allowed, low-confidence Blocked, or fail-open Inconclusive — carry the judge's own confidence through
+            // instead of discarding it, so a fleet-wide correlator can later notice several near-miss verdicts.
+            _ => GateVerdict.Allow(PolicyName) with { Confidence = verdict.Confidence },
         };
     }
 

--- a/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
@@ -64,6 +64,14 @@ public class CompositeJudgeGateTests
     }
 
     [Fact]
+    public async Task AllowedVerdict_CarriesJudgeConfidenceThrough_ForFleetCorrelation()
+    {
+        // JudgeVerdict.Allowed() defaults to confidence 1.0 — the gate must not discard it once the judge ran.
+        var v = await Gate(new ScriptedChatClient().AddText("ALLOW")).InspectAsync("please scan this input");
+        Assert.Equal(1.0, v.Confidence);
+    }
+
+    [Fact]
     public async Task PrefilterFalse_ShortCircuits_ModelNeverCalled()
     {
         var model = new ScriptedChatClient().AddText("BLOCK");   // would block IF called
@@ -71,6 +79,7 @@ public class CompositeJudgeGateTests
 
         Assert.Equal(GateAction.Allow, v.Action);
         Assert.Empty(model.ReceivedMessages);   // proves the fast model was never invoked (0 tokens)
+        Assert.Null(v.Confidence);   // no judge ran — there is no soft signal to report, not even a fabricated one
     }
 
     [Fact]
@@ -88,6 +97,7 @@ public class CompositeJudgeGateTests
         var opts = new JudgeGateOptions { FailClosedOnInconclusive = false };
         var v = await Gate(new ScriptedChatClient().AddThrow(), opts).InspectAsync("please scan this");
         Assert.Equal(GateAction.Allow, v.Action);
+        Assert.Equal(0.0, v.Confidence);   // JudgeVerdict.Inconclusive's own confidence (0.0) carries through honestly
     }
 
     [Fact]
@@ -116,6 +126,11 @@ public class CompositeJudgeGateTests
         var opts = new JudgeGateOptions { BlockThreshold = 0.95 };
         var v = await Gate(new ScriptedChatClient().AddText("BLOCK"), opts).InspectAsync("please scan this");
         Assert.Equal(GateAction.Allow, v.Action);
+
+        // This is the exact near-miss case Fleet Correlation depends on: a sub-threshold Blocked decision that
+        // becomes an Allow must still surface its real confidence (0.9), not null or a fabricated 1.0 — a fleet
+        // correlator combining several of these across gates needs the true value, not a laundered "clean allow".
+        Assert.Equal(0.9, v.Confidence);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `GateVerdict` gains an optional, additive `Confidence` field (null = "this gate has no soft signal to report").
- `CompositeJudgeGate.InspectAsync` was computing `JudgeVerdict.Confidence` on every decision path and discarding it one line later on Allow/low-confidence-Block/fail-open-Inconclusive. It now carries that value through.

This is Fleet Correlation Layer P0 (`strategy/Gatekeeper/Fleet-Correlation-Layer-Design.md`, local design doc, not part of this PR) — a fleet-wide correlator that notices several gates each showing sub-threshold concern in the same session needs this signal to exist. Nothing about fleet correlation itself ships here; this only stops the data from being deleted.

Non-breaking: `Confidence` defaults to `null`, every existing `GateVerdict.Allow(...)`/`Block(...)` call site is unaffected. No serialization/golden-file/full-record-equality test depends on `GateVerdict`'s shape (checked).

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `CompositeJudgeGateTests` (17 tests, net8/9/10) — all pass, including 4 new/extended assertions covering: Allowed carries confidence 1.0, sub-threshold Block-turned-Allow carries the real 0.9 (the exact near-miss case this exists for), prefilter-short-circuit leaves it null (no judge ran, no fabricated signal), fail-open Inconclusive carries 0.0
- [x] Full `Guardrails` namespace (225 tests, net8/9/10) — all pass
- [x] Self-reviewed diff: no breaking positional-arg risk, no equality/serialization blast radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro