### PR TITLE
fix(cli,docs,samples): complete the BUG-22 remap + write the missing Explainability & Trust docs

### DIFF
--- a/docs/benchmarks/gdpr/getting-started.md
+++ b/docs/benchmarks/gdpr/getting-started.md
@@ -21,7 +21,7 @@
 
 > **v1 access path.** The GDPR benchmark runs through the `agenteval` CLI binaries and is also available programmatically via NuGet (`using AgentEval.Compliance.Gdpr;`) — see [NuGet samples](../../samples/) for end-to-end consumer tests.
 
-> **Real judging requires all three** of `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_DEPLOYMENT`. If any are unset, the CLI refuses to run (exit code **2**). To exercise the pipeline without LLM cost — smoke-test mode only, **not for CI** — set `AGENTEVAL_ALLOW_STUB_JUDGE=1`. Stub-mode results are deterministic placeholders and **must not** be relied on as compliance evidence. See [CLI Reference — Environment variables](../../cli.md#environment-variables) for the full contract.
+> **Real judging requires all three** of `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_DEPLOYMENT`. If any are unset, the CLI refuses to run (exit code **3** — see [Exit codes](../../cli.md#exit-codes)). To exercise the pipeline without LLM cost — smoke-test mode only, **not for CI** — set `AGENTEVAL_ALLOW_STUB_JUDGE=1`. Stub-mode results are deterministic placeholders and **must not** be relied on as compliance evidence. See [CLI Reference — Environment variables](../../cli.md#environment-variables) for the full contract.
 
 Set up the real judge by exporting the following environment variables before running:
 

--- a/docs/benchmarks/longmemeval/getting-started.md
+++ b/docs/benchmarks/longmemeval/getting-started.md
@@ -94,7 +94,7 @@ Per-type accuracy is available in `report-native.json` under `QuestionResults` (
 
 CLI verdict mapping:
 - `overall_accuracy >= 0.5` → exit 0 (PASS).
-- `overall_accuracy < 0.5` → exit 2 (FAIL).
+- `overall_accuracy < 0.5` → exit 9 (`GateFailed` — see [CLI Reference — Exit codes](../../cli.md#exit-codes)).
 
 Treat the threshold as a defensive smoke-bar, not a published acceptance criterion. The paper baselines for production-quality memory architectures sit substantially above 0.5; calibrate against your own baseline before treating PASS as production-ready.
 

--- a/docs/benchmarks/memory/getting-started.md
+++ b/docs/benchmarks/memory/getting-started.md
@@ -100,7 +100,9 @@ Per-category interpretation:
 | `50 - 69` | Warning — degradation visible; investigate before shipping memory-critical features |
 | `< 50` | Fail — memory architecture is unable to handle the dimension at the preset's pressure level |
 
-CLI exit codes: `PASS` / `WARN` → exit 0 (pass and warn are treated as non-failing for CI), `FAIL` → exit 2.
+CLI exit codes: `PASS` → exit 0, `WARN` → exit 10 (`GateWarning`), `FAIL` → exit 9 (`GateFailed`) — see
+[CLI Reference — Exit codes](../../cli.md#exit-codes). (This previously said WARN maps to exit 0 alongside
+PASS — that was never accurate; WARN has always been non-zero, distinct from a clean PASS.)
 
 ## How to act on findings
 

--- a/docs/benchmarks/mitre/getting-started.md
+++ b/docs/benchmarks/mitre/getting-started.md
@@ -85,7 +85,7 @@ The composite `EvalResult` uses `MinAggregation` over the per-technique leaves �
 | `< 0.5` | `fail` | high / critical | Probes landed reliably; treat as exploit-class regression |
 | `skipped` | `skipped` | none | `NotTested` (applicable but unprobed) or `NotApplicable` (not testable at agent-API layer) |
 
-The CLI exit code mirrors the composite verdict: `pass` → exit 0, anything else (including `warn` and `skipped`) → exit 2 for CI strictness.
+The CLI exit code mirrors the composite verdict: `pass` → exit 0, `fail` → exit 9, `warn` → exit 10, `skipped` → exit 11 (see [CLI Reference — Exit codes](../../cli.md#exit-codes)).
 
 ## How to act on findings
 

--- a/docs/benchmarks/owasp/getting-started.md
+++ b/docs/benchmarks/owasp/getting-started.md
@@ -108,7 +108,7 @@ The composite `EvalResult` uses `MinAggregation` over the 10 OWASP-category leav
 | `< 0.5` | `fail` | high / critical | Probes landed reliably; treat as exploit-class regression |
 | (no probes run) | `skipped` | none | Category appears in the tree for completeness; no signal |
 
-The CLI exit code mirrors the composite verdict: `pass` → exit 0, anything else (including `warn` and `skipped`) → exit 2 for CI strictness.
+The CLI exit code mirrors the composite verdict: `pass` → exit 0, `fail` → exit 9, `warn` → exit 10, `skipped` → exit 11 (see [CLI Reference — Exit codes](../../cli.md#exit-codes)).
 
 ## How to act on findings
 

--- a/docs/benchmarks/perf/getting-started.md
+++ b/docs/benchmarks/perf/getting-started.md
@@ -87,7 +87,7 @@ The composite `EvalResult` aggregates 3 leaves (latency / throughput / cost) via
 | `>= 0.1` | `fail` | high | SLO breach |
 | `< 0.1` | `fail` | critical | Order-of-magnitude breach |
 
-The composite verdict is `pass` when composite score >= 0.6 AND no leaf is labelled `fail`. The CLI exit code mirrors the composite verdict: `pass` → exit 0, anything else → exit 2 for CI strictness.
+The composite verdict is `pass` when composite score >= 0.6 AND no leaf is labelled `fail`. The CLI exit code mirrors the composite verdict: `pass` → exit 0, `fail` → exit 9, `warn` → exit 10, `skipped` → exit 11 (see [CLI Reference — Exit codes](../../cli.md#exit-codes)).
 
 ## How to act on findings
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,12 +54,12 @@ Opt-in escape valve for running benchmarks **without** an Azure OpenAI endpoint.
 | Windows (cmd) | `set AGENTEVAL_ALLOW_STUB_JUDGE=1` |
 | GitHub Actions | `env: AGENTEVAL_ALLOW_STUB_JUDGE: "1"` *(don't — set the AZURE_OPENAI_* secrets instead)* |
 
-**Resolution order** (as of v0.8.1-beta):
+**Resolution order** (as of v0.8.1-beta; exit codes updated for BUG-22, see [Exit codes](#exit-codes)):
 1. Test override (programmatic; not user-visible).
 2. All three `AZURE_OPENAI_*` set → real Azure OpenAI judge.
-3. Any of the three set but not all three → exit 2 with diagnostic.
+3. Any of the three set but not all three → exit 3 (`RuntimeError`) with diagnostic.
 4. None set + `AGENTEVAL_ALLOW_STUB_JUDGE=1` → stub judge (with stderr warning).
-5. None set + no opt-in → exit 2 ("Set AZURE_OPENAI_… or AGENTEVAL_ALLOW_STUB_JUDGE=1").
+5. None set + no opt-in → exit 3 ("Set AZURE_OPENAI_… or AGENTEVAL_ALLOW_STUB_JUDGE=1").
 
 ### `AgentEval__Root`
 

--- a/docs/gatekeeper-cli.md
+++ b/docs/gatekeeper-cli.md
@@ -59,7 +59,8 @@ so `matches` and `redactedText` are **always null** — a secret can never land 
 `--policy warn` forces exit `0` for any Allow/Block/Inconclusive (the verdict is still emitted) — for an advisory CI
 step. It does **not** suppress `2` (a usage/structural error is the caller's malformed input, not a policy outcome) or
 `7` (not certified). Note: `calibrate` returns `0` when a judge is inline-ready, else `1` — distinct from the
-`bench`/compliance `calibrate` verbs (which return `2` on gate-fail), so do not assume the same across commands.
+`bench`/compliance `calibrate` verbs (which return `9` on gate-fail — see [CLI Reference — Exit codes](cli.md#exit-codes)),
+so do not assume the same across commands.
 
 ## Credential-free CI recipe
 

--- a/docs/gatekeeper/explainability-and-trust.md
+++ b/docs/gatekeeper/explainability-and-trust.md
@@ -1,0 +1,102 @@
+# Explainability & Trust
+
+Three primitives that make a Gatekeeper decision reconstructable — WHY a gate decided what it decided, WHAT a
+different configuration would have decided against the same traffic, and HOW to combine several signals into
+one honest composite score. Shipped 2026-07-19 as library APIs, each independently tested; none has a CLI
+command yet (see each section's "Status" note) — the mechanism is real and testable today from code, and a
+CLI wrapper for each is a bounded, low-risk follow-on.
+
+> **Honest scope note.** These are additive to the existing gate primitives documented in the
+> [gate reference](gate-reference.md) and [examples](examples.md) — nothing here changes how an existing gate
+> behaves. `GateVerdictDto`, the JSON contract `gatekeeper inspect` emits, is a **frozen v1 schema** (see its
+> own remarks) that does not yet surface `Confidence` or `Provenance` — both exist in the C# `GateVerdict`
+> today, but reaching them from the CLI's JSON output needs a deliberate, versioned schema bump, not done here.
+
+## Gate provenance chains
+
+`AgentEval.Guardrails.GateProvenance` is a reconstructable "why" behind a `GateVerdict` — richer than the
+existing free-text `Reason` string: which rule fired (`RuleName`), what evidence it saw (`Evidence`), and,
+for a threshold-based gate, the threshold it was compared against versus the actual value observed
+(`Threshold`/`ActualValue`). A `Contributing` list lets a gate that aggregates other gates' findings attach
+their provenance chains too — not populated by anything yet (no aggregating gate is wired), but the shape is
+there for one.
+
+Attached via a new, optional `GateVerdict.Provenance` field — additive, same precedent as the existing
+`Confidence` field: a gate that doesn't populate it behaves exactly as before.
+
+**Wired into:** `CompositeJudgeGate<TRubric>` (the Tribunal primitive — see [gate reference](gate-reference.md)),
+for both the Block path and the near-miss-Allow-with-Confidence path Fleet Correlation already reads.
+
+```csharp
+var verdict = await judgeGate.InspectAsync(text);
+if (verdict.Provenance is { } why)
+{
+    Console.WriteLine($"Rule: {why.RuleName}");
+    Console.WriteLine($"Threshold {why.Threshold} vs actual {why.ActualValue}");
+    Console.WriteLine($"Evidence: {string.Join(", ", why.Evidence)}");
+}
+```
+
+**Status:** wired into one gate (`CompositeJudgeGate`). Deterministic (regex/keyword) gates and
+`FleetCorrelator`-level chain aggregation across a whole session are natural follow-ons, not done yet.
+
+## Counterfactual gate replay
+
+"What would a DIFFERENT tool-gate configuration have done to this SAME captured traffic?"
+`AgentEval.MAF.Gatekeeper.GateReplayer.CompareAsync` runs a baseline and a candidate list of the REAL
+`IToolGate` objects — not a simulation — against the same captured `GatedToolCall`s, using the identical
+sequential, first-Block/Mutate-wins semantics the live `UseAgentEvalToolGate` pipeline applies. A divergence
+found here is exactly what would have happened had the candidate configuration been live at capture time.
+
+```csharp
+var comparison = await GateReplayer.CompareAsync(capturedCalls, baseline: currentGates, candidate: proposedGates);
+foreach (var row in comparison.Diverged)
+{
+    Console.WriteLine($"{row.Call.FunctionName}: {row.Baseline.Action} -> {row.Candidate.Action}");
+}
+```
+
+Tool gates are pure/bounded by construction (`GateCost.PureCode`/`GateCost.Bounded` — `UseAgentEvalToolGate`
+itself refuses `Network`/`Llm` gates inline), so replaying them against already-captured calls needs no
+network call and no live agent.
+
+**Status:** library API only. Getting `GatedToolCall`s to replay against currently means capturing them
+yourself (e.g. from a `AgentTrace`, or reconstructing them from a `--capture-fixture` JSONL capture — see
+[CLI Reference](../cli.md#agenteval-log-file)). A `agenteval log-file gate-replay` command wiring this
+directly to a capture file is the natural, mechanical next step — not built yet.
+
+## Unified Trust Score
+
+A single honest composite across gate verdicts and eval scores. The naive approach — average everything,
+including gaps — is exactly the trap `WeightedSumAggregation`'s own comment warns against: *"including
+\[skipped/error] at 0.0 would incorrectly drag the composite below threshold."* `AgentEval.Trust.
+TrustScoreCalculator.Compute` applies the same exclusion discipline already used across this repo's
+aggregation strategies (`WeightedSumAggregation`/`WeightedMedianAggregation`/`MinAggregation`/
+`MajorityVoteAggregation`) to a cross-cutting mix of signal SOURCES, not just sub-evals of one eval tree.
+
+```csharp
+var signals = new[]
+{
+    new TrustSignal("gate:injection", Score: verdict.Action == GateAction.Allow ? 1.0 : 0.0, Weight: 2),
+    new TrustSignal("eval:groundedness", Score: evalResult.Score.Value, Weight: 1),
+    new TrustSignal("eval:timed-out", Score: 0.0, Weight: 5, Label: "error"),   // excluded, not zero-scored
+};
+var trust = TrustScoreCalculator.Compute(signals);
+Console.WriteLine($"{trust.Explanation}");   // "Composite trust score 87/100 from 2/3 signal(s) measured; excluded: eval:timed-out (error) (never scored as distrust)."
+```
+
+A signal's `Label` uses the same `"measured"`/`"skipped"`/`"error"` vocabulary `EvalScore.Label` already
+uses — a `"skipped"` or `"error"` signal is excluded from the weighted math entirely, never scored at 0.0. A
+missing/excluded signal is never silently treated as fully trusted either — `SignalsMeasured`/`SignalsTotal`
+report exactly how much of the intended signal set actually contributed, and `Score` is `null` (not `0`)
+when nothing could be scored at all.
+
+**Status:** library API only, no CLI/report wiring. There is no built-in helper yet to turn a `GateVerdict` or
+an `EvalResult` into a `TrustSignal` automatically — the caller constructs the list today.
+
+## Related
+
+- [Gate reference](gate-reference.md) — every built-in gate, including `CompositeJudgeGate`'s Tribunal role.
+- [Examples](examples.md) — the general `UseGatekeeper(enforcement, configure)` wiring pattern.
+- [CLI Reference — Exit codes](../cli.md#exit-codes) — the BUG-22 exit-code split (`9`/`10`/`11` for
+  benchmark gate outcomes) this same session also shipped, a related but separate honesty fix.

--- a/docs/gatekeeper/introduction.md
+++ b/docs/gatekeeper/introduction.md
@@ -161,6 +161,7 @@ The [**Gate reference**](gate-reference.md) ranks every gate on exactly this bas
 
 - [**Gate reference**](gate-reference.md) — the ranked catalogue (what each gate does + how useful it is).
 - [**Examples**](examples.md) — runnable cookbook (the samples drive a real model — need Azure OpenAI) + a credential‑free CLI on‑ramp.
+- [**Explainability & Trust**](explainability-and-trust.md) — reconstructable gate provenance, counterfactual gate-config replay, and a unified Trust Score.
 - [Glass Box](../glass-box.md) — the dual‑boundary trace Gatekeeper records its evidence into.
 - [Guardrails](../guardrails.md) — the chat‑gate primitives (`IChatGate`, `EvalGatePolicy`) the run gate reuses.
 - [Red Team](../redteam.md) — the probes and canaries the moat gates are built from.

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -22,7 +22,7 @@ cd samples/AgentEval.Samples
 dotnet run
 ```
 
-The interactive menu organises samples into **groups (A–K)**. Select a group letter, then a sample number.
+The interactive menu organises samples into **groups (A–L)**. Select a group letter, then a sample number.
 You can also run a specific sample directly from the command line by its **legacy index** (1-based across the flat sample list, A1=1, A7=7, B1=8, …):
 
 ```bash
@@ -197,6 +197,20 @@ directory at build time — see the `.csproj` — never duplicated in source).
 | 2 | **Disclosure Efficiency** | Free structural metric (`SkillDisclosureEfficiencyMetric`) scoring the load→read→run funnel — order validity, redundant loads | Yes | 2 min |
 | 3 | **Compliance Scanner** | Static `SKILL.md` + governance-flag scan (`MafSkillScanner`) — offline, no model call in the scan itself | Yes | 1 min |
 | 4 | **Skill Security Index** | Compliance + Efficiency joined into one composite 0–100 score (`SkillSecurityIndex`) — a missing axis (security, not exercised here) is never faked as perfect | Yes | 2 min |
+| 5 | **SkillGate** | Construction-time drift enforcement (`UseGatekeeper` + `WithSkillGate`) — pins a baseline, simulates a rug-pull, `SkillDriftException` fails construction closed, then recovers | Yes | 3 min |
+
+---
+
+### L — Copilot Studio  🔑 real MCS agent — set `COPILOTSTUDIO_CONFIG_PATH` + `COPILOTSTUDIO_I_UNDERSTAND_LIVE_SIDE_EFFECTS=true`
+
+Red-teams and asserts against a **live Microsoft Copilot Studio (MCS) agent** — see
+[docs/redteam/copilot-studio.md](../../docs/redteam/copilot-studio.md) for the full connector doc, the
+consent-flag rationale, and the honest fidelity-ceiling disclosure (text-only; no tool-call evidence).
+
+| # | Sample | What It Exercises | Azure? | Time |
+|---|--------|-------------------|--------|------|
+| 1 | **Live Walkthrough** | `CopilotStudioAssertions` fluent API, multi-turn conversation continuity, Gatekeeper (`UseEvalGate`) composing over a live MCS agent exactly like any other `IChatClient` | No (MCS creds instead) | 5 min |
+| 2 | **Budget + Red Team** | A tight `--max-credits`-equivalent cap tripping `CopilotStudioBudgetExceededException` for real, `HaveStayedWithinCreditBudget`, `CanResistAsync` red-teaming a live MCS agent (same one-liner as an Azure OpenAI agent), `HaveStartedNewConversation`/`HaveStartedDifferentConversation` | No (MCS creds instead) | 6 min |
 
 ---
 

--- a/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
+++ b/src/AgentEval.Cli/Commands/AzureChatAgentFactory.cs
@@ -69,7 +69,7 @@ internal static class AzureChatAgentFactory
                 "✖ --azure-from-env was passed but the following env vars are not set: " +
                 string.Join(", ", missing) +
                 "\n  Set all three and retry, or drop --azure-from-env to use the built-in stub agent.");
-            return (null, 2);
+            return (null, ExitCodes.RuntimeError);
         }
 
         try
@@ -89,7 +89,7 @@ internal static class AzureChatAgentFactory
             Console.Error.WriteLine(
                 $"✖ Failed to construct Azure OpenAI agent: {ex.Message}\n" +
                 "  Check AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_API_KEY / AZURE_OPENAI_DEPLOYMENT values.");
-            return (null, 2);
+            return (null, ExitCodes.RuntimeError);
         }
     }
 
@@ -115,7 +115,7 @@ internal static class AzureChatAgentFactory
             Console.Error.WriteLine(
                 "✖ Azure OpenAI not configured. Missing: " + string.Join(", ", missing) +
                 "\n  This benchmark requires a real LLM and cannot fall back to a stub.");
-            return (null, null, 2);
+            return (null, null, ExitCodes.RuntimeError);
         }
 
         try
@@ -127,7 +127,7 @@ internal static class AzureChatAgentFactory
         catch (Exception ex)
         {
             Console.Error.WriteLine($"✖ Failed to construct Azure OpenAI chat client: {ex.Message}");
-            return (null, null, 2);
+            return (null, null, ExitCodes.RuntimeError);
         }
     }
 

--- a/src/AgentEval.Cli/Commands/BenchLongMemEvalCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchLongMemEvalCommand.cs
@@ -236,6 +236,6 @@ public static class BenchLongMemEvalCommand
             return 1;
         }
 
-        return result.OverallAccuracy >= 0.5 ? 0 : 2;
+        return result.OverallAccuracy >= 0.5 ? ExitCodes.Success : ExitCodes.GateFailed;
     }
 }

--- a/src/AgentEval.Cli/Commands/BenchPerfCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchPerfCommand.cs
@@ -225,12 +225,9 @@ public static class BenchPerfCommand
         Console.WriteLine($"Overall result: composite verdict {result.Score.Label.ToUpperInvariant()} " +
             $"(score {result.Score.Value:F3})");
 
-        return result.Score.Label.ToLowerInvariant() switch
-        {
-            "pass" => 0,
-            "fail" => 2,
-            _ => 2
-        };
+        // Reuse fix (BUG-22 follow-up): was an inlined duplicate of BenchExitCodes.FromLabel
+        // (identical pass=>0/fail=>2/_=>2 mapping, now split 9/10/11 — see that class's own remarks).
+        return BenchExitCodes.FromLabel(result.Score.Label);
     }
 
     /// <summary>

--- a/src/AgentEval.Cli/Commands/BenchTraceFidelityCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchTraceFidelityCommand.cs
@@ -130,7 +130,7 @@ public static class BenchTraceFidelityCommand
             Console.WriteLine();
             Console.WriteLine($"   Run ID: {runId}");
             Console.WriteLine($"   Canonical: {runDir}");
-            return result.Score.Passed ? 0 : 2;
+            return result.Score.Passed ? ExitCodes.Success : ExitCodes.GateFailed;
         }
         catch (Exception ex)
         {

--- a/tests/AgentEval.Tests/Benchmarks/BenchPerfCommandTests.cs
+++ b/tests/AgentEval.Tests/Benchmarks/BenchPerfCommandTests.cs
@@ -32,8 +32,8 @@ public class BenchPerfCommandTests
                 agentOverride: stubAgent);
 
             // Assert: exit code is 0 (pass) or 2 (warn/fail), not 1 (CLI error).
-            Assert.True(exitCode == 0 || exitCode == 2,
-                $"Expected exit code 0 (pass) or 2 (warn/fail), got {exitCode}.");
+            Assert.True(exitCode is 0 or 9 or 10 or 11,
+                $"Expected exit code 0 (pass), 9 (FAIL), 10 (WARN) or 11 (indeterminate), got {exitCode}.");
 
             // Confirm a run was persisted into .agenteval/ — runs live under
             // .agenteval/subjects/{subject}/runs/{runId}/.
@@ -69,8 +69,8 @@ public class BenchPerfCommandTests
                 rootOverride: workspace,
                 agentOverride: stubAgent);
 
-            Assert.True(exitCode == 0 || exitCode == 2,
-                $"Expected exit 0/2, got {exitCode} — a divergent report path made the run fail.");
+            Assert.True(exitCode is 0 or 9 or 10 or 11,
+                $"Expected exit 0/9/10/11, got {exitCode} — a divergent report path made the run fail.");
 
             // Exactly one run was persisted; the report must live in that same run dir.
             var subjectsDir = Path.Combine(workspace, ".agenteval", "subjects");

--- a/tests/AgentEval.Tests/Cli/AzureChatAgentFactoryTests.cs
+++ b/tests/AgentEval.Tests/Cli/AzureChatAgentFactoryTests.cs
@@ -10,7 +10,7 @@ namespace AgentEval.Tests.Cli;
 
 /// <summary>
 /// Pins the T0.2 honest fix for the "CLI scans stub agents" gap. The factory must:
-/// 1) refuse to build when any of the 3 required env vars is missing (returns exit code 2);
+/// 1) refuse to build when any of the 3 required env vars is missing (returns exit code 3, RuntimeError — BUG-22);
 /// 2) print a precise error naming the missing vars;
 /// 3) document its env-var convention identical to <see cref="JudgeFactory"/>'s.
 /// </summary>
@@ -28,7 +28,7 @@ namespace AgentEval.Tests.Cli;
 public class AzureChatAgentFactoryTests
 {
     [Fact]
-    public void TryBuildFromEnv_AllVarsMissing_ReturnsExitCode2WithFriendlyError()
+    public void TryBuildFromEnv_AllVarsMissing_ReturnsExitCode3WithFriendlyError()
     {
         // Arrange — clear all 3 vars
         using var _ = TempEnvVars(("AZURE_OPENAI_ENDPOINT", null), ("AZURE_OPENAI_API_KEY", null), ("AZURE_OPENAI_DEPLOYMENT", null));
@@ -42,7 +42,7 @@ public class AzureChatAgentFactoryTests
 
             // Assert — null agent, exit 2, error names all 3 missing vars
             Assert.Null(agent);
-            Assert.Equal(2, exitCode);
+            Assert.Equal(3, exitCode);
             var err = stderr.ToString();
             Assert.Contains("AZURE_OPENAI_ENDPOINT", err);
             Assert.Contains("AZURE_OPENAI_API_KEY", err);
@@ -70,7 +70,7 @@ public class AzureChatAgentFactoryTests
             var (agent, exitCode) = AzureChatAgentFactory.TryBuildFromEnv("TestSubject");
 
             Assert.Null(agent);
-            Assert.Equal(2, exitCode);
+            Assert.Equal(3, exitCode);
             var err = stderr.ToString();
             Assert.DoesNotContain("AZURE_OPENAI_ENDPOINT", err); // endpoint IS set, so should NOT be in the missing list
             Assert.Contains("AZURE_OPENAI_API_KEY", err);


### PR DESCRIPTION
## Summary

Self-review of PR #131 found real, concrete gaps in that work — this closes them.

- **2 more commands had the exact BUG-22 pattern PR #131 was supposed to unify**: `BenchTraceFidelityCommand.cs` (a separate command from `BenchWorkflowTraceFidelityCommand.cs`, which *was* fixed) and `BenchPerfCommand.cs` (now delegates to the shared `BenchExitCodes.FromLabel` instead of reimplementing it).
- **`AzureChatAgentFactory.cs`** — the SUT-agent-resolution counterpart to `JudgeFactory.cs` — had the identical config-resolution-conflated-with-usage-error bug across 4 return sites, missed entirely in PR #131.
- **8 more doc files** described the old exit-code contract: `docs/cli.md`'s resolution-order prose, `docs/gatekeeper-cli.md`'s cross-reference, and 6 getting-started pages (gdpr/memory/longmemeval/mitre/owasp/perf). One (memory) was actually wrong even *before* BUG-22.
- **Wrote the missing docs page** for the Explainability & Trust library code PR #131 shipped without any `docs/` coverage: `docs/gatekeeper/explainability-and-trust.md`.
- **Updated `samples/AgentEval.Samples/README.md`**, which never listed the Copilot Studio group at all and was missing the new SkillGate sample.

## Test plan

- [x] Full solution build clean across net8.0/net9.0/net10.0
- [x] Full `AgentEval.Tests` suite green: net8 8064/8064, net9 8064/8064, net10 8267/8267 (2 pre-existing skips)
- [x] Updated `AzureChatAgentFactoryTests` + `BenchPerfCommandTests` assertions for the corrected exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro