### PR TITLE
docs: add agent-skills.md and explainability-and-trust.md to the site nav

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -56,6 +56,8 @@
     href: gatekeeper/examples.md
   - name: Attack the Gate
     href: gatekeeper/attack-the-gate.md
+  - name: Explainability & Trust
+    href: gatekeeper/explainability-and-trust.md
 
 - name: Evaluation Coverage
   items:
@@ -66,6 +68,8 @@
       href: redteam-whats-new.md
     - name: Copilot Studio (--sut copilot-studio)
       href: redteam/copilot-studio.md
+  - name: Agent Skills
+    href: agent-skills.md
   - name: Responsible AI
     href: ResponsibleAI.md
   - name: Memory Evaluation


### PR DESCRIPTION
## Summary

- \`docs/toc.yml\` (the real docfx site navigation) never included \`docs/agent-skills.md\` — a pre-existing gap, found while doing a scored docs/samples review, unrelated to recent work. \`docs/index.md\`'s landing-page card list mentions it, but that's a separately-maintained list, not the actual sidebar nav.
- The newly-added \`docs/gatekeeper/explainability-and-trust.md\` had the same problem — reachable only via one in-content cross-link, not the nav.
- Verified via a full orphan-hunt (every \`toc.yml\` href diffed against all 101 \`docs/**/*.md\` files): no other gaps outside \`docs/adr/\`, which looks deliberately excluded from the public nav.

## Test plan

- [x] \`docs/toc.yml\` re-validated as well-formed YAML after the edit
- [x] Docs-only change, no source/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro