### PR TITLE
feat(cli): --capture-fixture JSONL capture + log-file to-fixture generator

### DIFF
--- a/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
+++ b/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
@@ -75,7 +75,7 @@ internal static class AzureChatAgentFactory
         try
         {
             var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!), BuildClientOptions());
-            IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
+            IChatClient chatClient = CliChatClientDiagnostics.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
             IEvaluableAgent agent = new ChatClientAgentAdapter(
                 chatClient,
                 name: subject,
@@ -121,7 +121,7 @@ internal static class AzureChatAgentFactory
         try
         {
             var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!), BuildClientOptions());
-            IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
+            IChatClient chatClient = CliChatClientDiagnostics.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "azure-env");
             return (chatClient, deployment, 0);
         }
         catch (Exception ex)

--- a/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
+++ b/src/AgentEval.Cli/Commands/BenchTier1SutResolver.cs
@@ -89,5 +89,5 @@ internal static class BenchTier1SutResolver
     /// abstraction (Part C of the design doc).
     /// </summary>
     internal static IEvaluableAgent BuildFromOpenAiEndpoint(string endpoint, string model, string? apiKey, string subject)
-        => VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint, model, apiKey), "sut").AsEvaluableAgent(name: subject);
+        => CliChatClientDiagnostics.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint, model, apiKey), "sut").AsEvaluableAgent(name: subject);
 }

--- a/src/AgentEval.Cli/Commands/EvalCommand.cs
+++ b/src/AgentEval.Cli/Commands/EvalCommand.cs
@@ -256,7 +256,7 @@ internal static class EvalCommand
                 systemPrompt = await File.ReadAllTextAsync(opts.SystemPromptFile.FullName, ct);
 
             // 3. Create IChatClient → IStreamableAgent
-            chatClient = VerboseLog.Wrap(opts.Azure
+            chatClient = CliChatClientDiagnostics.Wrap(opts.Azure
                 ? EndpointFactory.CreateAzure(opts.Endpoint, opts.DeploymentName!, opts.ApiKey)
                 : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey), "agent");
 
@@ -277,7 +277,7 @@ internal static class EvalCommand
 
         // 5. Create harness (optionally with LLM judge)
         IChatClient? judgeClient = opts.JudgeEndpoint is not null
-            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+            ? CliChatClientDiagnostics.Wrap(EndpointFactory.CreateOpenAICompatible(
                 opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.ApiKey), "judge")
             : null;
         var harness = judgeClient is not null

--- a/src/AgentEval.Cli/Commands/Gatekeeper/GatekeeperModelResolver.cs
+++ b/src/AgentEval.Cli/Commands/Gatekeeper/GatekeeperModelResolver.cs
@@ -41,7 +41,7 @@ internal static class GatekeeperModelResolver
                     return new(null, null, ExitCodes.UsageError);
                 }
 
-                var c = VerboseLog.Wrap(EndpointFactory.CreateAzure(azEndpoint, deploymentName!, apiKey), "judge");
+                var c = CliChatClientDiagnostics.Wrap(EndpointFactory.CreateAzure(azEndpoint, deploymentName!, apiKey), "judge");
                 return new(c, Fingerprint("azure", azEndpoint, deploymentName!), ExitCodes.Success);
             }
 
@@ -53,7 +53,7 @@ internal static class GatekeeperModelResolver
                     return new(null, null, ExitCodes.UsageError);
                 }
 
-                var c = VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint!, model!, apiKey), "judge");
+                var c = CliChatClientDiagnostics.Wrap(EndpointFactory.CreateOpenAICompatible(endpoint!, model!, apiKey), "judge");
                 return new(c, Fingerprint("openai", endpoint, model!), ExitCodes.Success);
             }
 
@@ -66,7 +66,7 @@ internal static class GatekeeperModelResolver
             var envDeployment = Env("AZURE_OPENAI_DEPLOYMENT");
             if (!string.IsNullOrWhiteSpace(envEndpoint) && !string.IsNullOrWhiteSpace(envDeployment))
             {
-                var c = VerboseLog.Wrap(EndpointFactory.CreateAzure(envEndpoint!, envDeployment!, apiKey), "judge");   // apiKey ?? env key, resolved inside
+                var c = CliChatClientDiagnostics.Wrap(EndpointFactory.CreateAzure(envEndpoint!, envDeployment!, apiKey), "judge");   // apiKey ?? env key, resolved inside
                 return new(c, Fingerprint("azure", envEndpoint, envDeployment!), ExitCodes.Success);
             }
 

--- a/src/AgentEval.Cli/Commands/JudgeFactory.cs
+++ b/src/AgentEval.Cli/Commands/JudgeFactory.cs
@@ -84,7 +84,7 @@ internal static class JudgeFactory
             try
             {
                 var azureClient = new AzureOpenAIClient(new Uri(endpoint!), new AzureKeyCredential(apiKey!));
-                IChatClient chatClient = VerboseLog.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "judge");
+                IChatClient chatClient = CliChatClientDiagnostics.Wrap(azureClient.GetChatClient(deployment!).AsIChatClient(), "judge");
                 IEvaluator real = new ChatClientEvaluator(chatClient, systemPrompt);
                 Console.Error.WriteLine(
                     $"✔ Azure OpenAI judge configured — endpoint={endpoint}, deployment={deployment} ({judgeKind})" +

--- a/src/AgentEval.Cli/Commands/LogFileCommand.cs
+++ b/src/AgentEval.Cli/Commands/LogFileCommand.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.Text.Json;
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+
+namespace AgentEval.Cli.Commands;
+
+/// <summary>
+/// The <c>agenteval log-file</c> command group — turns a <c>--capture-fixture</c> JSONL capture into a
+/// deterministic, versionable test fixture. See <see cref="LogFixtureGenerator"/> for the mapping logic this
+/// wraps. <c>replay</c> (comparing a fixture against a live target) is a separate, not-yet-built increment.
+/// </summary>
+internal static class LogFileCommand
+{
+    private static readonly JsonSerializerOptions OutputJsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static Command Create()
+    {
+        var logFileCmd = new Command("log-file", "Utilities for working with --capture-fixture JSONL captures.");
+        logFileCmd.Subcommands.Add(BuildToFixtureCommand());
+        return logFileCmd;
+    }
+
+    private static Command BuildToFixtureCommand()
+    {
+        var toFixtureCmd = new Command(
+            "to-fixture",
+            "Turn a --capture-fixture JSONL capture into a ScriptedFixtureTurn[] JSON array — a deterministic, " +
+            "versionable test fixture (load it with ScriptedChatClient.FromFixture).");
+
+        var capturedArg = new Argument<FileInfo>("captured")
+            { Description = "Path to a JSONL file written by --capture-fixture." };
+        var outOpt = new Option<FileInfo>("--out") { Required = true, Description = "Where to write the generated fixture JSON array." };
+
+        toFixtureCmd.Arguments.Add(capturedArg);
+        toFixtureCmd.Options.Add(outOpt);
+
+        toFixtureCmd.SetAction(async (parseResult, ct) =>
+        {
+            try
+            {
+                return await ToFixtureAsync(parseResult.GetValue(capturedArg)!, parseResult.GetValue(outOpt)!, ct);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"  Error: {ex.Message}");
+                return ExitCodes.RuntimeError;
+            }
+        });
+
+        return toFixtureCmd;
+    }
+
+    internal static async Task<int> ToFixtureAsync(FileInfo captured, FileInfo output, CancellationToken ct)
+    {
+        if (!captured.Exists)
+        {
+            Console.Error.WriteLine($"  Error: capture file not found: {captured.FullName}");
+            return ExitCodes.RuntimeError;
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(captured.FullName, ct).ConfigureAwait(false);
+
+        var parentDir = output.Directory;
+        if (parentDir is not null && !parentDir.Exists)
+        {
+            parentDir.Create();
+        }
+
+        var json = JsonSerializer.Serialize(turns, OutputJsonOptions);
+        await File.WriteAllTextAsync(output.FullName, json, ct).ConfigureAwait(false);
+
+        Console.WriteLine($"  Fixture written: {output.FullName} ({turns.Count} turn(s))");
+        return ExitCodes.Success;
+    }
+
+    /// <summary>Loads a fixture JSON array previously written by <see cref="ToFixtureAsync"/>.</summary>
+    internal static async Task<IReadOnlyList<ScriptedFixtureTurn>> LoadFixtureAsync(string path, CancellationToken ct = default)
+    {
+        var json = await File.ReadAllTextAsync(path, ct).ConfigureAwait(false);
+        return JsonSerializer.Deserialize<IReadOnlyList<ScriptedFixtureTurn>>(json)
+            ?? throw new InvalidOperationException($"Fixture JSON at '{path}' deserialized to null.");
+    }
+}

--- a/src/AgentEval.Cli/Commands/RedTeamCommand.cs
+++ b/src/AgentEval.Cli/Commands/RedTeamCommand.cs
@@ -369,7 +369,7 @@ internal static class RedTeamCommand
         }
         else
         {
-            IChatClient chatClient = VerboseLog.Wrap(opts.Azure
+            IChatClient chatClient = CliChatClientDiagnostics.Wrap(opts.Azure
                 ? EndpointFactory.CreateAzure(opts.Endpoint, opts.DeploymentName!, opts.ApiKey)
                 : EndpointFactory.CreateOpenAICompatible(opts.Endpoint!, opts.Model!, opts.ApiKey), "sut");
 
@@ -491,7 +491,7 @@ internal static class RedTeamCommand
         // 5. Create ScanOptions
         // Per-role keys fall back to the target --api-key so the common single-gateway case stays a one-flag setup.
         IChatClient? judgeClient = opts.JudgeEndpoint is not null
-            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+            ? CliChatClientDiagnostics.Wrap(EndpointFactory.CreateOpenAICompatible(
                 opts.JudgeEndpoint, opts.JudgeModel ?? resolvedName, opts.JudgeApiKey ?? opts.ApiKey), "judge")
             : null;
 
@@ -501,7 +501,7 @@ internal static class RedTeamCommand
 
         // Wave C′: the attacker LLM drives Crescendo/PAIR/TAP. Distinct from the judge (it generates, the judge scores).
         IChatClient? attackerClient = opts.AttackerEndpoint is not null
-            ? VerboseLog.Wrap(EndpointFactory.CreateOpenAICompatible(
+            ? CliChatClientDiagnostics.Wrap(EndpointFactory.CreateOpenAICompatible(
                 opts.AttackerEndpoint, opts.AttackerModel ?? resolvedName, opts.AttackerApiKey ?? opts.ApiKey), "attacker")
             : null;
 

--- a/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
+++ b/src/AgentEval.Cli/CopilotStudio/CopilotStudioRedTeamTarget.cs
@@ -255,7 +255,7 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
         // iUnderstandLiveSideEffects: true is safe here — Validate() (above, in this same class) already
         // enforced --i-understand-live-side-effects before RedTeamCommand ever reaches this Build call.
         var maxCredits = (opts.TargetOptionsFor<CopilotStudioTargetOptions>(Sut) ?? new CopilotStudioTargetOptions()).MaxCredits;
-        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true, maxCredits, c => VerboseLog.Wrap(c, "sut"));
+        return CopilotStudioAgentFactory.BuildLive(EnsureConfig(opts), iUnderstandLiveSideEffects: true, maxCredits, c => CliChatClientDiagnostics.Wrap(c, "sut"));
     }
 
     public void WritePostScanSummary(RedTeamResult result, AgentTrace trace, TextWriter err)
@@ -368,7 +368,7 @@ internal sealed class CopilotStudioRedTeamTarget : IRedTeamBuiltInTarget, ISutTa
             EnsureSutConfig(common, own),
             iUnderstandLiveSideEffects: true,
             (own as CopilotStudioSutOptions ?? common.TargetOptionsFor<CopilotStudioSutOptions>(Sut))?.MaxCredits ?? 0,
-            c => VerboseLog.Wrap(c, "sut"));
+            c => CliChatClientDiagnostics.Wrap(c, "sut"));
 
     private CopilotStudioConfig EnsureSutConfig(CommonTargetOptions common, ISutTargetOptions? own)
     {

--- a/src/AgentEval.Cli/Infrastructure/CliChatClientDiagnostics.cs
+++ b/src/AgentEval.Cli/Infrastructure/CliChatClientDiagnostics.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// The single composing hook every <c>IChatClient</c>-constructing call site in the CLI should route through
+/// — applies <c>--log-file</c> (<see cref="VerboseLog.Wrap"/>) and <c>--capture-fixture</c>
+/// (<see cref="FixtureCapture.Wrap"/>) independently and composably: either, both, or neither may be active
+/// for a given invocation, and each flag's own on/off state is exactly what decides whether ITS wrap is a
+/// no-op — this method never has to know which. Introduced so a new diagnostic sink (this one, and any
+/// future one) doesn't require re-auditing every call site that previously called <see cref="VerboseLog.Wrap"/>
+/// directly.
+/// </summary>
+internal static class CliChatClientDiagnostics
+{
+    /// <summary>Applies every active CLI diagnostic wrap to <paramref name="client"/>, in order.</summary>
+    /// <param name="client">The chat client to observe.</param>
+    /// <param name="label">A short role label (e.g. "sut"/"judge"/"attacker") passed to every active wrap.</param>
+    public static IChatClient Wrap(IChatClient client, string? label = null) =>
+        FixtureCapture.Wrap(VerboseLog.Wrap(client, label), label);
+}

--- a/src/AgentEval.Cli/Infrastructure/FixtureCapture.cs
+++ b/src/AgentEval.Cli/Infrastructure/FixtureCapture.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// The ambient hook every <c>IChatClient</c>-constructing call site in the CLI wraps its result through for
+/// <c>--capture-fixture</c> — sibling to <see cref="VerboseLog"/>, same shape, same lifecycle
+/// (<see cref="Initialize"/> called once in <c>Program.cs</c>). Deliberately a SEPARATE ambient hook from
+/// <see cref="VerboseLog"/>, not a mode on it — a user troubleshooting a one-off failure wants the
+/// human-readable log and nothing else; a user building a regression fixture wants the structured capture and
+/// may not care about the prose log at all. See <see cref="CliChatClientDiagnostics.Wrap"/> for the single
+/// call-site hook that composes both when a caller wants either/both to apply.
+/// </summary>
+internal static class FixtureCapture
+{
+    /// <summary>
+    /// The shared writer for this process, or <see langword="null"/> when <c>--capture-fixture</c> was not
+    /// passed. Always <see cref="TextWriter.Synchronized(TextWriter)"/>-wrapped — see <see cref="VerboseLog.Writer"/>'s
+    /// matching remark for why.
+    /// </summary>
+    public static TextWriter? Writer { get; private set; }
+
+    /// <summary>
+    /// Opens <paramref name="fixturePath"/> for writing (overwriting any prior content) and sets
+    /// <see cref="Writer"/>. Same "a bad path degrades to no capture, it never fails the command" contract as
+    /// <see cref="VerboseLog.Initialize"/> — see its remarks.
+    /// </summary>
+    public static TextWriter? Initialize(string? fixturePath)
+    {
+        Writer?.Dispose();
+        Writer = null;
+
+        if (string.IsNullOrWhiteSpace(fixturePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            var raw = new StreamWriter(fixturePath, append: false) { AutoFlush = true };
+            var synchronized = TextWriter.Synchronized(raw);
+            Writer = synchronized;
+            return synchronized;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            Console.Error.WriteLine($"  Warning: could not open --capture-fixture '{fixturePath}': {ex.Message}. Continuing without fixture capture.");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Wraps <paramref name="client"/> in a <see cref="FixtureCapturingChatClient"/> if fixture capture is
+    /// active; returns it unchanged otherwise. See <see cref="VerboseLog.Wrap"/>'s matching remark for the
+    /// <paramref name="label"/> convention.
+    /// </summary>
+    public static IChatClient Wrap(IChatClient client, string? label = null) =>
+        Writer is null ? client : new FixtureCapturingChatClient(client, Writer, label);
+}

--- a/src/AgentEval.Cli/Infrastructure/FixtureCaptureModels.cs
+++ b/src/AgentEval.Cli/Infrastructure/FixtureCaptureModels.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// One JSONL line written by <see cref="FixtureCapturingChatClient"/> — one COMPLETE round-trip (request +
+/// outcome together), unlike <c>VerboseLoggingChatClient</c>'s human-readable log (which writes a REQUEST
+/// entry and a separate RESPONSE/ERROR/ABANDONED entry). A fixture consumer (<c>log-file to-fixture</c>)
+/// needs each entry to be self-contained, not paired by matching index across two lines.
+/// </summary>
+/// <param name="Index">0-based round-trip index for this client instance (matches <c>VerboseLoggingChatClient</c>'s numbering scheme).</param>
+/// <param name="Label">The optional role label passed to the wrapping call (e.g. "sut"/"judge"/"attacker").</param>
+/// <param name="Kind">One of "response" / "error" / "abandoned" — mirrors <c>VerboseLoggingChatClient</c>'s three outcome kinds.</param>
+/// <param name="TimestampUtc">When this round-trip completed.</param>
+/// <param name="ElapsedMs">Wall-clock duration of the round-trip.</param>
+/// <param name="Request">The exact request sent (full message array — the whole point of this capture, unlike the lossy human-readable log).</param>
+/// <param name="Response">The response received; <see langword="null"/> for "error"/"abandoned".</param>
+/// <param name="Error">The full exception text (<c>Exception.ToString()</c>); <see langword="null"/> except for "error".</param>
+public sealed record FixtureCaptureEntry(
+    int Index,
+    string? Label,
+    string Kind,
+    DateTimeOffset TimestampUtc,
+    long ElapsedMs,
+    FixtureCaptureRequest Request,
+    FixtureCaptureResponse? Response,
+    string? Error);
+
+/// <summary>The exact request sent on one round-trip.</summary>
+public sealed record FixtureCaptureRequest(
+    string? Instructions,
+    FixtureCaptureOptions? Options,
+    IReadOnlyList<FixtureCaptureMessage> Messages);
+
+/// <summary>The subset of <see cref="Microsoft.Extensions.AI.ChatOptions"/> relevant to replay/fixture generation.</summary>
+public sealed record FixtureCaptureOptions(
+    float? Temperature,
+    int? MaxOutputTokens,
+    string? ModelId,
+    IReadOnlyList<FixtureCaptureTool>? Tools);
+
+/// <summary>One tool definition offered on the request.</summary>
+public sealed record FixtureCaptureTool(string Name, string? Description, JsonElement? ParametersSchema);
+
+/// <summary>One message in the request's full history.</summary>
+public sealed record FixtureCaptureMessage(string Role, string? Text);
+
+/// <summary>The response received (only populated when <see cref="FixtureCaptureEntry.Kind"/> is "response").</summary>
+public sealed record FixtureCaptureResponse(
+    string? Text,
+    IReadOnlyList<FixtureCaptureToolCall>? ToolCalls,
+    string? FinishReason,
+    FixtureCaptureUsage? Usage);
+
+/// <summary>One tool call the model emitted.</summary>
+public sealed record FixtureCaptureToolCall(string? CallId, string Name, IDictionary<string, object?>? Arguments);
+
+/// <summary>Token usage, when the response reported any.</summary>
+public sealed record FixtureCaptureUsage(long? InputTokens, long? OutputTokens);

--- a/src/AgentEval.Cli/Infrastructure/FixtureCapturingChatClient.cs
+++ b/src/AgentEval.Cli/Infrastructure/FixtureCapturingChatClient.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// CLI-only decorator behind <c>--capture-fixture &lt;path&gt;</c> — writes every LLM round-trip as a
+/// structured JSONL line, with FULL fidelity (complete message array, complete options, complete response),
+/// for later replay or fixture generation via <c>agenteval log-file to-fixture</c>. Sibling to
+/// <see cref="VerboseLoggingChatClient"/>, NOT a replacement — the two solve different problems
+/// (human troubleshooting vs. faithful replay) and both can be active on the same client at once; see
+/// <see cref="CliChatClientDiagnostics.Wrap"/> for the single call-site hook that composes them.
+/// </summary>
+/// <remarks>
+/// <b>Logs content RAW, with no redaction — same disclosure as <see cref="VerboseLoggingChatClient"/>.</b>
+/// <c>--capture-fixture</c> is opt-in and local-only by design; the file can contain secrets/PII carried in
+/// prompts/responses.
+/// <para><b>Thread safety.</b> Identical contract to <see cref="VerboseLoggingChatClient"/>: this class does
+/// no locking of its own — <see cref="CliChatClientDiagnostics.Wrap"/> always supplies a
+/// <see cref="TextWriter.Synchronized(TextWriter)"/>-wrapped sink.</para>
+/// <para><b>One JSON line per round-trip, request AND outcome together</b> — unlike
+/// <see cref="VerboseLoggingChatClient"/>'s two-writes-per-round-trip (REQUEST then RESPONSE/ERROR/ABANDONED),
+/// a fixture consumer needs each entry to be self-contained, not paired by matching index across two lines.
+/// The request is captured but only written once the outcome (response/error/abandoned) is known.</para>
+/// </remarks>
+public sealed class FixtureCapturingChatClient : DelegatingChatClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
+
+    private readonly TextWriter _sink;
+    private readonly string? _label;
+    private int _index;
+    private bool _writeFailureReported;
+
+    /// <summary>Wraps <paramref name="inner"/>, writing every round-trip to <paramref name="sink"/>.</summary>
+    /// <param name="inner">The chat client to observe.</param>
+    /// <param name="sink">Where to write. See this class's remarks for the thread-safety contract.</param>
+    /// <param name="label">An optional short role label recorded in every entry from this client (e.g. "sut").</param>
+    public FixtureCapturingChatClient(IChatClient inner, TextWriter sink, string? label = null)
+        : base(inner)
+    {
+        _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        _label = string.IsNullOrWhiteSpace(label) ? null : label;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var msgs = messages as IList<ChatMessage> ?? messages.ToList();
+        var i = Interlocked.Increment(ref _index) - 1;
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var resp = await base.GetResponseAsync(msgs, options, cancellationToken).ConfigureAwait(false);
+            sw.Stop();
+            WriteEntry(i, "response", sw.ElapsedMilliseconds, msgs, options, resp, error: null);
+            return resp;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;   // the CALLER's own token fired — a deliberate cancellation, not diagnostically interesting
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            WriteEntry(i, "error", sw.ElapsedMilliseconds, msgs, options, response: null, ex);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages, ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var msgs = messages as IList<ChatMessage> ?? messages.ToList();
+        var i = Interlocked.Increment(ref _index) - 1;
+        var sw = Stopwatch.StartNew();
+        var updates = new List<ChatResponseUpdate>();
+        var terminalEntryWritten = false;
+        await using var enumerator = base.GetStreamingResponseAsync(msgs, options, cancellationToken)
+            .GetAsyncEnumerator(cancellationToken);
+        try
+        {
+            while (true)
+            {
+                ChatResponseUpdate current;
+                try
+                {
+                    if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    current = enumerator.Current;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;   // the caller's own token fired — see GetResponseAsync's matching remark
+                }
+                catch (Exception ex)
+                {
+                    sw.Stop();
+                    WriteEntry(i, "error", sw.ElapsedMilliseconds, msgs, options, response: null, ex);
+                    terminalEntryWritten = true;
+                    throw;
+                }
+
+                updates.Add(current);
+                yield return current;
+            }
+
+            sw.Stop();
+            var resp = updates.Count == 0 ? new ChatResponse() : updates.ToChatResponse();
+            WriteEntry(i, "response", sw.ElapsedMilliseconds, msgs, options, resp, error: null);
+            terminalEntryWritten = true;
+        }
+        finally
+        {
+            // Same "the consumer stopped enumerating early" case VerboseLoggingChatClient guards — see its
+            // matching remark for why this must not be skipped.
+            if (!terminalEntryWritten)
+            {
+                WriteEntry(i, "abandoned", sw.ElapsedMilliseconds, msgs, options, response: null, error: null);
+            }
+        }
+    }
+
+    private void WriteEntry(
+        int index, string kind, long elapsedMs, IList<ChatMessage> messages, ChatOptions? options,
+        ChatResponse? response, Exception? error)
+    {
+        var entry = new FixtureCaptureEntry(
+            index,
+            _label,
+            kind,
+            DateTimeOffset.UtcNow,
+            elapsedMs,
+            BuildRequest(messages, options),
+            response is null ? null : BuildResponse(response),
+            error?.ToString());
+
+        Write(JsonSerializer.Serialize(entry, JsonOptions));
+    }
+
+    private static FixtureCaptureRequest BuildRequest(IList<ChatMessage> messages, ChatOptions? options)
+    {
+        var fixtureOptions = options is null
+            ? null
+            : new FixtureCaptureOptions(
+                options.Temperature,
+                options.MaxOutputTokens,
+                options.ModelId,
+                options.Tools is { Count: > 0 } ? options.Tools.Select(BuildTool).ToList() : null);
+
+        var fixtureMessages = messages.Select(m => new FixtureCaptureMessage(m.Role.Value, m.Text)).ToList();
+        return new FixtureCaptureRequest(options?.Instructions, fixtureOptions, fixtureMessages);
+    }
+
+    private static FixtureCaptureTool BuildTool(AITool tool)
+    {
+        // Only AIFunction carries a JSON schema — a bare AITool (rare; most tools in this codebase are
+        // AIFunction instances) has none to capture, same "honestly report what's there" discipline used
+        // elsewhere in this codebase rather than fabricating a schema.
+        JsonElement? schema = tool is AIFunction f && f.JsonSchema.ValueKind != JsonValueKind.Undefined
+            ? f.JsonSchema
+            : null;
+        return new FixtureCaptureTool(tool.Name, tool.Description, schema);
+    }
+
+    private static FixtureCaptureResponse BuildResponse(ChatResponse response)
+    {
+        var toolCalls = (response.Messages ?? []).SelectMany(m => m.Contents).OfType<FunctionCallContent>()
+            .Select(c => new FixtureCaptureToolCall(c.CallId, c.Name, c.Arguments))
+            .ToList();
+
+        var usage = response.Usage is null
+            ? null
+            : new FixtureCaptureUsage(response.Usage.InputTokenCount, response.Usage.OutputTokenCount);
+
+        return new FixtureCaptureResponse(
+            response.Text,
+            toolCalls.Count > 0 ? toolCalls : null,
+            response.FinishReason?.Value,
+            usage);
+    }
+
+    private void Write(string line)
+    {
+        // Same "a purely diagnostic, opt-in side channel must never break an otherwise-successful command"
+        // discipline as VerboseLoggingChatClient.Write — see its matching remark.
+        try
+        {
+            _sink.WriteLine(line);
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or NotSupportedException or UnauthorizedAccessException)
+        {
+            if (!_writeFailureReported)
+            {
+                _writeFailureReported = true;
+                Console.Error.WriteLine($"  Warning: --capture-fixture write failed ({ex.GetType().Name}: {ex.Message}) — further fixture-capture entries from this client may be incomplete.");
+            }
+        }
+    }
+}

--- a/src/AgentEval.Cli/Infrastructure/LogFixtureGenerator.cs
+++ b/src/AgentEval.Cli/Infrastructure/LogFixtureGenerator.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AgentEval.Testing;
+
+namespace AgentEval.Cli.Infrastructure;
+
+/// <summary>
+/// <c>agenteval log-file to-fixture</c> — reads a <c>--capture-fixture</c> JSONL file (see
+/// <see cref="FixtureCapturingChatClient"/>/<see cref="FixtureCaptureEntry"/>) and emits an array of
+/// <see cref="ScriptedFixtureTurn"/>, ready for <see cref="ScriptedChatClient.FromFixture"/> or to be embedded
+/// literally in a test's <c>fixture.json</c>. A fixture scripts RESPONSES, not requests — the captured
+/// request is what you'd send TO the fixture in a test, not part of it, so everything except each entry's
+/// <see cref="FixtureCaptureEntry.Response"/> is dropped.
+/// </summary>
+public static class LogFixtureGenerator
+{
+    /// <summary>Reads every line of <paramref name="capturedJsonlPath"/> and maps it to a fixture turn.</summary>
+    public static async Task<IReadOnlyList<ScriptedFixtureTurn>> GenerateAsync(
+        string capturedJsonlPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(capturedJsonlPath);
+
+        var lines = await File.ReadAllLinesAsync(capturedJsonlPath, cancellationToken).ConfigureAwait(false);
+        var turns = new List<ScriptedFixtureTurn>();
+        var skippedAbandoned = 0;
+
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var entry = JsonSerializer.Deserialize<FixtureCaptureEntry>(line)
+                ?? throw new InvalidOperationException($"Captured fixture line deserialized to null: {line}");
+
+            switch (entry.Kind)
+            {
+                case "response":
+                    if (entry.Response is null)
+                    {
+                        throw new InvalidOperationException($"'response'-kind entry at index {entry.Index} has no Response.");
+                    }
+
+                    turns.Add(MapResponse(entry.Response));
+                    break;
+                case "error":
+                    turns.Add(new ScriptedFixtureTurn { Throw = ExtractMessage(entry.Error) });
+                    break;
+                case "abandoned":
+                    // No scripted-fixture equivalent for "the stream was abandoned mid-flight" — not silently
+                    // dropped without disclosure, see the summary note below.
+                    skippedAbandoned++;
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown captured entry kind '{entry.Kind}' at index {entry.Index}.");
+            }
+        }
+
+        if (skippedAbandoned > 0)
+        {
+            Console.Error.WriteLine(
+                $"  Note: {skippedAbandoned} 'abandoned' entr{(skippedAbandoned == 1 ? "y" : "ies")} skipped — " +
+                "no scripted-fixture equivalent for a stream abandoned mid-flight.");
+        }
+
+        return turns;
+    }
+
+    private static ScriptedFixtureTurn MapResponse(FixtureCaptureResponse response)
+    {
+        var usage = response.Usage;
+
+        if (response.ToolCalls is { Count: >= 2 })
+        {
+            return new ScriptedFixtureTurn
+            {
+                ToolCalls = response.ToolCalls
+                    .Select(c => new ScriptedFixtureToolCall { ToolCallId = c.CallId, ToolName = c.Name, ToolArgs = c.Arguments })
+                    .ToList(),
+                FinishReason = response.FinishReason,
+                InputTokens = usage?.InputTokens,
+                OutputTokens = usage?.OutputTokens,
+            };
+        }
+
+        if (response.ToolCalls is { Count: 1 })
+        {
+            var call = response.ToolCalls[0];
+            return new ScriptedFixtureTurn
+            {
+                ToolCallId = call.CallId,
+                ToolName = call.Name,
+                ToolArgs = call.Arguments,
+                FinishReason = response.FinishReason,
+                InputTokens = usage?.InputTokens,
+                OutputTokens = usage?.OutputTokens,
+            };
+        }
+
+        return new ScriptedFixtureTurn
+        {
+            Text = response.Text,
+            FinishReason = response.FinishReason,
+            InputTokens = usage?.InputTokens,
+            OutputTokens = usage?.OutputTokens,
+        };
+    }
+
+    // A fixture throw doesn't need to reproduce a real stack trace — the first line of a captured
+    // Exception.ToString() is conventionally "{ExceptionType}: {Message}", a reasonable message-only summary
+    // without this generator needing the capture format to separately carry ex.Message alongside the full text.
+    private static string ExtractMessage(string? fullExceptionText) =>
+        string.IsNullOrEmpty(fullExceptionText) ? "Simulated provider error" : fullExceptionText.Split('\n')[0].TrimEnd('\r');
+}

--- a/src/AgentEval.Cli/Program.cs
+++ b/src/AgentEval.Cli/Program.cs
@@ -708,6 +708,19 @@ var logFileOpt = new Option<string?>("--log-file")
 };
 rootCmd.Options.Add(logFileOpt);
 
+// --capture-fixture: a SEPARATE recursive option from --log-file, not a mode of it — --log-file's format is
+// deliberately lossy (newest-message-only, to avoid O(N²) growth in a multi-turn log); this captures full
+// per-round-trip fidelity as JSONL for later replay/fixture generation via `agenteval log-file to-fixture`.
+// Both can be passed together. Same ambient-writer pattern as --log-file — see FixtureCapture's own remarks.
+var captureFixtureOpt = new Option<string?>("--capture-fixture")
+{
+    Description = "Write a structured JSONL capture of every LLM round-trip (full message array, full response) to " +
+                   "this file, for later replay or fixture generation via 'agenteval log-file to-fixture'. Off by " +
+                   "default. Same raw, UNREDACTED content warning as --log-file. Overwritten on each invocation.",
+    Recursive = true,
+};
+rootCmd.Options.Add(captureFixtureOpt);
+
 // Legacy command surface ported from AgentEvalHQ/AgentEval.Cli v0.2.0-alpha
 // (documentation and CI pipelines depend on these exact names and flags):
 rootCmd.Add(datasetInitCmd);                  // init — scaffold an evaluation dataset
@@ -731,6 +744,11 @@ rootCmd.Add(AgentEval.Cli.Commands.Gatekeeper.GatekeeperCommand.Create());
 // (previously library-only; see Skills-Scan-CLI-Verb-Design.md). Credential-free, offline, static scan.
 rootCmd.Add(SkillsScanCommand.Create());
 
+// `log-file to-fixture` — turns a --capture-fixture JSONL capture into a deterministic, versionable test
+// fixture (ScriptedChatClient.FromFixture).
+rootCmd.Add(LogFileCommand.Create());
+
 var parseResult = rootCmd.Parse(args);
 using var logWriter = VerboseLog.Initialize(parseResult.GetValue(logFileOpt));
+using var fixtureWriter = FixtureCapture.Initialize(parseResult.GetValue(captureFixtureOpt));
 return await parseResult.InvokeAsync();

--- a/src/AgentEval.Core/Testing/ScriptedChatClient.cs
+++ b/src/AgentEval.Core/Testing/ScriptedChatClient.cs
@@ -75,6 +75,27 @@ public sealed class ScriptedChatClient : IChatClient
     public ScriptedChatClient AddThrow(string message = "Simulated provider error")
         => Add(new ScriptedTurn { Throw = message });
 
+    /// <summary>
+    /// Loads a script from data — the counterpart to every <c>Add*</c> method above, which all build the
+    /// queue by hand in C#. Used by <c>agenteval log-file to-fixture</c> (CLI, <c>AgentEval.Cli</c>) to hydrate
+    /// a <see cref="ScriptedChatClient"/> from a captured real conversation
+    /// (<c>--capture-fixture</c> → <see cref="ScriptedFixtureTurn"/>[] JSON), so a real, once-observed
+    /// conversation becomes a deterministic, versionable test fixture. A fresh <see cref="ScriptedChatClient"/>
+    /// is returned (this is a factory, not an instance method) — every existing usage pattern
+    /// (<c>new ScriptedChatClient().AddText(...)</c>) still works unchanged; this is purely additive.
+    /// </summary>
+    public static ScriptedChatClient FromFixture(IEnumerable<ScriptedFixtureTurn> turns)
+    {
+        ArgumentNullException.ThrowIfNull(turns);
+        var client = new ScriptedChatClient();
+        foreach (var turn in turns)
+        {
+            client.Add(turn.ToScriptedTurn());
+        }
+
+        return client;
+    }
+
     /// <inheritdoc />
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
@@ -203,5 +224,69 @@ public sealed class ScriptedToolCall
     public required string ToolName { get; init; }
 
     /// <summary>Tool-call arguments (defaults to empty when null).</summary>
+    public IDictionary<string, object?>? ToolArgs { get; init; }
+}
+
+/// <summary>
+/// A 1:1 serializable mirror of <see cref="ScriptedTurn"/>, for <see cref="ScriptedChatClient.FromFixture"/>.
+/// Exists as a SEPARATE type rather than making <see cref="ScriptedTurn"/> itself serializable because
+/// <see cref="ScriptedTurn.FinishReason"/> is a <see cref="ChatFinishReason"/> (a MEAI extensible-enum struct)
+/// — this type stores it as a plain <see cref="string"/> instead, so a fixture JSON file has no dependency on
+/// how that struct happens to (de)serialize.
+/// </summary>
+public sealed class ScriptedFixtureTurn
+{
+    /// <summary>See <see cref="ScriptedTurn.Text"/>.</summary>
+    public string? Text { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.ToolCallId"/>.</summary>
+    public string? ToolCallId { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.ToolName"/>.</summary>
+    public string? ToolName { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.ToolArgs"/>.</summary>
+    public IDictionary<string, object?>? ToolArgs { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.ToolCalls"/>.</summary>
+    public IReadOnlyList<ScriptedFixtureToolCall>? ToolCalls { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.FinishReason"/> — stored as its raw <see cref="ChatFinishReason.Value"/>.</summary>
+    public string? FinishReason { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.InputTokens"/>.</summary>
+    public long? InputTokens { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.OutputTokens"/>.</summary>
+    public long? OutputTokens { get; init; }
+
+    /// <summary>See <see cref="ScriptedTurn.Throw"/>.</summary>
+    public string? Throw { get; init; }
+
+    /// <summary>Converts this data-only shape into the real <see cref="ScriptedTurn"/> <see cref="ScriptedChatClient"/> consumes.</summary>
+    public ScriptedTurn ToScriptedTurn() => new()
+    {
+        Text = Text,
+        ToolCallId = ToolCallId,
+        ToolName = ToolName,
+        ToolArgs = ToolArgs,
+        ToolCalls = ToolCalls?.Select(c => new ScriptedToolCall { ToolCallId = c.ToolCallId, ToolName = c.ToolName, ToolArgs = c.ToolArgs }).ToList(),
+        FinishReason = FinishReason is null ? null : new ChatFinishReason(FinishReason),
+        InputTokens = InputTokens,
+        OutputTokens = OutputTokens,
+        Throw = Throw,
+    };
+}
+
+/// <summary>A 1:1 serializable mirror of <see cref="ScriptedToolCall"/> — see <see cref="ScriptedFixtureTurn"/>.</summary>
+public sealed class ScriptedFixtureToolCall
+{
+    /// <summary>See <see cref="ScriptedToolCall.ToolCallId"/>.</summary>
+    public string? ToolCallId { get; init; }
+
+    /// <summary>See <see cref="ScriptedToolCall.ToolName"/>.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>See <see cref="ScriptedToolCall.ToolArgs"/>.</summary>
     public IDictionary<string, object?>? ToolArgs { get; init; }
 }

--- a/tests/AgentEval.Tests/Cli/Infrastructure/CliChatClientDiagnosticsTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/CliChatClientDiagnosticsTests.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// The single composing hook every <c>IChatClient</c>-constructing call site routes through — proves
+/// <c>--log-file</c> and <c>--capture-fixture</c> apply independently and composably (either, both, or
+/// neither). Joins "ConsoleTests" — see <see cref="VerboseLogTests"/>'s matching remark; exercises both
+/// <see cref="VerboseLog"/> and <see cref="FixtureCapture"/> static state.
+/// </summary>
+[Collection("ConsoleTests")]
+public class CliChatClientDiagnosticsTests : IDisposable
+{
+    public CliChatClientDiagnosticsTests()
+    {
+        VerboseLog.Initialize(null);
+        FixtureCapture.Initialize(null);
+    }
+
+    public void Dispose()
+    {
+        VerboseLog.Initialize(null);
+        FixtureCapture.Initialize(null);
+    }
+
+    [Fact]
+    public void Wrap_NeitherActive_ReturnsSameInstance_NoOp()
+    {
+        var inner = new ScriptedChatClient();
+        Assert.Same(inner, CliChatClientDiagnostics.Wrap(inner));
+    }
+
+    [Fact]
+    public void Wrap_OnlyLogFileActive_WrapsWithVerboseLoggingOnly()
+    {
+        var logPath = Path.Combine(Path.GetTempPath(), "agenteval-diag-log-" + Guid.NewGuid().ToString("N") + ".log");
+        try
+        {
+            using var logWriter = VerboseLog.Initialize(logPath);
+            var inner = new ScriptedChatClient();
+
+            var wrapped = CliChatClientDiagnostics.Wrap(inner);
+
+            Assert.IsType<VerboseLoggingChatClient>(wrapped);
+        }
+        finally
+        {
+            if (File.Exists(logPath)) File.Delete(logPath);
+        }
+    }
+
+    [Fact]
+    public void Wrap_OnlyCaptureFixtureActive_WrapsWithFixtureCapturingOnly()
+    {
+        var fixturePath = Path.Combine(Path.GetTempPath(), "agenteval-diag-fixture-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            using var fixtureWriter = FixtureCapture.Initialize(fixturePath);
+            var inner = new ScriptedChatClient();
+
+            var wrapped = CliChatClientDiagnostics.Wrap(inner);
+
+            Assert.IsType<FixtureCapturingChatClient>(wrapped);
+        }
+        finally
+        {
+            if (File.Exists(fixturePath)) File.Delete(fixturePath);
+        }
+    }
+
+    [Fact]
+    public async Task Wrap_BothActive_BothObserveTheSameRoundTrip()
+    {
+        var logPath = Path.Combine(Path.GetTempPath(), "agenteval-diag-both-log-" + Guid.NewGuid().ToString("N") + ".log");
+        var fixturePath = Path.Combine(Path.GetTempPath(), "agenteval-diag-both-fixture-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            var logWriter = VerboseLog.Initialize(logPath);
+            var fixtureWriter = FixtureCapture.Initialize(fixturePath);
+            var inner = new ScriptedChatClient().AddText("composed answer");
+
+            var wrapped = CliChatClientDiagnostics.Wrap(inner);
+            // Outermost layer must still be a functioning IChatClient — proves the composition round-trips a
+            // real call through BOTH decorators without either one interfering with the response.
+            var response = await wrapped.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+            Assert.Equal("composed answer", response.Text);
+
+            // Close before reading back — matches VerboseLogTests' own precedent (a StreamWriter's file handle
+            // is still open here; File.ReadAllText would otherwise race an in-progress write / hit a sharing violation).
+            logWriter!.Dispose();
+            fixtureWriter!.Dispose();
+            Assert.Contains("composed answer", File.ReadAllText(logPath), StringComparison.Ordinal);
+            Assert.Contains("composed answer", File.ReadAllText(fixturePath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(logPath)) File.Delete(logPath);
+            if (File.Exists(fixturePath)) File.Delete(fixturePath);
+        }
+    }
+}

--- a/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCaptureTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCaptureTests.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// The ambient <c>--capture-fixture</c> hook — sibling to <see cref="VerboseLog"/>, same shape, same
+/// static-state-leak risk across parallel test classes (see <see cref="VerboseLogTests"/>'s matching remark
+/// for why this joins the same "ConsoleTests" collection).
+/// </summary>
+[Collection("ConsoleTests")]
+public class FixtureCaptureTests : IDisposable
+{
+    public FixtureCaptureTests() => FixtureCapture.Initialize(null);
+
+    public void Dispose() => FixtureCapture.Initialize(null);
+
+    [Fact]
+    public void Initialize_NullPath_WriterStaysNull_AndReturnsNull()
+    {
+        var writer = FixtureCapture.Initialize(null);
+
+        Assert.Null(writer);
+        Assert.Null(FixtureCapture.Writer);
+    }
+
+    [Fact]
+    public void Initialize_EmptyOrWhitespacePath_TreatedAsNotSet()
+    {
+        var writer = FixtureCapture.Initialize("   ");
+
+        Assert.Null(writer);
+        Assert.Null(FixtureCapture.Writer);
+    }
+
+    [Fact]
+    public void Initialize_RealPath_OpensFileAndSetsWriter()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-fixturecapture-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            var writer = FixtureCapture.Initialize(path);
+            Assert.NotNull(writer);
+            Assert.Same(writer, FixtureCapture.Writer);
+            writer!.Write("hello");
+            writer.Dispose();
+
+            Assert.Equal("hello", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Initialize_ReRunOverwritesPriorContent()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-fixturecapture-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            var first = FixtureCapture.Initialize(path);
+            first!.Write("first run content that should be gone");
+            first.Dispose();
+
+            var second = FixtureCapture.Initialize(path);
+            second!.Write("second run");
+            second.Dispose();
+
+            Assert.DoesNotContain("first run", File.ReadAllText(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void Wrap_NoWriterSet_ReturnsSameInstance_NoOp()
+    {
+        FixtureCapture.Initialize(null);
+        var inner = new ScriptedChatClient();
+
+        var wrapped = FixtureCapture.Wrap(inner);
+
+        Assert.Same(inner, wrapped);
+    }
+
+    [Fact]
+    public void Wrap_WriterSet_ReturnsFixtureCapturingChatClient()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "agenteval-fixturecapture-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
+        try
+        {
+            using var writer = FixtureCapture.Initialize(path);
+            var inner = new ScriptedChatClient();
+
+            var wrapped = FixtureCapture.Wrap(inner);
+
+            Assert.IsType<FixtureCapturingChatClient>(wrapped);
+            Assert.NotSame(inner, wrapped);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCapturingChatClientTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCapturingChatClientTests.cs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// The <c>--capture-fixture</c> decorator: writes every LLM round-trip as a structured JSONL line with FULL
+/// fidelity (unlike <c>VerboseLoggingChatClient</c>'s lossy human-readable log). Verified by parsing each
+/// written line back into <see cref="FixtureCaptureEntry"/> and asserting on the structured fields, matching
+/// the format's own structured nature (not text-substring checks).
+/// </summary>
+public class FixtureCapturingChatClientTests
+{
+    private static IList<ChatMessage> Conversation() => new List<ChatMessage>
+    {
+        new(ChatRole.System, "You are a helpful travel agent."),
+        new(ChatRole.User, "Plan a trip to Tokyo."),
+    };
+
+    private static List<FixtureCaptureEntry> ParseLines(string jsonl) =>
+        jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(l => JsonSerializer.Deserialize<FixtureCaptureEntry>(l)!)
+            .ToList();
+
+    [Fact]
+    public async Task GetResponseAsync_WritesOneLine_WithFullMessageArray_NotJustTheNewestMessage()
+    {
+        // The exact gap --log-file's format cannot fill: the WHOLE message array, not "N total (...)" + newest only.
+        var scripted = new ScriptedChatClient().AddText("Sure, here is a plan.", inTok: 42, outTok: 7);
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await client.GetResponseAsync(Conversation(), new ChatOptions { Temperature = 0.2f, ModelId = "gpt-4o-mini" });
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        Assert.Equal("response", entry.Kind);
+        Assert.Equal(0, entry.Index);
+        Assert.Equal(2, entry.Request.Messages.Count);
+        Assert.Equal("system", entry.Request.Messages[0].Role);
+        Assert.Equal("You are a helpful travel agent.", entry.Request.Messages[0].Text);
+        Assert.Equal("user", entry.Request.Messages[1].Role);
+        Assert.Equal("Plan a trip to Tokyo.", entry.Request.Messages[1].Text);
+        Assert.Equal("gpt-4o-mini", entry.Request.Options!.ModelId);
+        Assert.Equal(0.2f, entry.Request.Options.Temperature);
+        Assert.Equal("Sure, here is a plan.", entry.Response!.Text);
+        Assert.Equal("stop", entry.Response.FinishReason);
+        Assert.Equal(42, entry.Response.Usage!.InputTokens);
+        Assert.Equal(7, entry.Response.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ToolCall_CapturesCallIdNameAndArguments()
+    {
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "SearchFlights", new Dictionary<string, object?> { ["to"] = "NRT" });
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await client.GetResponseAsync(Conversation());
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        var call = Assert.Single(entry.Response!.ToolCalls!);
+        Assert.Equal("c1", call.CallId);
+        Assert.Equal("SearchFlights", call.Name);
+        Assert.Equal("NRT", call.Arguments!["to"]!.ToString());
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_ModelThrows_CapturesFullExceptionText_AndRethrows()
+    {
+        var scripted = new ScriptedChatClient().AddThrow("simulated provider outage");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync(Conversation()));
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        Assert.Equal("error", entry.Kind);
+        Assert.Null(entry.Response);
+        Assert.Contains("simulated provider outage", entry.Error, StringComparison.Ordinal);
+        Assert.Contains("InvalidOperationException", entry.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_WritesOneLine_WithAccumulatedResponse()
+    {
+        var scripted = new ScriptedChatClient().AddText("Streamed answer.");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        var chunks = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync(Conversation()))
+        {
+            chunks.Add(update);
+        }
+
+        Assert.NotEmpty(chunks);
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        Assert.Equal("response", entry.Kind);
+        Assert.Equal("Streamed answer.", entry.Response!.Text);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ConsumerBreaksEarly_WritesAbandonedEntry()
+    {
+        var scripted = new ScriptedChatClient().AddText("a streamed answer");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await foreach (var _ in client.GetStreamingResponseAsync(Conversation()))
+        {
+            break;
+        }
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        Assert.Equal("abandoned", entry.Kind);
+        Assert.Null(entry.Response);
+    }
+
+    [Fact]
+    public async Task TwoRoundTrips_UseDistinctIndices()
+    {
+        var scripted = new ScriptedChatClient().AddText("First.").AddText("Second.");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await client.GetResponseAsync(Conversation());
+        await client.GetResponseAsync(Conversation());
+
+        var entries = ParseLines(sink.ToString());
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(0, entries[0].Index);
+        Assert.Equal(1, entries[1].Index);
+    }
+
+    [Fact]
+    public async Task Label_AppearsOnEveryEntry()
+    {
+        var scripted = new ScriptedChatClient().AddText("Answer.");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink, "judge");
+
+        await client.GetResponseAsync(Conversation());
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        Assert.Equal("judge", entry.Label);
+    }
+
+    [Fact]
+    public async Task ToolsOnOptions_CapturedWithNameAndDescription()
+    {
+        var tool = AIFunctionFactory.Create((string x) => x, "search", "Searches for flights.");
+        var scripted = new ScriptedChatClient().AddText("ok");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await client.GetResponseAsync(Conversation(), new ChatOptions { Tools = [tool] });
+
+        var entry = Assert.Single(ParseLines(sink.ToString()));
+        var capturedTool = Assert.Single(entry.Request.Options!.Tools!);
+        Assert.Equal("search", capturedTool.Name);
+        Assert.Equal("Searches for flights.", capturedTool.Description);
+        Assert.NotNull(capturedTool.ParametersSchema);
+    }
+}

--- a/tests/AgentEval.Tests/Cli/Infrastructure/LogFixtureGeneratorTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/LogFixtureGeneratorTests.cs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Cli.Infrastructure;
+
+/// <summary>
+/// <c>agenteval log-file to-fixture</c>'s mapping logic: reads a captured JSONL file and drops everything
+/// except each entry's response, mapping it onto <see cref="ScriptedFixtureTurn"/>. Exercised end-to-end
+/// against real <see cref="FixtureCapturingChatClient"/> output (via <see cref="ScriptedChatClient"/> as the
+/// captured client), not hand-authored JSON — proves the round-trip capture → generate is actually correct,
+/// not just that the mapping function parses a hand-crafted line.
+/// </summary>
+public class LogFixtureGeneratorTests : IDisposable
+{
+    private readonly string _path = Path.Combine(Path.GetTempPath(), "agenteval-logfixturegen-test-" + Guid.NewGuid().ToString("N") + ".jsonl");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_path)) File.Delete(_path); } catch { /* best-effort cleanup */ }
+    }
+
+    private static IList<ChatMessage> Conversation() => new List<ChatMessage> { new(ChatRole.User, "hi") };
+
+    [Fact]
+    public async Task GenerateAsync_TextResponse_MapsToTextTurn()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddText("hello", inTok: 3, outTok: 4), sink);
+            await client.GetResponseAsync(Conversation());
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        var turn = Assert.Single(turns);
+        Assert.Equal("hello", turn.Text);
+        Assert.Equal("stop", turn.FinishReason);
+        Assert.Equal(3, turn.InputTokens);
+        Assert.Equal(4, turn.OutputTokens);
+        Assert.Null(turn.ToolName);
+        Assert.Null(turn.ToolCalls);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SingleToolCallResponse_MapsToSingleToolCallTurn()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(
+                new ScriptedChatClient().AddToolCall("c1", "SearchFlights", new Dictionary<string, object?> { ["to"] = "NRT" }), sink);
+            await client.GetResponseAsync(Conversation());
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        var turn = Assert.Single(turns);
+        Assert.Equal("c1", turn.ToolCallId);
+        Assert.Equal("SearchFlights", turn.ToolName);
+        Assert.Null(turn.ToolCalls);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ParallelToolCallResponse_MapsToToolCallsList()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(
+                new ScriptedChatClient().AddParallelToolCalls(
+                    ("c1", "SearchFlights", new Dictionary<string, object?> { ["to"] = "NRT" }),
+                    ("c2", "SearchHotels", new Dictionary<string, object?> { ["city"] = "Tokyo" })),
+                sink);
+            await client.GetResponseAsync(Conversation());
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        var turn = Assert.Single(turns);
+        Assert.Null(turn.ToolName);   // the single-call trio must stay empty — ToolCalls is the populated path
+        Assert.Equal(2, turn.ToolCalls!.Count);
+        Assert.Contains(turn.ToolCalls, c => c.ToolName == "SearchFlights" && c.ToolCallId == "c1");
+        Assert.Contains(turn.ToolCalls, c => c.ToolName == "SearchHotels" && c.ToolCallId == "c2");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ErrorEntry_MapsToThrowTurn_MessageOnly_NotFullStackTrace()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddThrow("simulated provider outage"), sink);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetResponseAsync(Conversation()));
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        var turn = Assert.Single(turns);
+        Assert.NotNull(turn.Throw);
+        Assert.Contains("simulated provider outage", turn.Throw, StringComparison.Ordinal);
+        Assert.DoesNotContain("at AgentEval", turn.Throw, StringComparison.Ordinal);   // no stack frames, message-line only
+    }
+
+    [Fact]
+    public async Task GenerateAsync_AbandonedEntry_SkippedWithoutThrowing()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddText("a streamed answer"), sink);
+            await foreach (var _ in client.GetStreamingResponseAsync(Conversation()))
+            {
+                break;   // abandon before natural completion
+            }
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        Assert.Empty(turns);   // no exception, no scripted-fixture equivalent for an abandoned stream
+    }
+
+    [Fact]
+    public async Task GenerateAsync_MixedEntries_PreservesOrder()
+    {
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(
+                new ScriptedChatClient().AddText("first").AddToolCall("c1", "search", new Dictionary<string, object?>()), sink);
+            await client.GetResponseAsync(Conversation());
+            await client.GetResponseAsync(Conversation());
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+
+        Assert.Equal(2, turns.Count);
+        Assert.Equal("first", turns[0].Text);
+        Assert.Equal("search", turns[1].ToolName);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_RoundTripsThroughScriptedChatClientFromFixture()
+    {
+        // End-to-end proof: a real captured conversation becomes a fixture that replays identically.
+        using (var sink = new StreamWriter(_path))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddText("a real captured answer"), sink);
+            await client.GetResponseAsync(Conversation());
+        }
+
+        var turns = await LogFixtureGenerator.GenerateAsync(_path);
+        var replay = ScriptedChatClient.FromFixture(turns);
+        var response = await replay.GetResponseAsync(Conversation());
+
+        Assert.Equal("a real captured answer", response.Text);
+    }
+}

--- a/tests/AgentEval.Tests/Cli/LogFileCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/LogFileCommandTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Cli;
+using AgentEval.Cli.Commands;
+using AgentEval.Cli.Infrastructure;
+using AgentEval.Testing;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.Cli;
+
+/// <summary>
+/// <c>agenteval log-file to-fixture</c> — the CLI surface over <see cref="LogFixtureGenerator"/>. Credential-free
+/// (no LLM call — <c>ScriptedChatClient</c> produces the captured input).
+/// </summary>
+public class LogFileCommandTests : IDisposable
+{
+    private readonly string _capturedPath = Path.Combine(Path.GetTempPath(), "agenteval-logfilecmd-captured-" + Guid.NewGuid().ToString("N") + ".jsonl");
+    private readonly string _outPath = Path.Combine(Path.GetTempPath(), "agenteval-logfilecmd-fixture-" + Guid.NewGuid().ToString("N") + ".json");
+
+    public void Dispose()
+    {
+        try { if (File.Exists(_capturedPath)) File.Delete(_capturedPath); } catch { /* best-effort cleanup */ }
+        try { if (File.Exists(_outPath)) File.Delete(_outPath); } catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public void Create_ReturnsLogFileCommand_WithToFixtureSubcommand()
+    {
+        var command = LogFileCommand.Create();
+        Assert.Equal("log-file", command.Name);
+        Assert.Contains(command.Subcommands, c => c.Name == "to-fixture");
+    }
+
+    [Fact]
+    public async Task ToFixtureAsync_RealCapture_WritesFixtureJson_LoadableByScriptedChatClient()
+    {
+        using (var sink = new StreamWriter(_capturedPath))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddText("captured via CLI test"), sink);
+            await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "hi") });
+        }
+
+        var exit = await LogFileCommand.ToFixtureAsync(new FileInfo(_capturedPath), new FileInfo(_outPath), default);
+
+        Assert.Equal(ExitCodes.Success, exit);
+        Assert.True(File.Exists(_outPath));
+
+        var turns = await LogFileCommand.LoadFixtureAsync(_outPath);
+        var replay = ScriptedChatClient.FromFixture(turns);
+        var response = await replay.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "hi") });
+        Assert.Equal("captured via CLI test", response.Text);
+    }
+
+    [Fact]
+    public async Task ToFixtureAsync_MissingCaptureFile_ReturnsRuntimeError()
+    {
+        var exit = await LogFileCommand.ToFixtureAsync(
+            new FileInfo(Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N") + ".jsonl")),
+            new FileInfo(_outPath), default);
+
+        Assert.Equal(ExitCodes.RuntimeError, exit);
+        Assert.False(File.Exists(_outPath));
+    }
+
+    [Fact]
+    public async Task ToFixtureAsync_CreatesOutputParentDirectory_WhenItDoesNotExist()
+    {
+        using (var sink = new StreamWriter(_capturedPath))
+        {
+            var client = new FixtureCapturingChatClient(new ScriptedChatClient().AddText("ok"), sink);
+            await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "hi") });
+        }
+
+        var nestedOut = Path.Combine(Path.GetTempPath(), "agenteval-logfilecmd-nested-" + Guid.NewGuid().ToString("N"), "sub", "fixture.json");
+        try
+        {
+            var exit = await LogFileCommand.ToFixtureAsync(new FileInfo(_capturedPath), new FileInfo(nestedOut), default);
+            Assert.Equal(ExitCodes.Success, exit);
+            Assert.True(File.Exists(nestedOut));
+        }
+        finally
+        {
+            var top = Path.GetDirectoryName(Path.GetDirectoryName(nestedOut))!;
+            try { Directory.Delete(top, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/tests/AgentEval.Tests/Testing/ScriptedChatClientTests.cs
+++ b/tests/AgentEval.Tests/Testing/ScriptedChatClientTests.cs
@@ -172,4 +172,108 @@ public class ScriptedChatClientTests
         Assert.Single(calls);
         Assert.Equal("search", calls[0].Name);
     }
+
+    // ── FromFixture: the data-loading counterpart to every Add* method above ──
+
+    [Fact]
+    public async Task FromFixture_TextTurn_BehavesIdenticallyToAddText()
+    {
+        var client = ScriptedChatClient.FromFixture(new[]
+        {
+            new ScriptedFixtureTurn { Text = "hello from a fixture", FinishReason = "stop", InputTokens = 10, OutputTokens = 5 },
+        });
+
+        var response = await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "hi") });
+
+        Assert.Equal("hello from a fixture", response.Text);
+        Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        Assert.Equal(10, response.Usage!.InputTokenCount);
+        Assert.Equal(5, response.Usage.OutputTokenCount);
+    }
+
+    [Fact]
+    public async Task FromFixture_SingleToolCallTurn_BehavesIdenticallyToAddToolCall()
+    {
+        var client = ScriptedChatClient.FromFixture(new[]
+        {
+            new ScriptedFixtureTurn
+            {
+                ToolCallId = "c1",
+                ToolName = "SearchFlights",
+                ToolArgs = new Dictionary<string, object?> { ["query"] = "tokyo" },
+                FinishReason = "tool_calls",
+            },
+        });
+
+        var response = await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "plan a trip") });
+
+        var call = response.Messages.SelectMany(m => m.Contents).OfType<FunctionCallContent>().Single();
+        Assert.Equal("SearchFlights", call.Name);
+        Assert.Equal("c1", call.CallId);
+        Assert.Equal("tokyo", call.Arguments!["query"]);
+        Assert.Equal(ChatFinishReason.ToolCalls, response.FinishReason);
+    }
+
+    [Fact]
+    public async Task FromFixture_ParallelToolCallsTurn_BehavesIdenticallyToAddParallelToolCalls()
+    {
+        var client = ScriptedChatClient.FromFixture(new[]
+        {
+            new ScriptedFixtureTurn
+            {
+                ToolCalls = new[]
+                {
+                    new ScriptedFixtureToolCall { ToolCallId = "c1", ToolName = "SearchFlights", ToolArgs = new Dictionary<string, object?> { ["to"] = "NRT" } },
+                    new ScriptedFixtureToolCall { ToolCallId = "c2", ToolName = "SearchHotels", ToolArgs = new Dictionary<string, object?> { ["city"] = "Tokyo" } },
+                },
+                FinishReason = "tool_calls",
+            },
+        });
+
+        var response = await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "plan a trip") });
+
+        var calls = response.Messages.SelectMany(m => m.Contents).OfType<FunctionCallContent>().ToList();
+        Assert.Equal(2, calls.Count);
+        Assert.Contains(calls, c => c.Name == "SearchFlights" && c.CallId == "c1");
+        Assert.Contains(calls, c => c.Name == "SearchHotels" && c.CallId == "c2");
+    }
+
+    [Fact]
+    public async Task FromFixture_ThrowTurn_BehavesIdenticallyToAddThrow()
+    {
+        var client = ScriptedChatClient.FromFixture(new[] { new ScriptedFixtureTurn { Throw = "provider down" } });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "hi") }));
+        Assert.Equal("provider down", ex.Message);
+    }
+
+    [Fact]
+    public async Task FromFixture_MultipleTurns_ConsumedInOrder()
+    {
+        var client = ScriptedChatClient.FromFixture(new[]
+        {
+            new ScriptedFixtureTurn { Text = "first" },
+            new ScriptedFixtureTurn { Text = "second" },
+        });
+
+        var r1 = await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "1") });
+        var r2 = await client.GetResponseAsync(new[] { new ChatMessage(ChatRole.User, "2") });
+
+        Assert.Equal("first", r1.Text);
+        Assert.Equal("second", r2.Text);
+    }
+
+    [Fact]
+    public void FromFixture_NullTurns_Throws()
+        => Assert.Throws<ArgumentNullException>(() => ScriptedChatClient.FromFixture(null!));
+
+    [Fact]
+    public void FromFixture_EmptyTurns_ReturnsUsableClient_DefaultBenignResponse()
+    {
+        // Matches the existing "queue empty" contract (a benign empty "stop" response, not a throw) — FromFixture
+        // with zero turns must behave identically to `new ScriptedChatClient()` with nothing added.
+        var client = ScriptedChatClient.FromFixture(Array.Empty<ScriptedFixtureTurn>());
+        Assert.NotNull(client);
+    }
 }


### PR DESCRIPTION
## Summary
`--log-file`'s format is deliberately lossy (newest-message-only, an explicit anti-O(N²) decision from PR #119) — correct for human troubleshooting, wrong shape for replay/fixture generation, which needs the exact message array sent on every round-trip. `AgentTrace`/`TraceRecordingChatClient` (Glass Box) is also unsuitable — it only captures the last user message's text, for a different purpose (audit-trail assembly), and coupling a CLI debugging feature to its schema would entangle two independently-evolving features. A third, narrow, purpose-built JSONL writer is the honest answer.

- New `FixtureCapturingChatClient` (sibling to `VerboseLoggingChatClient`, not a replacement — both can be active at once): one JSONL line per round-trip, request AND outcome together (full message array, full options incl. tool schemas, full response), behind a new `--capture-fixture` root option.
- New `CliChatClientDiagnostics.Wrap` composes `VerboseLog.Wrap` and `FixtureCapture.Wrap` at the single call site every `IChatClient` construction in the CLI already routed through `VerboseLog.Wrap` directly — 14 call sites across 7 files, mechanically renamed (verified: only the function-name token changed at every site, nothing else). `--log-file` and `--capture-fixture` now apply independently and composably wherever either already did.
- New `agenteval log-file to-fixture <captured.jsonl> --out <fixture.json>`: `LogFixtureGenerator` drops everything except each entry's `response` (a fixture scripts responses, not requests) and maps it onto the target this repo's own test suite already uses everywhere — `ScriptedChatClient`, via a new `FromFixture(...)` static factory hydrating the same internal turn queue from a plain `ScriptedFixtureTurn[]` data shape (kept as a separate type from `ScriptedTurn` since `ChatFinishReason` doesn't need a JSON dependency baked into the fixture format).

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] 8 `FixtureCapturingChatClient` tests — parsing captured JSONL back into structured entries, not text-substring checks
- [x] 6 ambient-hook tests (`FixtureCaptureTests`) + 4 composition tests (`CliChatClientDiagnosticsTests`) — joined to the existing `"ConsoleTests"` xUnit collection to avoid the same static-state race `VerboseLogTests` already guards against
- [x] 7 new `ScriptedChatClient.FromFixture` tests — each fixture shape (text/single-tool-call/parallel-tool-calls/throw) proven to behave identically to its `Add*` counterpart
- [x] 7 `LogFixtureGenerator` tests exercised against REAL `FixtureCapturingChatClient` output (not hand-authored JSON), including a full capture → generate → `FromFixture` → replay round-trip
- [x] 4 CLI command tests (`LogFileCommandTests`)
- [x] Full solution suite (net8/9/10): all green, 0 regressions (~8150+ tests)

## Note
`replay` (comparing a fixture against a live target) is a separate, larger increment — not built here. `LogFileCommand.LoadFixtureAsync` exists now (tested, used by this PR's own round-trip test) as the natural counterpart to `ToFixtureAsync`, ready for that later increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro