### PR TITLE
docs: stop burying Copilot Studio under Red Team in site nav

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -256,7 +256,7 @@ await result.ExportHtmlReportAsync("memory-report.html");
 
 -   **🧩 Agent Skills**
     
-    Evaluate & govern MAF Agent Skills — disclosure assertions, efficiency metric, compliance scanning, injection red-team, governance gates
+    Evaluate & govern MAF Agent Skills — disclosure assertions, efficiency metric, `SKILL.md` compliance scanning, skill-injection red-team, `run_skill_script` governance gates, Skill Security Index
 
 -   **🛡️ Responsible AI**
     
@@ -289,10 +289,6 @@ await result.ExportHtmlReportAsync("memory-report.html");
 -   **🔄 Multi-Turn Evaluation**
     
     Full conversation flow evaluation
-
--   **🧩 MAF Agent Skills**
-
-    Disclosure assertions + efficiency metric, `SKILL.md` compliance scanner, skill-injection red team, `run_skill_script` governance gates, Skill Security Index
 
 </div>
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -68,8 +68,8 @@
     items:
     - name: What's New
       href: redteam-whats-new.md
-    - name: Copilot Studio (--sut copilot-studio)
-      href: copilot-studio.md
+  - name: Copilot Studio
+    href: copilot-studio.md
   - name: Agent Skills
     href: agent-skills.md
     items:


### PR DESCRIPTION
## Summary
- `docs/toc.yml` nested **Copilot Studio** three levels deep as a sub-item of *Red Team Security*, even though the doc page covers general evaluation, direct-code usage, and fluent assertions — not just red-teaming. It was effectively invisible in the site sidebar unless you drilled into Red Team. Promoted to a top-level Evaluation Coverage entry, sibling to Red Team Security and Agent Skills.
- `docs/index.md`'s feature-card grid had two near-duplicate **Agent Skills** cards ("🧩 Agent Skills" and "🧩 MAF Agent Skills") left over from incremental edits across sessions — merged into one.

## Test plan
- [x] `python3 tools/check_docs_toc.py` → OK (77 doc files reachable, 30 index.md links resolve)
- [x] Verified no duplicate/removed content — same href set, just reorganized nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro