### PR TITLE
feat(copilot-studio): fluent assertions for CS-flavored chat responses

### DIFF
--- a/src/AgentEval.Core/Assertions/CopilotStudioAssertions.cs
+++ b/src/AgentEval.Core/Assertions/CopilotStudioAssertions.cs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Assertions;
+
+/// <summary>
+/// Fluent assertion sugar for Copilot Studio-flavored chat responses. Extension methods over
+/// <see cref="ResponseAssertions"/> (plain response text) and a new <see cref="ChatResponseAssertions"/>
+/// (plain <see cref="ChatResponse"/>) — never over <c>CopilotStudioChatClient</c> itself, so this file adds
+/// zero dependency from <c>AgentEval.Core</c> onto <c>AgentEval.MAF.CopilotStudio</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why not connector/topic/fallback assertions too.</b> A Copilot Studio agent's topic routing, connector
+/// invocations, and flow actions happen server-side; <c>CopilotStudioChatClient.AsUpdates()</c> only ever
+/// surfaces <c>Type == "message"</c> activity text — everything else is silently dropped by design (the
+/// documented <c>SutTier.TextOnly</c> / <c>EvidenceFidelity.Verbal</c> fidelity ceiling). Building assertions
+/// for data that isn't captured would mean inventing signal, which this repo's design refuses to do elsewhere
+/// — see <c>CopilotStudioRedTeamTarget.WritePostScanSummary</c>'s own "proof of what was SAID, never what was
+/// DONE" disclosure. Only what the bridge genuinely surfaces is asserted on below.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// response.Text.Should().HaveRespondedWithNonEmptyMessage();
+/// response.Should().HaveContinuedConversation(firstTurnConversationId);
+/// </code>
+/// </example>
+public static class CopilotStudioAssertions
+{
+    /// <summary>
+    /// Assert the response text is non-empty, with a Copilot Studio-specific failure message that teaches the
+    /// text-only fidelity ceiling instead of a generic empty-string complaint: a CS agent's reply can
+    /// legitimately be empty when it responded with a non-text activity (adaptive card, suggested action),
+    /// which the bridge silently drops rather than fabricates as text.
+    /// </summary>
+    /// <param name="a">The response assertions instance (e.g. <c>response.Text.Should()</c>).</param>
+    /// <param name="because">Optional reason for the assertion (shown in failure message).</param>
+    [StackTraceHidden]
+    public static ResponseAssertions HaveRespondedWithNonEmptyMessage(this ResponseAssertions a, string? because = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        if (string.IsNullOrWhiteSpace(a.Response))
+        {
+            AgentEvalScope.FailWith(
+                ResponseAssertionException.Create(
+                    "Expected a non-empty Copilot Studio reply.",
+                    expected: "Non-empty response text",
+                    actual: a.Response.Length == 0 ? "empty string" : "whitespace only",
+                    suggestions: new[]
+                    {
+                        "A Copilot Studio agent's reply can be empty when it responded with a non-text activity " +
+                        "(adaptive card, suggested action) — the CS bridge is text-only by design " +
+                        "(CopilotStudioChatClient.AsUpdates), so those are silently dropped, not an error.",
+                        "If you expect richer output, this fidelity ceiling — not a bug — is why it isn't visible here.",
+                    },
+                    because: because));
+        }
+
+        return a;
+    }
+
+    /// <summary>
+    /// Assert this response's <see cref="ChatResponse.ConversationId"/> matches <paramref name="previousConversationId"/> —
+    /// proves the server-side Copilot Studio conversation actually resumed rather than silently starting a new
+    /// one. This concept has no equivalent for a stateless Azure OpenAI call.
+    /// </summary>
+    /// <param name="a">The chat-response assertions instance (e.g. <c>response.Should()</c>).</param>
+    /// <param name="previousConversationId">The conversation id a prior turn reported.</param>
+    /// <param name="because">Optional reason for the assertion (shown in failure message).</param>
+    [StackTraceHidden]
+    public static ChatResponseAssertions HaveContinuedConversation(this ChatResponseAssertions a, string previousConversationId, string? because = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(previousConversationId);
+        var actual = a.Response.ConversationId;
+
+        if (!string.Equals(actual, previousConversationId, StringComparison.Ordinal))
+        {
+            AgentEvalScope.FailWith(
+                ResponseAssertionException.Create(
+                    "Expected the Copilot Studio conversation to have continued.",
+                    expected: $"ConversationId == \"{previousConversationId}\"",
+                    actual: actual is null ? "null (no conversation id on this response)" : $"\"{actual}\"",
+                    because: because));
+        }
+
+        return a;
+    }
+
+    /// <summary>
+    /// Assert this response has a non-null, non-empty <see cref="ChatResponse.ConversationId"/> — a
+    /// conversation was actually established server-side.
+    /// </summary>
+    /// <param name="a">The chat-response assertions instance (e.g. <c>response.Should()</c>).</param>
+    /// <param name="because">Optional reason for the assertion (shown in failure message).</param>
+    [StackTraceHidden]
+    public static ChatResponseAssertions HaveStartedNewConversation(this ChatResponseAssertions a, string? because = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        if (string.IsNullOrEmpty(a.Response.ConversationId))
+        {
+            AgentEvalScope.FailWith(
+                ResponseAssertionException.Create(
+                    "Expected a new Copilot Studio conversation to have started.",
+                    expected: "Non-empty ConversationId",
+                    actual: "null or empty",
+                    because: because));
+        }
+
+        return a;
+    }
+
+    /// <summary>
+    /// Assert this response's <see cref="ChatResponse.ConversationId"/> is non-empty AND different from
+    /// <paramref name="previousConversationId"/> — proves a genuinely NEW server-side conversation started,
+    /// rather than the prior one silently resuming. Deliberately a differently-named method, not a
+    /// <see cref="HaveStartedNewConversation(ChatResponseAssertions, string?)"/> overload: a single positional
+    /// string argument is otherwise ambiguous between "the because reason" and "the previous conversation id"
+    /// — C#'s default-argument tie-break silently resolves such a call to the no-previous-id overload instead
+    /// of throwing a compile error, which is a real, hard-to-notice correctness trap, not just a style choice.
+    /// </summary>
+    /// <param name="a">The chat-response assertions instance (e.g. <c>response.Should()</c>).</param>
+    /// <param name="previousConversationId">The conversation id a prior, different conversation reported.</param>
+    /// <param name="because">Optional reason for the assertion (shown in failure message).</param>
+    [StackTraceHidden]
+    public static ChatResponseAssertions HaveStartedDifferentConversation(this ChatResponseAssertions a, string previousConversationId, string? because = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(previousConversationId);
+        var actual = a.Response.ConversationId;
+
+        if (string.IsNullOrEmpty(actual) || string.Equals(actual, previousConversationId, StringComparison.Ordinal))
+        {
+            AgentEvalScope.FailWith(
+                ResponseAssertionException.Create(
+                    "Expected a new Copilot Studio conversation, distinct from the previous one.",
+                    expected: $"Non-empty ConversationId != \"{previousConversationId}\"",
+                    actual: string.IsNullOrEmpty(actual) ? "null or empty" : $"\"{actual}\" (same as previous)",
+                    because: because));
+        }
+
+        return a;
+    }
+
+    /// <summary>
+    /// Assert an estimated Copilot Credit spend stayed within a budget — the fluent counterpart to
+    /// <c>--max-credits</c> enforcement, reading the SAME estimate
+    /// (<c>CopilotStudioChatClient.EstimatedCreditsUsed</c>) that enforcement uses, not a parallel one.
+    /// Takes the estimate as a value rather than the client itself, so this stays a plain-MEAI-type
+    /// assertion with no dependency on the Copilot Studio package.
+    /// </summary>
+    /// <param name="a">The chat-response assertions instance (e.g. <c>response.Should()</c>).</param>
+    /// <param name="estimatedCreditsUsed">The estimate to check (e.g. <c>copilotStudioClient.EstimatedCreditsUsed</c>).</param>
+    /// <param name="maxCredits">The budget cap.</param>
+    /// <param name="because">Optional reason for the assertion (shown in failure message).</param>
+    [StackTraceHidden]
+    public static ChatResponseAssertions HaveStayedWithinCreditBudget(this ChatResponseAssertions a, int estimatedCreditsUsed, int maxCredits, string? because = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        if (estimatedCreditsUsed > maxCredits)
+        {
+            AgentEvalScope.FailWith(
+                ResponseAssertionException.Create(
+                    "Expected estimated Copilot Credit spend to stay within budget. Credit cost is an ESTIMATE, " +
+                    "not a metered value — actual spend may already be ahead of this number.",
+                    expected: $"estimated credits used <= {maxCredits}",
+                    actual: $"estimated credits used == {estimatedCreditsUsed}",
+                    because: because));
+        }
+
+        return a;
+    }
+}
+
+/// <summary>
+/// Begins fluent assertions on a plain <see cref="ChatResponse"/> (e.g. one returned by any <c>IChatClient</c>,
+/// including <c>CopilotStudioChatClient</c>). Deliberately generic — see <see cref="CopilotStudioAssertions"/>
+/// for the Copilot Studio-flavored extension methods built on top of it.
+/// </summary>
+public static class ChatResponseAssertionsExtensions
+{
+    /// <summary>Start fluent assertions on a <see cref="ChatResponse"/>.</summary>
+    public static ChatResponseAssertions Should(this ChatResponse response) => new(response);
+}
+
+/// <summary>Fluent assertion builder wrapping a plain <see cref="ChatResponse"/>.</summary>
+public sealed class ChatResponseAssertions
+{
+    /// <summary>The wrapped response.</summary>
+    public ChatResponse Response { get; }
+
+    /// <summary>Creates a new <see cref="ChatResponseAssertions"/> over <paramref name="response"/>.</summary>
+    internal ChatResponseAssertions(ChatResponse response)
+    {
+        Response = response ?? throw new ArgumentNullException(nameof(response));
+    }
+}

--- a/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
+++ b/src/AgentEval.MAF.CopilotStudio/CopilotStudioChatClient.cs
@@ -70,6 +70,13 @@ public sealed class CopilotStudioChatClient : IChatClient
     private bool _disposed;
     private int _estimatedCreditsUsed;
 
+    /// <summary>
+    /// Estimated Copilot Credit spend so far on this conversation (<see cref="EstimatedCreditsPerTurn"/> per
+    /// completed turn) — the SAME counter the <c>maxCredits</c> budget gate itself reads. An ESTIMATE, never a
+    /// metered value — see this type's own remarks.
+    /// </summary>
+    public int EstimatedCreditsUsed => _estimatedCreditsUsed;
+
     /// <param name="client">The conversation client this bridges into <see cref="IChatClient"/>.</param>
     /// <param name="maxCredits">
     /// Estimated Copilot Credit spend cap (0 = no cap, the default). Checked BEFORE each turn — a turn that

--- a/tests/AgentEval.Tests/Assertions/CopilotStudioAssertionsTests.cs
+++ b/tests/AgentEval.Tests/Assertions/CopilotStudioAssertionsTests.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Assertions;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Assertions;
+
+/// <summary>
+/// Unit tests for <see cref="CopilotStudioAssertions"/> and <see cref="ChatResponseAssertions"/>. Exercised
+/// entirely against hand-built plain <see cref="ChatResponse"/> objects — no Copilot Studio package
+/// dependency, matching the assertions' own design (they inspect plain MEAI types, never
+/// <c>CopilotStudioChatClient</c>). For proof against the real Copilot Studio bridge, see
+/// <c>CopilotStudioChatClientTests</c>.
+/// </summary>
+public class CopilotStudioAssertionsTests
+{
+    private static ChatResponse Response(string text, string? conversationId = null) =>
+        new(new ChatMessage(ChatRole.Assistant, text)) { ConversationId = conversationId };
+
+    [Fact]
+    public void HaveRespondedWithNonEmptyMessage_NonEmptyText_Passes()
+        => "hello".Should().HaveRespondedWithNonEmptyMessage();
+
+    [Fact]
+    public void HaveRespondedWithNonEmptyMessage_EmptyText_ThrowsWithFidelityCeilingExplanation()
+    {
+        var ex = Assert.Throws<ResponseAssertionException>(() => "".Should().HaveRespondedWithNonEmptyMessage());
+        Assert.Contains("adaptive card", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("fidelity ceiling", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HaveRespondedWithNonEmptyMessage_WhitespaceOnly_Throws()
+        => Assert.Throws<ResponseAssertionException>(() => "   ".Should().HaveRespondedWithNonEmptyMessage());
+
+    [Fact]
+    public void HaveContinuedConversation_MatchingId_Passes()
+        => Response("reply", "conv-1").Should().HaveContinuedConversation("conv-1");
+
+    [Fact]
+    public void HaveContinuedConversation_DifferentId_Throws()
+    {
+        var ex = Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", "conv-2").Should().HaveContinuedConversation("conv-1"));
+        Assert.Contains("conv-1", ex.Message);
+        Assert.Contains("conv-2", ex.Message);
+    }
+
+    [Fact]
+    public void HaveContinuedConversation_NullConversationId_Throws()
+        => Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", conversationId: null).Should().HaveContinuedConversation("conv-1"));
+
+    [Fact]
+    public void HaveStartedNewConversation_NonEmptyId_Passes()
+        => Response("reply", "conv-1").Should().HaveStartedNewConversation();
+
+    [Fact]
+    public void HaveStartedNewConversation_NullId_Throws()
+        => Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", conversationId: null).Should().HaveStartedNewConversation());
+
+    [Fact]
+    public void HaveStartedDifferentConversation_DifferentId_Passes()
+        => Response("reply", "conv-2").Should().HaveStartedDifferentConversation("conv-1");
+
+    [Fact]
+    public void HaveStartedDifferentConversation_SameId_Throws()
+    {
+        var ex = Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", "conv-1").Should().HaveStartedDifferentConversation("conv-1"));
+        Assert.Contains("same as previous", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HaveStartedDifferentConversation_NullId_Throws()
+        => Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", conversationId: null).Should().HaveStartedDifferentConversation("conv-1"));
+
+    [Fact]
+    public void HaveStartedNewConversation_SingleArgCall_NeverAmbiguouslyBindsToPreviousId()
+    {
+        // Regression guard for the overload-ambiguity bug found while writing these tests: a call with exactly
+        // one positional string argument must resolve to the (because) overload, not silently be mistaken for
+        // a "differs from previous id" check — HaveStartedDifferentConversation exists precisely so a single
+        // positional string can never mean two different things across two same-named overloads.
+        Response("reply", "conv-1").Should().HaveStartedNewConversation("any string is just a because reason here");
+    }
+
+    [Fact]
+    public void HaveStayedWithinCreditBudget_UnderCap_Passes()
+        => Response("reply", "conv-1").Should().HaveStayedWithinCreditBudget(estimatedCreditsUsed: 3, maxCredits: 5);
+
+    [Fact]
+    public void HaveStayedWithinCreditBudget_AtCap_Passes()
+        => Response("reply", "conv-1").Should().HaveStayedWithinCreditBudget(estimatedCreditsUsed: 5, maxCredits: 5);
+
+    [Fact]
+    public void HaveStayedWithinCreditBudget_OverCap_Throws()
+    {
+        var ex = Assert.Throws<ResponseAssertionException>(
+            () => Response("reply", "conv-1").Should().HaveStayedWithinCreditBudget(estimatedCreditsUsed: 6, maxCredits: 5));
+        Assert.Contains("6", ex.Message);
+        Assert.Contains("5", ex.Message);
+    }
+
+    [Fact]
+    public void ChatResponseShould_ChainsAcrossMultipleAssertions()
+        => Response("reply", "conv-1").Should()
+            .HaveContinuedConversation("conv-1")
+            .HaveStartedNewConversation()
+            .HaveStayedWithinCreditBudget(1, 5);
+
+    [Fact]
+    public void ChatResponseAssertions_NullResponse_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new ChatResponseAssertions(null!));
+}

--- a/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
+++ b/tests/AgentEval.Tests/MAF/CopilotStudio/CopilotStudioChatClientTests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using AgentEval.Assertions;
 using AgentEval.MAF.CopilotStudio;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.AI;
@@ -228,6 +229,70 @@ public class CopilotStudioChatClientTests
 
         Assert.Equal(1, ex.EstimatedCreditsUsed);
         Assert.Equal(1, fake.AskCallCount);   // turn 2 never reached the conversation client
+    }
+
+    [Fact]
+    public async Task EstimatedCreditsUsed_PublicAccessor_ReadsTheSameCounterBudgetEnforcementUses()
+    {
+        // The public accessor (added for HaveStayedWithinCreditBudget) must read the identical counter the
+        // --max-credits gate itself uses — not a parallel/duplicated one.
+        var fake = new FakeCopilotStudioConversationClient();
+        fake.OnStart = (_, _) => Empty();
+        fake.OnAsk = (_, _, _) => One(Message("ok", "conv-1"));
+
+        using var client = new CopilotStudioChatClient(fake);
+        Assert.Equal(0, client.EstimatedCreditsUsed);
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 1")]);
+        Assert.Equal(1, client.EstimatedCreditsUsed);
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 2")]);
+        Assert.Equal(2, client.EstimatedCreditsUsed);
+    }
+
+    [Fact]
+    public async Task EstimatedCreditsUsed_DoesNotIncrement_OnAFailedTurn()
+    {
+        // GetStreamingResponseCoreAsync only bumps _estimatedCreditsUsed AFTER a fully successful turn (see
+        // its own remarks) — the public accessor must reflect that, not double-count or count a failed attempt.
+        var fake = new FakeCopilotStudioConversationClient();
+        fake.OnStart = (_, _) => Empty();
+        fake.OnAsk = (_, _, _) => throw new InvalidOperationException("simulated transport failure");
+
+        using var client = new CopilotStudioChatClient(fake);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "turn 1")]));
+
+        Assert.Equal(0, client.EstimatedCreditsUsed);
+    }
+
+    // ── fluent assertions against the real bridge (CopilotStudioAssertions) ──
+
+    [Fact]
+    public async Task FluentAssertions_HaveContinuedConversation_PassesAcrossARealBridgedMultiTurnFlow()
+    {
+        var mock = new MockCopilotStudioConversationClient("conv-mock-1")
+            .WithReply("first reply")
+            .WithReply("second reply");
+
+        using var client = new CopilotStudioChatClient(mock);
+        var first = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+        first.Should().HaveStartedNewConversation();
+        first.Text.Should().HaveRespondedWithNonEmptyMessage();
+
+        var second = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "again")]);
+        second.Should().HaveContinuedConversation(first.ConversationId!);
+    }
+
+    [Fact]
+    public async Task FluentAssertions_HaveStayedWithinCreditBudget_ReflectsRealBridgedSpend()
+    {
+        var mock = new MockCopilotStudioConversationClient("conv-mock-2").WithReply("ok");
+        using var client = new CopilotStudioChatClient(mock);
+
+        var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        response.Should().HaveStayedWithinCreditBudget(client.EstimatedCreditsUsed, maxCredits: 5);
     }
 
     // ── activity builders ──


### PR DESCRIPTION
## Summary
- New `CopilotStudioAssertions.cs` (`AgentEval.Core/Assertions`): `HaveRespondedWithNonEmptyMessage`, `HaveContinuedConversation`, `HaveStartedNewConversation`, `HaveStartedDifferentConversation`, `HaveStayedWithinCreditBudget` — all extension methods over plain MEAI `ResponseAssertions`/`ChatResponse`, zero new dependency from `AgentEval.Core` onto `AgentEval.MAF.CopilotStudio`.
- New public `CopilotStudioChatClient.EstimatedCreditsUsed` accessor (previously private) — `HaveStayedWithinCreditBudget` reads the same counter `--max-credits` enforcement already uses.
- **Deliberately NOT included:** `HaveInvokedConnector`/`HaveUsedTopic`/`HaveTriggeredFallback`. `CopilotStudioChatClient.AsUpdates()` only ever surfaces message-activity text — server-side topic/connector/flow metadata is discarded by design. Building those methods would mean inventing signal that doesn't exist, which this repo refuses to do elsewhere (see `CopilotStudioRedTeamTarget`'s own "SAID, never DONE" disclosure). A live-tenant investigation would be needed before that's buildable — out of scope here.

## A bug found and fixed while writing tests
An initial two-overload `HaveStartedNewConversation(previousId)` design was ambiguous with the single-arg `HaveStartedNewConversation(because)` overload — C#'s default-argument tie-break rule silently resolved a single positional string argument to the WRONG overload instead of raising a compile error (verified: my own test caught it — a call meant to check "different conversation" silently ran the "non-empty" check instead and passed for the wrong reason). Fixed by renaming the previous-id variant to `HaveStartedDifferentConversation`, with a regression test guarding the single-arg call path.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] 16 new unit tests (`CopilotStudioAssertionsTests`) against hand-built `ChatResponse` objects — no CS package dependency, matching the assertions' own design
- [x] 4 new end-to-end tests in `CopilotStudioChatClientTests` driving the real `CopilotStudioChatClient` bridge via the existing `MockCopilotStudioConversationClient`, proving the assertions work against genuine bridged multi-turn output (including credit-accessor increment/no-increment-on-failure)
- [x] Full `CopilotStudio` + `Assertions` namespaces (156 + 143 tests, net8/9/10) — all pass
- [x] Self-reviewed: constructor visibility tightened to `internal` (matches `WorkflowAssertionBuilder` precedent), no serialization/equality blast radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro