### PR TITLE
feat(gatekeeper): SkillGate Tier 1 - runtime enforcement for Agent Skills drift

### DIFF
--- a/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
+++ b/src/AgentEval.Cli/Commands/SkillsScanCommand.cs
@@ -853,10 +853,100 @@ internal static class SkillsScanCommand
             }
         });
 
+        var approveCmd = new Command(
+            "approve",
+            "SkillGate recapture: re-hash ONE skill's current content and pin it into the SkillManifestBaseline used by UseGatekeeper's SkillGate construction-time check — the 'I reviewed this legitimate update, trust it again' path after a SkillDriftException.");
+        var approveSkillNameArg = new Argument<string>("skill-name") { Description = "The skill to (re)approve." };
+        var approveSkillPathOpt = new Option<DirectoryInfo>("--skill-path") { Required = true, Description = "Directory containing this skill (or a parent directory of many skills — the named skill is located within it)." };
+        var approveBaselineOpt = new Option<FileInfo>("--baseline") { Required = true, Description = "Path to the SkillManifestBaseline JSON file GatekeeperOptions.SkillBaselinePath points at. Created if it does not exist yet." };
+        var approveNoteOpt = new Option<string?>("--note") { Description = "Optional human note recorded on the updated baseline (who approved it, why)." };
+        approveCmd.Arguments.Add(approveSkillNameArg);
+        approveCmd.Options.Add(approveSkillPathOpt);
+        approveCmd.Options.Add(approveBaselineOpt);
+        approveCmd.Options.Add(approveNoteOpt);
+        approveCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await ApproveAsync(
+                    parseResult.GetValue(approveSkillNameArg)!,
+                    parseResult.GetValue(approveSkillPathOpt)!,
+                    parseResult.GetValue(approveBaselineOpt)!,
+                    parseResult.GetValue(approveNoteOpt),
+                    ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
         baselineCmd.Subcommands.Add(listCmd);
         baselineCmd.Subcommands.Add(diffCmd);
         baselineCmd.Subcommands.Add(historyCmd);
+        baselineCmd.Subcommands.Add(approveCmd);
         return baselineCmd;
+    }
+
+    /// <summary>
+    /// SkillGate P1 recapture path (§5 of the SkillGate design). Scans <paramref name="skillPath"/> the same
+    /// credential-free way <c>skills scan</c> itself does (a no-op <see cref="ChatClientAgent"/> — skill
+    /// discovery never calls the model), locates the ONE named skill, re-hashes it (structural fingerprint
+    /// always; content hash too when its on-disk folder resolves), and updates ONLY that skill's entry in the
+    /// baseline at <paramref name="baselinePath"/> — every other skill's existing pinned hash is left
+    /// untouched, so approving one skill can never silently re-trust an unrelated one.
+    /// </summary>
+    internal static async Task<int> ApproveAsync(string skillName, DirectoryInfo skillPath, FileInfo baselinePath, string? note, CancellationToken ct)
+    {
+        AIAgent noOpAgent = new ChatClientAgent(new ScriptedChatClient(), new ChatClientAgentOptions { Name = "SkillsScanCommand" });
+        var result = await MafSkillScanner.ScanFileSkillsWithInfoAsync(skillPath.FullName, noOpAgent, options: null, ct).ConfigureAwait(false);
+
+        var found = result.Skills.FirstOrDefault(s => string.Equals(s.Manifest.Name, skillName, StringComparison.Ordinal));
+        if (found is null)
+        {
+            Console.Error.WriteLine($"  Error: skill '{skillName}' not found under {skillPath.FullName}.");
+            return ExitCodes.RuntimeError;
+        }
+
+        var existing = baselinePath.Exists
+            ? await SkillManifestBaseline.LoadAsync(baselinePath.FullName, ct).ConfigureAwait(false)
+            : new SkillManifestBaseline(DateTimeOffset.UtcNow, new Dictionary<string, string>());
+
+        var structuralFingerprint = SkillManifestPoisoningGate.Fingerprint(found.Manifest);
+        var updatedHashes = new Dictionary<string, string>(existing.HashesBySkillName, StringComparer.Ordinal)
+        {
+            [skillName] = structuralFingerprint,
+        };
+
+        var updatedContentHashes = new Dictionary<string, string>(
+            existing.ContentHashesBySkillName ?? new Dictionary<string, string>(), StringComparer.Ordinal);
+        var contentHash = found.AbsolutePath is not null ? SkillContentHasher.HashSkillFolder(found.AbsolutePath) : null;
+        if (contentHash is not null)
+        {
+            updatedContentHashes[skillName] = contentHash;
+        }
+
+        var updated = existing with
+        {
+            CapturedAt = DateTimeOffset.UtcNow,
+            HashesBySkillName = updatedHashes,
+            Notes = note ?? existing.Notes,
+            ContentHashesBySkillName = updatedContentHashes.Count > 0 ? updatedContentHashes : existing.ContentHashesBySkillName,
+        };
+
+        var parentDir = baselinePath.Directory;
+        if (parentDir is not null && !parentDir.Exists)
+        {
+            parentDir.Create();
+        }
+
+        await updated.SaveAsync(baselinePath.FullName, ct).ConfigureAwait(false);
+        Console.WriteLine(
+            $"  Approved '{skillName}': structural={structuralFingerprint[..8]}..." +
+            (contentHash is not null ? $" content={contentHash[..8]}..." : " (no on-disk folder — content hash not captured)") +
+            $" -> {baselinePath.FullName}");
+        return ExitCodes.Success;
     }
 
     internal static async Task<int> ListAsync(string baselineRoot, CancellationToken ct)

--- a/src/AgentEval.Core/Skills/SkillManifestPoisoningGate.cs
+++ b/src/AgentEval.Core/Skills/SkillManifestPoisoningGate.cs
@@ -65,8 +65,21 @@ public static class SkillManifestPoisoningGate
 /// <param name="CapturedAt">When this baseline was captured.</param>
 /// <param name="HashesBySkillName">Skill name → <see cref="SkillManifestPoisoningGate.Fingerprint"/> at capture time.</param>
 /// <param name="Notes">Optional human note (who approved it, why).</param>
+/// <param name="ContentHashesBySkillName">
+/// SkillGate (runtime governance) addition — optional, additive. Skill name →
+/// <see cref="AgentEval.Skills.SkillContentHasher.HashSkillFolder"/> at capture time, for skills whose
+/// on-disk folder was known when this baseline was captured. <see langword="null"/> for any baseline
+/// captured before this field existed, or for a skill with no resolvable folder (non-file-sourced) — the
+/// structural <see cref="HashesBySkillName"/> fingerprint alone still applies to those. A stronger,
+/// OPTIONAL companion signal: two skills can share an identical structural fingerprint (same name/
+/// description/resource-and-script inventory) while a resource file's actual BYTES silently changed —
+/// this catches that, the structural fingerprint alone cannot.
+/// </param>
 public sealed record SkillManifestBaseline(
-    DateTimeOffset CapturedAt, IReadOnlyDictionary<string, string> HashesBySkillName, string? Notes = null)
+    DateTimeOffset CapturedAt,
+    IReadOnlyDictionary<string, string> HashesBySkillName,
+    string? Notes = null,
+    IReadOnlyDictionary<string, string>? ContentHashesBySkillName = null)
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
 

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalGatekeeperExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalGatekeeperExtensions.cs
@@ -74,6 +74,22 @@ public static class AgentEvalGatekeeperExtensions
             }
         }
 
+        // SkillGate Tier 1 (runtime governance) — same fail-fast-before-any-mutation placement and the same
+        // fail-LOUD-on-half-configuration discipline as PromptTemplates/PromptTemplateBaseline immediately
+        // above. Opt-in: both Skills and SkillBaselinePath must be set together.
+        if (options.Skills is null != options.SkillBaselinePath is null)
+        {
+            throw new InvalidOperationException(
+                "UseGatekeeper: exactly one of GatekeeperOptions.Skills / SkillBaselinePath is set — both must " +
+                "be set together for the SkillGate drift check to run (or neither, to leave it disabled). Set " +
+                "the missing one, or clear the one you did set.");
+        }
+
+        if (options.Skills is not null && options.SkillBaselinePath is not null)
+        {
+            SkillGateConstructionCheck.CheckAndEnforce(options.Skills, options.SkillBaselinePath, options.SkillGateMode);
+        }
+
         // #2: compute the AUTHORITATIVE coverage report — against the SAME ToolGates snapshot that is actually
         // registered below (options.ToolGates.ToArray()), not a separately-tracked list a caller could pass to
         // GatekeeperCoverageAnalyzer.Analyze themselves and let drift. Populated whenever KnownTools is set,

--- a/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using AgentEval.Guardrails;
+using AgentEval.MAF.Skills;
 using AgentEval.Tracing;
 using Microsoft.Extensions.AI;
 using AgentTrace = AgentEval.Tracing.AgentTrace;
@@ -169,4 +170,54 @@ public sealed class GatekeeperOptions
     /// present in both is; that's the actual tamper signal this guard exists to catch.
     /// </summary>
     public IReadOnlyDictionary<string, string>? PromptTemplateBaseline { get; set; }
+
+    /// <summary>
+    /// SkillGate Tier 1 (runtime governance) — the skills this agent will expose, to check for drift at
+    /// construction time. Typically <c>MafSkillScanner.ScanFileSkillsWithInfoAsync(...).Skills</c>, run by the
+    /// caller BEFORE this call (<c>UseGatekeeper</c> executes before <c>.Build()</c>, so it cannot read a live
+    /// agent's own skill source — same reason <see cref="KnownTools"/> is caller-supplied, see its remarks).
+    /// Paired with <see cref="SkillBaselinePath"/>; both must be set TOGETHER for the check to run (leave BOTH
+    /// unset to disable it — setting exactly one throws <see cref="InvalidOperationException"/>, same
+    /// fail-loud-on-half-configuration discipline as <see cref="PromptTemplates"/>/<see cref="PromptTemplateBaseline"/>).
+    /// </summary>
+    public IReadOnlyList<ScannedSkillInfo>? Skills { get; set; }
+
+    /// <summary>
+    /// Path to the pinned <see cref="AgentEval.Skills.SkillManifestBaseline"/> JSON file to check
+    /// <see cref="Skills"/> against. Unlike <see cref="PromptTemplateBaseline"/> (an in-memory dictionary the
+    /// caller manages), this is a FILE PATH — <see cref="SkillGateMode.Bootstrap"/> needs to write an extended
+    /// baseline back to the same file it read, so a persistent location is load-bearing here, not just a
+    /// convenience. When both this and <see cref="Skills"/> are set, <c>UseGatekeeper</c> computes drift
+    /// EAGERLY at construction time via <see cref="SkillGateConstructionCheck.CheckAndEnforce"/> and throws
+    /// <see cref="SkillDriftException"/> immediately on a blocking finding (fail-closed, the same pattern as
+    /// <see cref="PromptTemplateBaseline"/>). A path that does not exist yet is treated as an EMPTY baseline,
+    /// not an error — under <see cref="SkillGateMode.Strict"/> (the default) that refuses every skill until an
+    /// initial baseline is captured (via <c>agenteval skills baseline approve</c> or a one-time
+    /// <see cref="SkillGateMode.Bootstrap"/> run); under <see cref="SkillGateMode.Bootstrap"/> it seeds the
+    /// file from this first construction.
+    /// </summary>
+    public string? SkillBaselinePath { get; set; }
+
+    /// <summary>
+    /// How <see cref="SkillGateConstructionCheck"/> handles a skill in <see cref="Skills"/> with no entry at
+    /// all in the baseline at <see cref="SkillBaselinePath"/>. Defaults to <see cref="SkillGateMode.Strict"/> —
+    /// see that enum for what each mode does and why Strict is the safe default.
+    /// </summary>
+    public SkillGateMode SkillGateMode { get; set; } = SkillGateMode.Strict;
+
+    /// <summary>
+    /// Fluent sugar for setting <see cref="Skills"/>/<see cref="SkillBaselinePath"/>/<see cref="SkillGateMode"/>
+    /// together — SkillGate Tier 1's one-call configuration entry point, matching the shape shown in its own
+    /// design doc. Returns <see langword="this"/> so it can chain inside the <c>configure</c> callback; not
+    /// required — setting the three properties individually has the identical effect.
+    /// </summary>
+    public GatekeeperOptions WithSkillGate(IReadOnlyList<ScannedSkillInfo> skills, string baselinePath, SkillGateMode mode = SkillGateMode.Strict)
+    {
+        Skills = skills ?? throw new ArgumentNullException(nameof(skills));
+        SkillBaselinePath = string.IsNullOrWhiteSpace(baselinePath)
+            ? throw new ArgumentException("baselinePath must be non-empty.", nameof(baselinePath))
+            : baselinePath;
+        SkillGateMode = mode;
+        return this;
+    }
 }

--- a/src/AgentEval.MAF/Gatekeeper/SkillDriftException.cs
+++ b/src/AgentEval.MAF/Gatekeeper/SkillDriftException.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Thrown by <c>UseGatekeeper</c> at agent-CONSTRUCTION time (not per-turn — see
+/// <see cref="SkillGateConstructionCheck"/> for why Tier 1 needs no runtime seam) when SkillGate refuses to
+/// build: a skill's content has changed since it was trust-pinned, or (under <see cref="SkillGateMode.Strict"/>)
+/// a skill has no baseline entry at all. Fail-closed, the same pattern as
+/// <see cref="PromptTemplateDriftException"/>/<see cref="UnprotectedHighRiskToolException"/>.
+/// </summary>
+public sealed class SkillDriftException : Exception
+{
+    /// <summary>
+    /// The offending finding(s) — a mix of <see cref="ManifestDriftKind.Changed"/> (drift on a known skill,
+    /// always blocking) and, under <see cref="SkillGateMode.Strict"/> only, <see cref="ManifestDriftKind.New"/>
+    /// (a skill with no baseline entry at all).
+    /// </summary>
+    public IReadOnlyList<ManifestDriftFinding> Findings { get; }
+
+    /// <summary>Creates the exception from the offending <paramref name="findings"/> (must be non-empty).</summary>
+    public SkillDriftException(IReadOnlyList<ManifestDriftFinding> findings)
+        : base(BuildMessage(findings))
+    {
+        Findings = findings;
+    }
+
+    private static string BuildMessage(IReadOnlyList<ManifestDriftFinding> findings)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        var changed = findings.Where(f => f.Kind == ManifestDriftKind.Changed).Select(f => f.Key).ToArray();
+        var unknown = findings.Where(f => f.Kind == ManifestDriftKind.New).Select(f => f.Key).ToArray();
+
+        var parts = new List<string>();
+        if (changed.Length > 0)
+        {
+            parts.Add(
+                $"content changed since baseline for [{string.Join(", ", changed)}] (a possible tamper/rug-pull " +
+                "on a skill this agent trusts by construction — re-review the change and, if legitimate, re-approve " +
+                "via 'agenteval skills baseline approve <skill-name>')");
+        }
+
+        if (unknown.Length > 0)
+        {
+            parts.Add(
+                $"no baseline entry at all for [{string.Join(", ", unknown)}] (SkillGateMode.Strict refuses to " +
+                "trust an unrecognized skill by default — approve it via 'agenteval skills baseline approve " +
+                "<skill-name>', or construct with SkillGateMode.Bootstrap to auto-trust unrecognized skills on " +
+                "first sight)");
+        }
+
+        return "UseGatekeeper: SkillGate refused construction — " + string.Join("; ", parts) + ".";
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/SkillGateConstructionCheck.cs
+++ b/src/AgentEval.MAF/Gatekeeper/SkillGateConstructionCheck.cs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+using AgentEval.MAF.Skills;
+using AgentEval.Skills;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// SkillGate Tier 1 — Agent Skills governance moves from audit-time-only (<c>agenteval skills scan</c>) to
+/// enforcement-time: refuses to let an agent construct at all if a skill it will expose has drifted from its
+/// pinned baseline, or (under <see cref="SkillGateMode.Strict"/>) is not recognized at all.
+/// </summary>
+/// <remarks>
+/// <b>Construction-time-only, not a runtime seam — deliberately.</b> This is the THIRD application of the
+/// same pattern already used for skill manifests (<see cref="SkillManifestPoisoningGate"/>, audit-time) and
+/// prompt templates (<see cref="PromptTemplateDriftGate"/>/<see cref="PromptTemplateDriftException"/>,
+/// enforcement-time) — a skill's configured set doesn't change mid-run (an <c>AgentSkillsSource</c> is wired
+/// once at agent construction), so a per-turn check would be pure waste. A long-running server whose skill
+/// FOLDER is modified on disk WHILE already constructed is a narrower, real threat this check cannot catch —
+/// that is the opt-in, per-call Tier 2 gate (a future increment, not built here).
+/// <para>
+/// <b>Two independent hash signals, both optional per skill.</b> The STRUCTURAL fingerprint
+/// (<see cref="SkillManifestPoisoningGate.Fingerprint"/> — name/description/resource-and-script inventory/
+/// allowed-tools/compatibility-length) always applies. The stronger CONTENT hash
+/// (<see cref="SkillContentHasher.HashSkillFolder"/> — every file's actual bytes) additionally applies only
+/// when BOTH the baseline captured a content hash for that skill name AND the current scan resolved that
+/// skill's on-disk folder (file-sourced skills only). A content-only change (a resource file's body edited,
+/// nothing in the frontmatter) would be invisible to the structural fingerprint alone — this is exactly the
+/// gap Wave 1's <see cref="SkillContentHasher"/> was built to close, reused here at enforcement time instead
+/// of only at audit time.
+/// </para>
+/// </remarks>
+public static class SkillGateConstructionCheck
+{
+    /// <summary>
+    /// Loads the baseline at <paramref name="baselinePath"/> (or starts from an empty one if the file does
+    /// not exist yet — see <see cref="SkillGateMode"/> for why an empty baseline under
+    /// <see cref="SkillGateMode.Strict"/> refuses EVERY skill, and how to bootstrap past that on a first-ever
+    /// run), computes drift against <paramref name="skills"/>, and either throws <see cref="SkillDriftException"/>
+    /// or — under <see cref="SkillGateMode.Bootstrap"/> with newly-seen skills — persists an extended baseline
+    /// back to <paramref name="baselinePath"/>.
+    /// </summary>
+    public static void CheckAndEnforce(IReadOnlyList<ScannedSkillInfo> skills, string baselinePath, SkillGateMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(skills);
+        ArgumentException.ThrowIfNullOrWhiteSpace(baselinePath);
+
+        var baseline = LoadOrEmpty(baselinePath);
+        var manifests = skills.Select(s => s.Manifest).ToList();
+        var structural = SkillManifestPoisoningGate.CheckDrift(manifests, baseline);
+
+        var changed = structural.Where(f => f.Kind == ManifestDriftKind.Changed).ToList();
+        var unknown = structural.Where(f => f.Kind == ManifestDriftKind.New).ToList();
+
+        var contentBaseline = baseline.ContentHashesBySkillName ?? EmptyHashes;
+        var contentCurrent = skills
+            .Where(s => s.AbsolutePath is not null && contentBaseline.ContainsKey(s.Manifest.Name))
+            .ToDictionary(s => s.Manifest.Name, s => SkillContentHasher.HashSkillFolder(s.AbsolutePath!), StringComparer.Ordinal);
+        var contentChanged = contentCurrent.Count == 0
+            ? Array.Empty<ManifestDriftFinding>()
+            : ManifestDriftDetector.Detect(contentBaseline, contentCurrent)
+                .Where(f => f.Kind == ManifestDriftKind.Changed)
+                .ToArray();
+
+        var blocking = new List<ManifestDriftFinding>(changed);
+        // A content-only change on a skill the structural pass ALREADY flagged is not reported twice —
+        // the structural finding already names the skill and blocks; a second, differently-worded finding
+        // for the same key would be redundant, not additional information.
+        blocking.AddRange(contentChanged.Where(cf => changed.All(f => f.Key != cf.Key)));
+
+        if (mode == SkillGateMode.Strict)
+        {
+            blocking.AddRange(unknown);
+        }
+
+        if (blocking.Count > 0)
+        {
+            throw new SkillDriftException(blocking);
+        }
+
+        if (mode == SkillGateMode.Bootstrap && unknown.Count > 0)
+        {
+            PersistBootstrappedBaseline(baseline, baselinePath, skills, unknown, contentBaseline);
+        }
+    }
+
+    private static SkillManifestBaseline LoadOrEmpty(string baselinePath)
+    {
+        if (!File.Exists(baselinePath))
+        {
+            return new SkillManifestBaseline(DateTimeOffset.UtcNow, EmptyHashes, ContentHashesBySkillName: EmptyHashes);
+        }
+
+        // Sync I/O is deliberate: UseGatekeeper's whole configure/registration path is synchronous (see
+        // AgentEvalGatekeeperExtensions — the PromptTemplateDrift check reads its inputs from memory only, but
+        // this check, unlike that one, needs to read a FILE, and UseGatekeeper has no async seam to do that
+        // through), matching the same File.ReadAllText/WriteAllText-not-Async choice already used elsewhere in
+        // this builder's synchronous construction path.
+        var json = File.ReadAllText(baselinePath);
+        return SkillManifestBaseline.FromJson(json);
+    }
+
+    private static void PersistBootstrappedBaseline(
+        SkillManifestBaseline baseline,
+        string baselinePath,
+        IReadOnlyList<ScannedSkillInfo> skills,
+        IReadOnlyList<ManifestDriftFinding> unknown,
+        IReadOnlyDictionary<string, string> contentBaseline)
+    {
+        var extendedHashes = new Dictionary<string, string>(baseline.HashesBySkillName, StringComparer.Ordinal);
+        foreach (var finding in unknown)
+        {
+            // CurrentHash is always non-null for a ManifestDriftKind.New finding (Detect only emits New when
+            // the key IS present on the current side) — see ManifestDriftDetector.Detect's own (hasBaseline,
+            // hasCurrent) switch.
+            extendedHashes[finding.Key] = finding.CurrentHash!;
+        }
+
+        var extendedContentHashes = new Dictionary<string, string>(contentBaseline, StringComparer.Ordinal);
+        var unknownNames = new HashSet<string>(unknown.Select(f => f.Key), StringComparer.Ordinal);
+        foreach (var skill in skills)
+        {
+            if (unknownNames.Contains(skill.Manifest.Name) && skill.AbsolutePath is not null)
+            {
+                extendedContentHashes[skill.Manifest.Name] = SkillContentHasher.HashSkillFolder(skill.AbsolutePath);
+            }
+        }
+
+        var updated = baseline with
+        {
+            CapturedAt = DateTimeOffset.UtcNow,
+            HashesBySkillName = extendedHashes,
+            ContentHashesBySkillName = extendedContentHashes.Count > 0 ? extendedContentHashes : baseline.ContentHashesBySkillName,
+        };
+
+        var parentDir = Path.GetDirectoryName(Path.GetFullPath(baselinePath));
+        if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
+        {
+            Directory.CreateDirectory(parentDir);
+        }
+
+        File.WriteAllText(baselinePath, updated.ToJson());
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyHashes = new Dictionary<string, string>();
+}

--- a/src/AgentEval.MAF/Gatekeeper/SkillGateMode.cs
+++ b/src/AgentEval.MAF/Gatekeeper/SkillGateMode.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// How <c>UseGatekeeper</c>'s SkillGate construction-time check handles a skill with NO entry at all in the
+/// pinned baseline — the one case that is genuinely mode-dependent (a CHANGED fingerprint for a skill present
+/// in both sides always blocks, regardless of mode; see <see cref="SkillGateConstructionCheck"/>).
+/// </summary>
+public enum SkillGateMode
+{
+    /// <summary>
+    /// Default. An unrecognized skill (no baseline entry) refuses construction — the same fail-closed
+    /// doctrine <c>CompositeJudgeGate</c>/<c>GateCalibrationHarness.IsInlineReady</c> already apply
+    /// elsewhere in this repo: an unknown skill is not innocent-until-proven-guilty. Recommended for CI and
+    /// production.
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Explicit opt-in. An unrecognized skill is trusted on first sight — auto-added to the baseline (both
+    /// the structural fingerprint and, when the skill's folder is resolvable, the content hash), then the
+    /// UPDATED baseline is written back to the same file <c>UseGatekeeper</c> loaded it from, so the NEXT
+    /// construction (next process start) can detect drift against it. This is the direct enforcement-side
+    /// counterpart of the skills-scan CLI's <c>MatchesPreviouslyVettedCopy</c> trust-on-first-use detector —
+    /// same semantic, made load-bearing here instead of purely informational.
+    /// <para>
+    /// Writes to disk during agent construction — a real side effect, not just a read. Intended for local
+    /// development / a controlled first-ever rollout, not for production processes with concurrent or
+    /// frequent re-construction against the same baseline file (no file locking is applied; a race between
+    /// two processes bootstrapping the same path concurrently can lose one process's newly-trusted entries).
+    /// </para>
+    /// </summary>
+    Bootstrap,
+}

--- a/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/SkillsBaselineCommandTests.cs
@@ -4,7 +4,11 @@
 
 using AgentEval.Cli;
 using AgentEval.Cli.Commands;
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.MAF.Skills;
 using AgentEval.Skills;
+using AgentEval.Testing;
+using Microsoft.Agents.AI;
 using Xunit;
 
 namespace AgentEval.Tests.Cli;
@@ -520,6 +524,111 @@ public class SkillsBaselineCommandTests : IDisposable
             new SkillBaselineEntry("a", SkillSourceKind.File, ".claude/skills/a", "struct-a", "hash-a", null, null, null, []),
         };
         Assert.Empty(SkillsScanCommand.DetectPreviouslyVetted(entries, []));
+    }
+
+    // ── skills baseline approve (SkillGate P1 recapture path) ──
+
+    [Fact]
+    public void Create_BaselineSubcommand_HasApprove()
+    {
+        var baselineCmd = SkillsScanCommand.Create().Subcommands.Single(c => c.Name == "baseline");
+        Assert.Contains(baselineCmd.Subcommands, c => c.Name == "approve");
+    }
+
+    [Fact]
+    public async Task ApproveAsync_NewBaselineFile_CreatesItWithTheSkillsFingerprint()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        var baselinePath = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skillgate-approve-" + Guid.NewGuid().ToString("N") + ".json"));
+        try
+        {
+            var exit = await SkillsScanCommand.ApproveAsync(skillName, dir, baselinePath, note: null, default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+            // File.Exists (static, always live), not baselinePath.Exists (FileInfo caches its stat block from
+            // the first read — which happened, correctly returning false, INSIDE ApproveAsync before the file
+            // was written — and never auto-refreshes; asserting on the same cached instance after the write
+            // would silently check stale state).
+            Assert.True(File.Exists(baselinePath.FullName));
+            var baseline = await SkillManifestBaseline.LoadAsync(baselinePath.FullName);
+            Assert.True(baseline.HashesBySkillName.ContainsKey(skillName));
+            Assert.NotNull(baseline.ContentHashesBySkillName);
+            Assert.True(baseline.ContentHashesBySkillName!.ContainsKey(skillName));
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+            if (File.Exists(baselinePath.FullName)) File.Delete(baselinePath.FullName);
+        }
+    }
+
+    [Fact]
+    public async Task ApproveAsync_UnknownSkillName_ReturnsRuntimeError()
+    {
+        var dir = CreateCompliantFixture(out _);
+        var baselinePath = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skillgate-approve-unknown-" + Guid.NewGuid().ToString("N") + ".json"));
+        try
+        {
+            var exit = await SkillsScanCommand.ApproveAsync("does-not-exist", dir, baselinePath, note: null, default);
+            Assert.Equal(ExitCodes.RuntimeError, exit);
+            Assert.False(File.Exists(baselinePath.FullName));
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    [Fact]
+    public async Task ApproveAsync_ExistingBaseline_UpdatesOnlyTheNamedSkill_LeavesOthersUntouched()
+    {
+        var dir = CreateCompliantFixture(out var skillName);
+        var baselinePath = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skillgate-approve-scoped-" + Guid.NewGuid().ToString("N") + ".json"));
+        try
+        {
+            var untouched = new SkillManifestBaseline(
+                DateTimeOffset.UtcNow.AddDays(-1),
+                new Dictionary<string, string> { ["some-other-skill"] = "unrelated-fingerprint" },
+                ContentHashesBySkillName: new Dictionary<string, string> { ["some-other-skill"] = "unrelated-content-hash" });
+            await untouched.SaveAsync(baselinePath.FullName);
+
+            var exit = await SkillsScanCommand.ApproveAsync(skillName, dir, baselinePath, note: "reviewed by test", default);
+
+            Assert.Equal(ExitCodes.Success, exit);
+            var updated = await SkillManifestBaseline.LoadAsync(baselinePath.FullName);
+            Assert.True(updated.HashesBySkillName.ContainsKey(skillName));
+            Assert.Equal("unrelated-fingerprint", updated.HashesBySkillName["some-other-skill"]);
+            Assert.Equal("unrelated-content-hash", updated.ContentHashesBySkillName!["some-other-skill"]);
+            Assert.Equal("reviewed by test", updated.Notes);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+            if (File.Exists(baselinePath.FullName)) File.Delete(baselinePath.FullName);
+        }
+    }
+
+    [Fact]
+    public async Task ApproveAsync_ThenSkillGateConstructionCheck_KnownUnchanged_DoesNotThrow()
+    {
+        // End-to-end proof of the actual recapture story: approve, then SkillGate's own construction check
+        // (Strict mode, the default) must accept the now-approved skill without throwing.
+        var dir = CreateCompliantFixture(out var skillName);
+        var baselinePath = new FileInfo(Path.Combine(Path.GetTempPath(), "agenteval-skillgate-approve-e2e-" + Guid.NewGuid().ToString("N") + ".json"));
+        try
+        {
+            await SkillsScanCommand.ApproveAsync(skillName, dir, baselinePath, note: null, default);
+
+            AIAgent noOpAgent = new ChatClientAgent(new ScriptedChatClient(), new ChatClientAgentOptions { Name = "test" });
+            var scanned = await MafSkillScanner.ScanFileSkillsWithInfoAsync(dir.FullName, noOpAgent, options: null, default);
+
+            var ex = Record.Exception(() =>
+                SkillGateConstructionCheck.CheckAndEnforce(scanned.Skills, baselinePath.FullName, SkillGateMode.Strict));
+
+            Assert.Null(ex);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+            if (File.Exists(baselinePath.FullName)) File.Delete(baselinePath.FullName);
+        }
     }
 
     // ── helpers (mirrors SkillsScanCommandTests' fixture builder) ──

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/AgentEvalGatekeeperExtensionsTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/AgentEvalGatekeeperExtensionsTests.cs
@@ -4,6 +4,8 @@
 
 using AgentEval.Guardrails;
 using AgentEval.MAF.Gatekeeper;
+using AgentEval.MAF.Skills;
+using AgentEval.Skills;
 using AgentEval.Testing;
 using AgentEval.Tracing;
 using Microsoft.Agents.AI;
@@ -455,6 +457,137 @@ public class AgentEvalGatekeeperExtensionsTests
             }));
 
         Assert.Contains("PromptTemplates", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ── SkillGate Tier 1 (runtime governance), construction-time-only — wiring through UseGatekeeper ──
+    // Core detection-logic coverage lives in SkillGateConstructionCheckTests; these confirm UseGatekeeper
+    // itself wires Skills/SkillBaselinePath/SkillGateMode correctly (half-configuration, opt-in no-op).
+
+    private static ScannedSkillInfo SkillInfo(string name, string description = "desc") =>
+        new(new SkillManifest(name, description, [], [], null, [], SkillSourceKind.File, name), AbsolutePath: null);
+
+    [Fact]
+    public void SkillGate_NotConfigured_DoesNotThrow()
+    {
+        // Opt-in: leaving both Skills and SkillBaselinePath unset must be a complete no-op.
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+
+        var ex = Record.Exception(() =>
+            agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g => g.Add(new ForbiddenToolGate("x"))));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void SkillGate_OnlySkillsSet_NotBaselinePath_ThrowsRatherThanSilentlyNoOp()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+            {
+                g.Add(new ForbiddenToolGate("x"));
+                g.Skills = [SkillInfo("a")];
+                // SkillBaselinePath deliberately left unset.
+            }));
+
+        Assert.Contains("SkillBaselinePath", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SkillGate_OnlyBaselinePathSet_NotSkills_ThrowsRatherThanSilentlyNoOp()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+            {
+                g.Add(new ForbiddenToolGate("x"));
+                g.SkillBaselinePath = Path.Combine(Path.GetTempPath(), "does-not-need-to-exist.json");
+                // Skills deliberately left unset.
+            }));
+
+        Assert.Contains("Skills", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SkillGate_UnknownSkill_StrictDefault_ThrowsAtRegistration_BeforeBuild()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+        var baselinePath = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-wiring-test-" + Guid.NewGuid().ToString("N") + ".json");
+
+        try
+        {
+            var ex = Assert.Throws<SkillDriftException>(() =>
+                agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+                {
+                    g.Add(new ForbiddenToolGate("x"));
+                    g.Skills = [SkillInfo("a")];
+                    g.SkillBaselinePath = baselinePath;
+                    // SkillGateMode left at its default — must be Strict.
+                }));
+
+            Assert.Contains("a", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { if (File.Exists(baselinePath)) File.Delete(baselinePath); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void SkillGate_WithSkillGateFluentSugar_WiresTheSamePropertiesAsSettingThemIndividually()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+        var baselinePath = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-fluent-test-" + Guid.NewGuid().ToString("N") + ".json");
+
+        try
+        {
+            var ex = Assert.Throws<SkillDriftException>(() =>
+                agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+                {
+                    g.Add(new ForbiddenToolGate("x"));
+                    g.WithSkillGate([SkillInfo("a")], baselinePath);
+                }));
+
+            Assert.Contains("a", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { if (File.Exists(baselinePath)) File.Delete(baselinePath); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void SkillGate_BootstrapMode_UnknownSkill_DoesNotThrow()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "x");
+        var agent = BuildAgent(tool, "x", new Dictionary<string, object?>());
+        var baselinePath = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-bootstrap-wiring-" + Guid.NewGuid().ToString("N") + ".json");
+
+        try
+        {
+            var ex = Record.Exception(() =>
+                agent.AsBuilder().UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+                {
+                    g.Add(new ForbiddenToolGate("x"));
+                    g.Skills = [SkillInfo("a")];
+                    g.SkillBaselinePath = baselinePath;
+                    g.SkillGateMode = SkillGateMode.Bootstrap;
+                }));
+
+            Assert.Null(ex);
+            Assert.True(File.Exists(baselinePath));
+        }
+        finally
+        {
+            try { if (File.Exists(baselinePath)) File.Delete(baselinePath); } catch { /* best-effort cleanup */ }
+        }
     }
 
     // ── #2: options.CoverageReport is the AUTHORITATIVE report, computed from the SAME snapshot that's registered ──

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/SkillGateConstructionCheckTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/SkillGateConstructionCheckTests.cs
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.MAF.Skills;
+using AgentEval.Skills;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>
+/// SkillGate Tier 1 (runtime governance, P0+P1) — direct unit coverage for
+/// <see cref="SkillGateConstructionCheck.CheckAndEnforce"/>. End-to-end wiring through <c>UseGatekeeper</c>
+/// lives in <c>AgentEvalGatekeeperExtensionsTests</c>.
+/// </summary>
+public class SkillGateConstructionCheckTests : IDisposable
+{
+    private readonly string _baselinePath;
+
+    public SkillGateConstructionCheckTests()
+    {
+        _baselinePath = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-test-" + Guid.NewGuid().ToString("N") + ".json");
+    }
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_baselinePath)) File.Delete(_baselinePath); } catch { /* best-effort cleanup */ }
+    }
+
+    private static SkillManifest Manifest(string name, string description = "desc") =>
+        new(name, description, [], [], null, [], SkillSourceKind.File, name);
+
+    private static ScannedSkillInfo Scanned(string name, string description = "desc", string? absolutePath = null) =>
+        new(Manifest(name, description), absolutePath);
+
+    // ── Strict mode (default) ──
+
+    [Fact]
+    public void Strict_UnknownSkill_NoBaselineFileYet_Throws()
+    {
+        var ex = Assert.Throws<SkillDriftException>(
+            () => SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Strict));
+
+        var finding = Assert.Single(ex.Findings);
+        Assert.Equal("a", finding.Key);
+        Assert.Equal(ManifestDriftKind.New, finding.Kind);
+        Assert.Contains("a", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("no baseline entry", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Strict_KnownUnchangedSkill_DoesNotThrow()
+    {
+        var baseline = SkillManifestBaseline.Capture([Manifest("a")]);
+        baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+        var ex = Record.Exception(
+            () => SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Strict));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Strict_ChangedSkill_Throws()
+    {
+        var baseline = SkillManifestBaseline.Capture([Manifest("a", "original description")]);
+        baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+        var ex = Assert.Throws<SkillDriftException>(() => SkillGateConstructionCheck.CheckAndEnforce(
+            [Scanned("a", "description changed after trust-pinning")], _baselinePath, SkillGateMode.Strict));
+
+        var finding = Assert.Single(ex.Findings);
+        Assert.Equal("a", finding.Key);
+        Assert.Equal(ManifestDriftKind.Changed, finding.Kind);
+        Assert.Contains("content changed since baseline", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Strict_MultipleUnknownSkills_ThrowsWithAllNames()
+    {
+        var ex = Assert.Throws<SkillDriftException>(() => SkillGateConstructionCheck.CheckAndEnforce(
+            [Scanned("a"), Scanned("b")], _baselinePath, SkillGateMode.Strict));
+
+        Assert.Equal(2, ex.Findings.Count);
+        Assert.Contains("a", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("b", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Strict_RemovedSkill_DoesNotThrow()
+    {
+        // A skill present in the baseline but no longer configured is a REDUCTION of surface, not a rug-pull
+        // — matches PromptTemplateDriftGate's own precedent of ignoring Removed.
+        var baseline = SkillManifestBaseline.Capture([Manifest("a"), Manifest("b")]);
+        baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+        var ex = Record.Exception(
+            () => SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Strict));
+
+        Assert.Null(ex);
+    }
+
+    // ── Bootstrap mode ──
+
+    [Fact]
+    public void Bootstrap_UnknownSkill_DoesNotThrow_AndPersistsBaseline()
+    {
+        SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Bootstrap);
+
+        Assert.True(File.Exists(_baselinePath));
+        var persisted = SkillManifestBaseline.LoadAsync(_baselinePath).GetAwaiter().GetResult();
+        Assert.True(persisted.HashesBySkillName.ContainsKey("a"));
+    }
+
+    [Fact]
+    public void Bootstrap_CreatesParentDirectory_WhenItDoesNotExist()
+    {
+        var nestedPath = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-nested-" + Guid.NewGuid().ToString("N"), "sub", "baseline.json");
+        try
+        {
+            SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], nestedPath, SkillGateMode.Bootstrap);
+            Assert.True(File.Exists(nestedPath));
+        }
+        finally
+        {
+            var top = Path.GetDirectoryName(Path.GetDirectoryName(nestedPath))!;
+            try { Directory.Delete(top, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void Bootstrap_SecondConstructionAfterFirstBootstrap_KnownUnchangedSkill_DoesNotThrow()
+    {
+        SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Bootstrap);
+
+        var ex = Record.Exception(
+            () => SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], _baselinePath, SkillGateMode.Bootstrap));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Bootstrap_SecondConstruction_ChangedSkill_StillThrows()
+    {
+        // Bootstrap only relaxes the UNKNOWN-skill case — a skill already known-and-then-changed always blocks,
+        // regardless of mode. This is the actual tamper signal SkillGate exists to catch.
+        SkillGateConstructionCheck.CheckAndEnforce([Scanned("a", "original")], _baselinePath, SkillGateMode.Bootstrap);
+
+        var ex = Assert.Throws<SkillDriftException>(() => SkillGateConstructionCheck.CheckAndEnforce(
+            [Scanned("a", "tampered after bootstrap")], _baselinePath, SkillGateMode.Bootstrap));
+
+        Assert.Equal(ManifestDriftKind.Changed, Assert.Single(ex.Findings).Kind);
+    }
+
+    [Fact]
+    public void Bootstrap_PreservesExistingEntries_ForSkillsNotInCurrentSet()
+    {
+        var baseline = SkillManifestBaseline.Capture([Manifest("existing")]);
+        baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+        // Only "new-one" is in the current scan — "existing" isn't present, which is a Removed finding
+        // (never blocking, never rewritten) rather than something Bootstrap's persistence should touch.
+        SkillGateConstructionCheck.CheckAndEnforce([Scanned("new-one")], _baselinePath, SkillGateMode.Bootstrap);
+
+        var persisted = SkillManifestBaseline.LoadAsync(_baselinePath).GetAwaiter().GetResult();
+        Assert.True(persisted.HashesBySkillName.ContainsKey("existing"));
+        Assert.True(persisted.HashesBySkillName.ContainsKey("new-one"));
+    }
+
+    // ── Content-hash signal (stronger than the structural fingerprint alone) ──
+
+    [Fact]
+    public void ContentHashDrift_CaughtEvenWhenStructuralFingerprintUnchanged()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-content-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "notes.txt"), "original body");
+            var manifest = Manifest("a");
+            var structuralHash = SkillManifestPoisoningGate.Fingerprint(manifest);
+            // A DIFFERENT (stale/wrong) content hash in the baseline than what's on disk now — simulates a
+            // resource file's bytes having changed since trust-pinning, with the frontmatter left untouched.
+            var baseline = new SkillManifestBaseline(
+                DateTimeOffset.UtcNow,
+                new Dictionary<string, string> { ["a"] = structuralHash },
+                ContentHashesBySkillName: new Dictionary<string, string> { ["a"] = "stale-content-hash-does-not-match-anything" });
+            baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+            var ex = Assert.Throws<SkillDriftException>(() => SkillGateConstructionCheck.CheckAndEnforce(
+                [new ScannedSkillInfo(manifest, dir)], _baselinePath, SkillGateMode.Strict));
+
+            Assert.Equal(ManifestDriftKind.Changed, Assert.Single(ex.Findings).Kind);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ContentHash_NotBaselined_SkillWithFolder_StructuralOnlyStillApplies()
+    {
+        // Baseline never captured a content hash for "a" (e.g. an older baseline, or Tier 1 structural-only
+        // usage) — the content-hash pass must be a no-op for it, not an error or a spurious finding.
+        var dir = Path.Combine(Path.GetTempPath(), "agenteval-skillgate-nocontent-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var manifest = Manifest("a");
+            var baseline = SkillManifestBaseline.Capture([manifest]);   // structural only, no ContentHashesBySkillName
+            baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+            var ex = Record.Exception(() => SkillGateConstructionCheck.CheckAndEnforce(
+                [new ScannedSkillInfo(manifest, dir)], _baselinePath, SkillGateMode.Strict));
+
+            Assert.Null(ex);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ContentHash_NoAbsolutePath_NonFileSkill_SkipsContentCheck_StructuralStillApplies()
+    {
+        var manifest = Manifest("a");
+        var baseline = new SkillManifestBaseline(
+            DateTimeOffset.UtcNow,
+            new Dictionary<string, string> { ["a"] = SkillManifestPoisoningGate.Fingerprint(manifest) },
+            ContentHashesBySkillName: new Dictionary<string, string> { ["a"] = "irrelevant-since-no-folder-to-hash" });
+        baseline.SaveAsync(_baselinePath).GetAwaiter().GetResult();
+
+        // AbsolutePath is null (non-file-sourced skill) — the content pass must skip it, not throw for a
+        // hash it structurally cannot compute.
+        var ex = Record.Exception(() => SkillGateConstructionCheck.CheckAndEnforce(
+            [new ScannedSkillInfo(manifest, AbsolutePath: null)], _baselinePath, SkillGateMode.Strict));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void NullSkills_Throws()
+        => Assert.Throws<ArgumentNullException>(() => SkillGateConstructionCheck.CheckAndEnforce(null!, _baselinePath, SkillGateMode.Strict));
+
+    [Fact]
+    public void EmptyBaselinePath_Throws()
+        => Assert.Throws<ArgumentException>(() => SkillGateConstructionCheck.CheckAndEnforce([Scanned("a")], "", SkillGateMode.Strict));
+}

--- a/tests/AgentEval.Tests/Skills/SkillManifestPoisoningGateTests.cs
+++ b/tests/AgentEval.Tests/Skills/SkillManifestPoisoningGateTests.cs
@@ -107,6 +107,49 @@ public class SkillManifestPoisoningGateTests
     }
 
     [Fact]
+    public void Baseline_ContentHashesBySkillName_DefaultsToNull_NonBreakingForExistingCallers()
+    {
+        // SkillGate addition (additive, optional) — Capture()/every pre-existing constructor call site never
+        // sets it, and must keep compiling and behaving exactly as before.
+        var baseline = SkillManifestBaseline.Capture([Manifest("expense-report", "desc")]);
+        Assert.Null(baseline.ContentHashesBySkillName);
+    }
+
+    [Fact]
+    public void Baseline_JsonRoundTrip_PreservesContentHashes_WhenPresent()
+    {
+        var baseline = new SkillManifestBaseline(
+            DateTimeOffset.UtcNow,
+            new Dictionary<string, string> { ["expense-report"] = "structural-hash" },
+            Notes: "reviewed",
+            ContentHashesBySkillName: new Dictionary<string, string> { ["expense-report"] = "content-hash" });
+
+        var reloaded = SkillManifestBaseline.FromJson(baseline.ToJson());
+
+        Assert.NotNull(reloaded.ContentHashesBySkillName);
+        Assert.Equal("content-hash", reloaded.ContentHashesBySkillName!["expense-report"]);
+    }
+
+    [Fact]
+    public void Baseline_FromJson_OlderJsonWithoutContentHashesField_DeserializesWithNullField()
+    {
+        // A baseline file captured before this field existed (or hand-authored/from an older AgentEval
+        // version) must still load cleanly — the whole point of the field being additive.
+        var olderJson = """
+            {
+              "CapturedAt": "2026-01-01T00:00:00+00:00",
+              "HashesBySkillName": { "expense-report": "structural-hash" },
+              "Notes": null
+            }
+            """;
+
+        var reloaded = SkillManifestBaseline.FromJson(olderJson);
+
+        Assert.Equal("structural-hash", reloaded.HashesBySkillName["expense-report"]);
+        Assert.Null(reloaded.ContentHashesBySkillName);
+    }
+
+    [Fact]
     public async Task Baseline_FileRoundTrip_PreservesHashes()
     {
         var baseline = SkillManifestBaseline.Capture([Manifest("expense-report", "desc")]);


### PR DESCRIPTION
## Summary
Agent Skills governance today is audit-time only (`agenteval skills scan` reports drift after the fact). SkillGate moves it to enforcement-time: `UseGatekeeper` refuses to construct an agent at all if a skill it will expose has drifted from its pinned baseline, or (under the default `SkillGateMode.Strict`) is not recognized at all.

Construction-time-only, not a runtime seam — a skill's configured set doesn't change mid-run, so a per-turn check would be waste. This is the third application of the hash-pin-and-diff pattern already used for skill manifests (`SkillManifestPoisoningGate`) and prompt templates (`PromptTemplateDriftGate`/`PromptTemplateDriftException`) — mirrored closely, no new detection primitive invented.

- `SkillManifestBaseline` gains an optional, additive `ContentHashesBySkillName` field — a stronger signal than the structural fingerprint alone (catches a resource file's bytes changing even when name/description/inventory stay the same).
- New `SkillGateConstructionCheck`: structural + optional content-hash drift, reusing `ManifestDriftDetector`/`SkillManifestPoisoningGate.CheckDrift` as-is.
- New `SkillGateMode`: `Strict` (default, unknown skill = block, same fail-closed doctrine as `CompositeJudgeGate`) vs `Bootstrap` (opt-in, trust-on-first-sight + persists the extended baseline back to disk — the enforcement-side counterpart of Wave 2's `MatchesPreviouslyVettedCopy` detector).
- `GatekeeperOptions.Skills`/`SkillBaselinePath`/`SkillGateMode` + `WithSkillGate(...)` fluent sugar, wired into `UseGatekeeper` with the same fail-loud-on-half-configuration discipline as `PromptTemplates`/`PromptTemplateBaseline`.
- New CLI recapture path: `agenteval skills baseline approve <skill-name> --skill-path <dir> --baseline <path>` — the "I reviewed this legitimate update, trust it again" path after a `SkillDriftException`, scoped to exactly one skill.

**Deliberately out of scope** (per the design doc): cross-location ambiguity (multiple skill directory conventions in one repo) stays a `scan-workspace`/CI concern, not a SkillGate concern — a single agent process resolves skills from one configured source, so there's no cross-location ambiguity to detect at that level. Tier 2 (opt-in per-call drift checking for long-running processes) is a future increment, not built here.

## A bug found and fixed while writing tests
`FileInfo.Exists` caches its stat block from the first read and never auto-refreshes. A test read it (via the same `FileInfo` instance passed into `ApproveAsync`, which read it internally first, correctly as `false`, before the file existed) and then asserted on it again after the file was created — getting the stale cached `false`. Fixed by using the static, always-live `File.Exists` in the affected assertions/cleanup paths.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] 15 new `SkillGateConstructionCheckTests` (Strict/Bootstrap, content-hash drift, half-configured, removed-skill-non-blocking)
- [x] 6 new `UseGatekeeper` wiring tests in `AgentEvalGatekeeperExtensionsTests`
- [x] 5 new CLI `approve` tests in `SkillsBaselineCommandTests`, including an end-to-end approve-then-construction-check proof
- [x] 4 new `SkillManifestBaseline` JSON round-trip tests for the new field (including an older-JSON-without-the-field compatibility test)
- [x] Full solution suite (net8/9/10): all green, 0 regressions (~8000+ tests)
- [x] Self-reviewed: no serialization/full-record-equality blast radius; the one edge case found (duplicate skill names across cross-location sources crashing the reused `ToDictionary` call) is pre-existing behavior in code this PR reuses unchanged, and is explicitly out of scope per the design (§3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro