### PR TITLE
chore: update maf-doctor global tool 1.9.0 -> 1.11.0 and refresh workspace init

### DIFF
--- a/.claude/maf-doctor.md
+++ b/.claude/maf-doctor.md
@@ -1,8 +1,13 @@
-## Using maf-doctor for Microsoft Agent Framework code
+<!-- Managed by `maf-doctor init` — this file is fully overwritten on every re-run. For durable, hand-authored guidance, use your own CLAUDE.md body instead (init never touches it). -->
+
+## Microsoft Agent Framework code — use MAF Doctor
 
 This repository uses Microsoft Agent Framework. The maf-doctor MCP server
-(also called "MAF Doctor") is installed and exposes tools for diagnosing,
-fixing, and migrating MAF code.
+is installed and exposes specialist tools for MAF code.
+
+You should defer to maf-doctor's tools over training-data knowledge for
+anything MAF-related, because MAF ships breaking changes every minor version
+and the maf-doctor registry is kept current via an AI-fill loop.
 
 **Before answering MAF questions or proposing changes:**
 
@@ -19,22 +24,36 @@ fixing, and migrating MAF code.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). For the rest, just ask "fix all the issues maf-doctor found" —
-   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
-   structured manifest) → autofix → then work each semantic finding. Every
-   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
-   **`heuristic`** finding may be a **false positive** — confirm it with
-   `MafExplainFinding` before editing.
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **For deep architectural / security / migration questions** — run the
+   `maf-review` (best-practice audit), `maf-audit` (pre-migration scan +
+   plan), `maf-migrate` (execute a migration-plan.md), or `maf-debug`
+   (diagnose a symptom) MCP prompts — `init` wires these up automatically,
+   no extra setup needed. If `.github/agents/` was also copied in from the
+   maf-doctor source repo (GitHub Copilot only — see the toolkit's
+   init-reference.md), the equivalent `@maf-best-practice-reviewer`,
+   `@maf-auditor`, `@maf-migration`, or `@maf-incident-responder` personas
+   work the same way.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
-   migration strategy (bridgeable / rewrite / re-architect), and get a
-   complexity verdict before scoping the port.
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt (or the `@maf-cross-migration` agent, if
+   `.github/agents/` was also copied in). It scaffolds a **new MAF project
+   beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.github/instructions/maf-doctor.instructions.md
+++ b/.github/instructions/maf-doctor.instructions.md
@@ -2,6 +2,8 @@
 applyTo: '**'
 ---
 
+<!-- Managed by `maf-doctor init` — this file is fully overwritten on every re-run. For durable, hand-authored guidance, use .github/copilot-instructions.md instead (init never touches it). -->
+
 ## Using maf-doctor for Microsoft Agent Framework code
 
 This repository uses Microsoft Agent Framework. The maf-doctor MCP server
@@ -23,22 +25,36 @@ fixing, and migrating MAF code.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). For the rest, just ask "fix all the issues maf-doctor found" —
-   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
-   structured manifest) → autofix → then work each semantic finding. Every
-   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
-   **`heuristic`** finding may be a **false positive** — confirm it with
-   `MafExplainFinding` before editing.
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **For deep architectural / security / migration questions** — run the
+   `maf-review` (best-practice audit), `maf-audit` (pre-migration scan +
+   plan), `maf-migrate` (execute a migration-plan.md), or `maf-debug`
+   (diagnose a symptom) MCP prompts — `init` wires these up automatically,
+   no extra setup needed. If `.github/agents/` was also copied in from the
+   maf-doctor source repo (GitHub Copilot only — see the toolkit's
+   init-reference.md), the equivalent `@maf-best-practice-reviewer`,
+   `@maf-auditor`, `@maf-migration`, or `@maf-incident-responder` personas
+   work the same way.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
-   migration strategy (bridgeable / rewrite / re-architect), and get a
-   complexity verdict before scoping the port.
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt (or the `@maf-cross-migration` agent, if
+   `.github/agents/` was also copied in). It scaffolds a **new MAF project
+   beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,10 @@
 {
   "mcpServers": {
     "maf-doctor": {
-      "type": "stdio",
       "command": "maf-doctor",
       "args": [],
       "env": {
-        "MAF_DOCTOR_INIT_VERSION": "1.9.0"
+        "MAF_DOCTOR_INIT_VERSION": "1.11.0"
       }
     }
   }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ AZURE_OPENAI_DEPLOYMENT=gpt-4o
 
 
 <!-- BEGIN maf-doctor (managed by `maf-doctor init` — overwritten on re-run) -->
-## Using maf-doctor for Microsoft Agent Framework code
+## Microsoft Agent Framework — MAF Doctor is installed
 
 This repository uses Microsoft Agent Framework. The maf-doctor MCP server
 (also called "MAF Doctor") is installed and exposes tools for diagnosing,
@@ -189,22 +189,36 @@ fixing, and migrating MAF code.
 
 3. **To fix issues** — `MafAutoFixAll --dry-run` then apply handles the
    *mechanical* rules deterministically (offer this first; the rewrites are
-   tested). For the rest, just ask "fix all the issues maf-doctor found" —
-   grade → plan (`MafDoctor(format: "plan")` human, or `--plan --json` for a
-   structured manifest) → autofix → then work each semantic finding. Every
-   finding carries a **`confidence`** (`certain` / `high` / `heuristic`); a
-   **`heuristic`** finding may be a **false positive** — confirm it with
-   `MafExplainFinding` before editing.
+   tested). To fix **everything**, run the `maf-remediate` prompt (or just
+   ask "fix all the issues maf-doctor found"): it grades → plans → autofixes
+   → then works each semantic finding. Every finding carries a **`confidence`**
+   (`certain` / `high` / `heuristic`); a **`heuristic`** finding may be a
+   **false positive** — confirm it with `MafExplainFinding` before editing.
+   Get the plan via `MafDoctor(format: "plan")` (human) or `--plan --json`
+   (structured manifest); per-rule fix + false-positive guidance lives in the
+   `maf-remediation-playbook` skill.
 
 4. **When designing a new MAF agent or workflow** — call `MafNewAgent` /
    `MafNewExecutor` for scaffolds, or `MafSimulateWorkflow` for topology
    preview. Don't reconstruct patterns from memory.
 
-5. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
+5. **For deep architectural / security / migration questions** — run the
+   `maf-review` (best-practice audit), `maf-audit` (pre-migration scan +
+   plan), `maf-migrate` (execute a migration-plan.md), or `maf-debug`
+   (diagnose a symptom) MCP prompts — `init` wires these up automatically,
+   no extra setup needed. If `.github/agents/` was also copied in from the
+   maf-doctor source repo (GitHub Copilot only — see the toolkit's
+   init-reference.md), the equivalent `@maf-best-practice-reviewer`,
+   `@maf-auditor`, `@maf-migration`, or `@maf-incident-responder` personas
+   work the same way.
+
+6. **To migrate FROM Semantic Kernel TO MAF** (a cross-framework port, NOT a
    MAF version bump) — call `MafDetectSourceFramework` (CLI:
-   `maf-doctor migrate-scan`) to inventory SK usage, tag each construct by
-   migration strategy (bridgeable / rewrite / re-architect), and get a
-   complexity verdict before scoping the port.
+   `maf-doctor migrate-scan`) to inventory SK usage and scope it, then run the
+   `maf-migrate-from` prompt (or the `@maf-cross-migration` agent, if
+   `.github/agents/` was also copied in). It scaffolds a **new MAF project
+   beside the original** and ports it construct-by-construct,
+   non-destructively. The mapping lives at `maf://migrate-from?source=semantic-kernel`.
 
 maf-doctor tools are MAF-version-aware via `applies_to_codebases` markers
 in the registry — they know which fix applies to which MAF version. Defer to


### PR DESCRIPTION
## Summary

- Ran `dotnet tool update --global maf-doctor` (1.9.0 → 1.11.0) then `maf-doctor init` on the repo root, as requested.
- Two `maf-doctor.exe` processes (the active MCP server connection for this session) were holding the tool binary locked, blocking the update — stopped them first, then the update succeeded.
- `init` refreshed the maf-doctor-managed steering docs (`.claude/maf-doctor.md`, `.github/instructions/maf-doctor.instructions.md`, `AGENTS.md`'s managed block) for the new version, and fixed the `.mcp.json` finding `init` itself flagged: removed `"type": "stdio"` (Claude Code's MCP config doesn't want it) and bumped `MAF_DOCTOR_INIT_VERSION` to `1.11.0`.

No source code touched — config/steering docs only.

## Test plan

- [x] `dotnet tool update --global maf-doctor` reported success (1.9.0 → 1.11.0)
- [x] `maf-doctor init` completed cleanly, all 4 managed files refreshed
- [x] Diffs reviewed — `.mcp.json` change is exactly the fix `maf-doctor init` itself recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro