### PR TITLE
chore(samples,ci): refresh NuGetConsumer to 0.16.0-beta, extend docs-drift check, update CHANGELOG

### DIFF
--- a/.github/workflows/docs-toc-check.yml
+++ b/.github/workflows/docs-toc-check.yml
@@ -1,8 +1,10 @@
 name: Docs nav completeness
 
 # Catches the exact bug found 2026-07-19: a new docs/**/*.md file that's never added to docs/toc.yml (the
-# real docfx site navigation) ships invisible in the sidebar. Deliberately separate from docs.yml (which
-# builds + deploys the site) so this stays fast and runs on every PR, not just pushes to main.
+# real docfx site navigation) ships invisible in the sidebar. Also catches the reverse drift: docs/index.md's
+# landing page linking to a page that's since been removed from toc.yml, or never added. Deliberately
+# separate from docs.yml (which builds + deploys the site) so this stays fast and runs on every PR, not just
+# pushes to main.
 on:
   pull_request:
     paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs/samples hardening follow-up + NuGetConsumer refresh to 0.16.0-beta
+
+A self-review of the BUG-22/Explainability & Trust batch below found real gaps and closed them, then a
+follow-on pass brought the Skills/Copilot Studio/Explainability & Trust docs and samples to full parity and
+refreshed the NuGet consumer samples.
+
+#### Fixed — completing the BUG-22 remap
+- **`BenchTraceFidelityCommand.cs`** and **`BenchPerfCommand.cs`** each independently hardcoded the exact
+  same gate-fail-as-exit-2 pattern the BUG-22 fix below was supposed to have unified everywhere — missed in
+  the first pass. `BenchPerfCommand` now delegates to the shared `BenchExitCodes.FromLabel` instead of
+  reimplementing it; both return `GateFailed` (9) on a hard fail.
+- **`AzureChatAgentFactory.cs`** — the SUT-agent-resolution counterpart to `JudgeFactory.cs` — had the
+  identical config-resolution-conflated-with-usage-error bug across 4 return sites, also missed. Now returns
+  `RuntimeError` (3).
+- 8 more docs described the old exit-code contract and were never updated: `docs/cli.md`'s resolution-order
+  prose, `docs/gatekeeper-cli.md`'s cross-reference, and 6 getting-started pages (gdpr/memory/longmemeval/
+  mitre/owasp/perf). One (`memory`) was actually wrong even *before* BUG-22 — it claimed WARN mapped to exit
+  0 alongside PASS, which was never true.
+
+#### Added — docs, mirroring the missing coverage
+- `docs/gatekeeper/explainability-and-trust.md` — the docs page the Explainability & Trust library code below
+  had shipped without any `docs/` coverage at all.
+- `docs/agent-skills-whats-new.md` and `docs/gatekeeper-whats-new.md` — capability-history pages mirroring
+  the existing `docs/redteam-whats-new.md` pattern, so a shipped-but-undocumented capability (this happened
+  twice in the same area: SkillGate, then Explainability & Trust itself) is easier to catch next time.
+- **"New to this? Start here"** plain-English concept sections added to `docs/agent-skills.md`,
+  `docs/copilot-studio.md`, and `docs/gatekeeper/explainability-and-trust.md`, plus short "in plain English"
+  framing on Agent Skills' three densest phases — docs read as progressive, not front-loaded with jargon.
+
+#### Added — samples
+- `samples/AgentEval.Samples/Gatekeeper/10_GatekeeperExplainabilityAndTrust.cs` (new) — 3 gradual scenes:
+  `GateProvenance` (a real judge call) → `GateReplayer` (deterministic) → `TrustScoreCalculator` (combines
+  both). Live-verified against real Azure OpenAI.
+- `samples/AgentEval.Samples/CopilotStudio/00_CopilotStudioHelloWorld.cs` (new) — a true one-concept on-ramp
+  before the existing multi-concept walkthroughs (which each covered 4-5 concepts at once).
+
+#### Changed — docs structure hygiene
+- Moved `docs/redteam/copilot-studio.md` → top-level `docs/copilot-studio.md`: it covers eval/bench
+  integration, fluent assertions, and Gatekeeper composition, not just red-teaming — inconsistent with the
+  `AgentEval.MAF.CopilotStudio` package and the samples menu, both of which already treat it as its own
+  top-level area (matching Agent Skills' precedent). All inbound references updated.
+- Renamed `ResponsibleAI.md` → `responsible-ai.md` and `docs/GlassBox/` → `docs/glassbox-history/` for
+  kebab-case consistency with every other doc file/folder.
+- **New CI check**: `tools/check_docs_toc.py` + `.github/workflows/docs-toc-check.yml` fails a PR if any
+  `docs/**/*.md` file isn't reachable from `docs/toc.yml` (the real site navigation, not `docs/index.md`'s
+  separately-maintained landing-page list) — the exact mechanism that let two doc pages ship invisible in the
+  sidebar this session, found only by manual audit. **Extended** to also catch the reverse drift: a local
+  link in `docs/index.md`'s landing page pointing at a page that isn't (or is no longer) in `docs/toc.yml` —
+  one-directional by design, since most nav pages aren't meant to be landing-page-highlighted.
+
+#### Changed — NuGet consumer samples refreshed to the latest released package
+- `samples/AgentEval.NuGetConsumer` / `AgentEval.NuGetConsumer.Tests` were pinned to `AgentEval 0.13.1-beta`
+  (built on MAF 1.11.1) — three releases stale. Bumped to `0.16.0-beta` (the actual latest published version
+  on NuGet.org — confirmed via the NuGet API, not assumed from `main`), with the full dependency baseline
+  (`Microsoft.Agents.AI` 1.13.0, `System.Memory.Data` 10.0.9) updated to match exactly what
+  `Directory.Packages.props` resolved at the `v0.16.0-beta` tag. Restored, built, and tested clean end-to-end
+  against the real published package (one transient Azure content-filter rejection on first run, confirmed
+  non-reproducible on re-run — a live-service flake, not a regression).
+
 ### BUG-22 resolution + Explainability & Trust (gate provenance, counterfactual replay, unified Trust Score) + docs/samples
 
 #### Changed (BREAKING — CLI exit-code contract)

--- a/samples/AgentEval.NuGetConsumer.Tests/AgentEval.NuGetConsumer.Tests.csproj
+++ b/samples/AgentEval.NuGetConsumer.Tests/AgentEval.NuGetConsumer.Tests.csproj
@@ -19,9 +19,9 @@
 
   <ItemGroup>
     <!-- AgentEval — used directly for TestCase, EvaluationOptions, assertions, harness -->
-    <!-- Tracks the LATEST shipped package (built on MAF 1.11.1) to validate the published-NuGet
+    <!-- Tracks the LATEST shipped package (built on MAF 1.13.0) to validate the published-NuGet
          downstream surface; kept in lockstep with AgentEval.NuGetConsumer's reference. -->
-    <PackageReference Include="AgentEval" Version="0.13.1-beta" />
+    <PackageReference Include="AgentEval" Version="0.16.0-beta" />
     <!-- Security: explicit transitive pin (GHSA-g94r-2vxg-569j); CPM disabled in this project -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
 

--- a/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
+++ b/samples/AgentEval.NuGetConsumer/AgentEval.NuGetConsumer.csproj
@@ -27,18 +27,19 @@
     <ProjectReference Include="../../src/AgentEval/AgentEval.csproj" />
     -->
     
-    <!-- NUGET: For validation — track the LATEST published package (built on MAF 1.11.1). -->
-    <PackageReference Include="AgentEval" Version="0.13.1-beta" />
+    <!-- NUGET: For validation — track the LATEST published package (built on MAF 1.13.0). -->
+    <PackageReference Include="AgentEval" Version="0.16.0-beta" />
 
-    <!-- Supporting packages with explicit versions (CPM disabled) — aligned to AgentEval 0.13.1-beta's
-         dependency baseline (MAF 1.11.1 / Microsoft.Extensions.AI 10.6.0). -->
+    <!-- Supporting packages with explicit versions (CPM disabled) — aligned to AgentEval 0.16.0-beta's
+         dependency baseline (MAF 1.13.0 / Microsoft.Extensions.AI 10.6.0), pinned to exactly what
+         Directory.Packages.props resolved at the v0.16.0-beta tag. -->
     <PackageReference Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
-    <PackageReference Include="System.Memory.Data" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.11.1" />
+    <PackageReference Include="System.Memory.Data" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.13.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <!-- Security: explicit transitive pin (GHSA-g94r-2vxg-569j); CPM disabled in this project.
-         MAF 1.11.1 already brings OpenTelemetry.Api 1.15.3 transitively, but a CPM-disabled consumer
+         MAF 1.13.0 already brings OpenTelemetry.Api 1.15.3 transitively, but a CPM-disabled consumer
          won't inherit transitive pinning — keep this explicit so the resolved version is unambiguous. -->
     <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     

--- a/tools/check_docs_toc.py
+++ b/tools/check_docs_toc.py
@@ -6,14 +6,21 @@ be linked from docs/index.md's separately-maintained landing-page card list, or 
 in-content cross-link. Both docs/agent-skills.md and the freshly-written
 docs/gatekeeper/explainability-and-trust.md slipped through exactly this way in the same session, found only
 by manual audit. This script is the automated version of that audit: fail CI if any doc file isn't reachable
-from toc.yml.
+from toc.yml, AND if docs/index.md's landing page links to a page that isn't in toc.yml either (the same
+drift, from the other direction — index.md and toc.yml are two independently hand-maintained lists with
+nothing else tying them together).
 
 Individual docs/adr/*.md files are intentionally excluded — they're indexed via docs/adr/README.md's own
 table (a hub-page pattern), not listed individually in toc.yml; that's a deliberate, reasonable structure,
 not a gap. See docs/adr/README.md's "## Index" table.
 
+Deliberately ONE-DIRECTIONAL for the index.md check: every local link index.md makes must resolve to a page
+that's also in toc.yml, but NOT every toc.yml entry needs a matching index.md link — most nav pages (every
+individual benchmark's getting-started.md, ADRs, etc.) are never meant to be landing-page-highlighted, so
+requiring the reverse would just be noise with no real signal.
+
 Usage: python3 tools/check_docs_toc.py [--docs-dir docs]
-Exit code 0 if every doc is reachable; 1 (with a list) otherwise.
+Exit code 0 if everything's consistent; 1 (with a list) otherwise.
 """
 
 import argparse
@@ -39,6 +46,28 @@ def find_doc_files(docs_dir: pathlib.Path) -> set[str]:
     return files
 
 
+def find_index_local_links(index_path: pathlib.Path) -> set[str]:
+    """Every markdown link in docs/index.md that points at a local .md file (relative path, no scheme,
+    not anchor-only). Links are resolved relative to docs/ (index.md's own directory) so they compare
+    directly against find_doc_files()'s output and find_hrefs()'s href set."""
+    if not index_path.exists():
+        return set()
+
+    text = index_path.read_text(encoding="utf-8")
+    links = set()
+    for target in re.findall(r"\]\(([^)]+)\)", text):
+        target = target.strip()
+        if not target or target.startswith("#"):
+            continue
+        if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", target):   # any URL scheme (http:, mailto:, etc.)
+            continue
+        path_part = target.split("#", 1)[0]
+        if not path_part.endswith(".md"):
+            continue
+        links.add(path_part)
+    return links
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--docs-dir", default="docs", help="Path to the docs/ directory (default: docs)")
@@ -46,6 +75,7 @@ def main() -> int:
 
     docs_dir = pathlib.Path(args.docs_dir)
     toc_path = docs_dir / "toc.yml"
+    index_path = docs_dir / "index.md"
 
     if not toc_path.exists():
         print(f"ERROR: {toc_path} not found.", file=sys.stderr)
@@ -59,8 +89,10 @@ def main() -> int:
     href_paths = {h.split("#", 1)[0] for h in hrefs}
 
     orphans = sorted(f for f in doc_files if f not in href_paths)
+    ok = True
 
     if orphans:
+        ok = False
         print(f"FAIL: {len(orphans)} doc file(s) under {docs_dir}/ are not reachable from {toc_path} "
               "(the real site navigation — docs/index.md's landing-page list does NOT count, it's a "
               "separate, driftable list):\n")
@@ -68,10 +100,24 @@ def main() -> int:
             print(f"  - {docs_dir}/{o}")
         print(f"\nAdd each one to {toc_path}, or add its containing directory to the excluded_dir_names "
               "list in this script if it's deliberately excluded (with a comment explaining why — see the "
-              "docs/adr/ precedent in this script's own docstring).")
+              "docs/adr/ precedent in this script's own docstring).\n")
+
+    index_links = find_index_local_links(index_path)
+    index_drift = sorted(link for link in index_links if link not in href_paths)
+
+    if index_drift:
+        ok = False
+        print(f"FAIL: {len(index_drift)} link(s) in {index_path} point at a page that is NOT in {toc_path} "
+              "(the landing page promises a page the sidebar nav doesn't have):\n")
+        for link in index_drift:
+            print(f"  - {index_path} links to {link}")
+        print(f"\nAdd each target to {toc_path}, or fix/remove the stale link in {index_path}.\n")
+
+    if not ok:
         return 1
 
-    print(f"OK: all {len(doc_files)} doc file(s) under {docs_dir}/ are reachable from {toc_path}.")
+    print(f"OK: all {len(doc_files)} doc file(s) under {docs_dir}/ are reachable from {toc_path}, "
+          f"and all {len(index_links)} local link(s) in {index_path} resolve to a page in {toc_path}.")
     return 0
 
 


### PR DESCRIPTION
## Summary

- **`AgentEval.NuGetConsumer` / `.Tests` refreshed**: was pinned to `AgentEval 0.13.1-beta` (MAF 1.11.1), three releases stale. Confirmed the actual latest *published* version directly via the NuGet API (`0.16.0-beta`, matching the `v0.16.0-beta` tag) and bumped both projects' full dependency baseline to match exactly what `Directory.Packages.props` resolved at that tag.
- **`tools/check_docs_toc.py` extended**: now also fails if `docs/index.md`'s landing page links to a page missing from `docs/toc.yml` (the reverse of what the check already caught) — one-directional by design.
- **`CHANGELOG.md` backfilled** for the two follow-up PRs since the last entry (BUG-22 completion pass, docs/samples-to-10 pass).

## Test plan

- [x] `AgentEval.NuGetConsumer` restores and builds clean against the real published `0.16.0-beta` package
- [x] `AgentEval.NuGetConsumer.Tests`: 9/9 pass (one transient Azure content-filter rejection on a benign prompt, confirmed non-reproducible on 2 re-runs — live-service flake, not a regression)
- [x] Full solution build clean
- [x] New drift-check logic verified by injecting a deliberately broken link into `docs/index.md`, confirming the check fails, then reverting cleanly
- [x] `tools/check_docs_toc.py` passes clean on the real repo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro