### PR TITLE
Gatekeeper security hardening — Fable 5 review (Phase 1 complete)

### DIFF
--- a/src/AgentEval.Cli/Infrastructure/FixtureCapturingChatClient.cs
+++ b/src/AgentEval.Cli/Infrastructure/FixtureCapturingChatClient.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using AgentEval.MAF.Gatekeeper;
 using Microsoft.Extensions.AI;
 
 namespace AgentEval.Cli.Infrastructure;
@@ -35,6 +36,7 @@ public sealed class FixtureCapturingChatClient : DelegatingChatClient
 
     private readonly TextWriter _sink;
     private readonly string? _label;
+    private readonly bool _redactSecrets;
     private int _index;
     private bool _writeFailureReported;
 
@@ -42,11 +44,15 @@ public sealed class FixtureCapturingChatClient : DelegatingChatClient
     /// <param name="inner">The chat client to observe.</param>
     /// <param name="sink">Where to write. See this class's remarks for the thread-safety contract.</param>
     /// <param name="label">An optional short role label recorded in every entry from this client (e.g. "sut").</param>
-    public FixtureCapturingChatClient(IChatClient inner, TextWriter sink, string? label = null)
+    /// <param name="redactSecrets">When <see langword="true"/> (default) recognized credential shapes are masked
+    /// before writing, so a captured fixture doesn't persist a live secret in plaintext (Fable 5 §12). Set
+    /// <see langword="false"/> only for a trusted local debugging session where you need the raw values.</param>
+    public FixtureCapturingChatClient(IChatClient inner, TextWriter sink, string? label = null, bool redactSecrets = true)
         : base(inner)
     {
         _sink = sink ?? throw new ArgumentNullException(nameof(sink));
         _label = string.IsNullOrWhiteSpace(label) ? null : label;
+        _redactSecrets = redactSecrets;
     }
 
     /// <inheritdoc/>
@@ -147,7 +153,8 @@ public sealed class FixtureCapturingChatClient : DelegatingChatClient
             response is null ? null : BuildResponse(response),
             error?.ToString());
 
-        Write(JsonSerializer.Serialize(entry, JsonOptions));
+        var json = JsonSerializer.Serialize(entry, JsonOptions);
+        Write(_redactSecrets ? ToolResultSecretGate.MaskSecrets(json) : json);
     }
 
     private static FixtureCaptureRequest BuildRequest(IList<ChatMessage> messages, ChatOptions? options)

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -19,7 +19,7 @@ namespace AgentEval.Guardrails.Judges;
 /// <para><b>Trust before deployment.</b> A judge should be calibrated against a per-axis gold set (the
 /// calibration harness) before it goes inline — an uncalibrated inline judge is a fabrication risk.</para>
 /// </summary>
-public sealed class CompositeJudgeGate<TRubric> : IChatGate
+public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibration
     where TRubric : IJudgeRubric
 {
     private readonly TRubric _rubric;
@@ -28,6 +28,9 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate
 
     /// <inheritdoc/>
     public string PolicyName { get; }
+
+    /// <inheritdoc/>
+    public string AxisName => _rubric.Axis;
 
     /// <summary>Creates the gate from a single-axis rubric and the fast model that answers it.</summary>
     public CompositeJudgeGate(TRubric rubric, IChatClient fastModel, JudgeGateOptions? options = null)

--- a/src/AgentEval.Core/Guardrails/Judges/IRequiresCalibration.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/IRequiresCalibration.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>
+/// Marks a gate whose right to <b>block live traffic inline</b> is contingent on calibration — an LLM judge that
+/// must have beaten its deterministic baseline on a gold set (<see cref="CalibrationReport.IsInlineReady"/>)
+/// before it may enforce. A construction-time guard (Fable 5 §9 / P1-1) can enumerate these and refuse to promote
+/// an un-proven judge inline, turning the repo's calibration-honesty discipline from documentation into an
+/// enforced invariant — the same fail-loud posture as <c>RefuseUnprotectedHighRiskTools</c> /
+/// <c>PromptTemplateBaseline</c>.
+/// </summary>
+public interface IRequiresCalibration
+{
+    /// <summary>The calibration axis id (matches <see cref="CalibrationReport.Axis"/> in the report store) whose
+    /// <see cref="CalibrationReport.IsInlineReady"/> flag decides whether this gate may block inline.</summary>
+    string AxisName { get; }
+}

--- a/src/AgentEval.Core/Guardrails/McpToolDescriptionPoisoningGate.cs
+++ b/src/AgentEval.Core/Guardrails/McpToolDescriptionPoisoningGate.cs
@@ -93,6 +93,24 @@ public sealed record McpToolDefinition(string Name, string? Description, string?
 /// Deterministic hash-pin-and-diff drift detection over a set of MCP tool definitions — catches a
 /// "rug-pull" (a previously-trusted tool's description/schema silently changing after registration/approval).
 /// </summary>
+/// <remarks>
+/// <b>Honest limits (Fable 5 §15) — this is a helper, not enforcement.</b>
+/// <list type="bullet">
+/// <item><b>Trust-on-first-use.</b> <see cref="CaptureBaseline"/> pins whatever definitions are present at capture
+/// time; it cannot flag a tool that ships a malicious description on FIRST use, and a baseline captured AFTER
+/// poisoning yields a clean diff. Capture from a trusted source, before the model ever sees the tools.</item>
+/// <item><b>Integrity, not authenticity.</b> The baseline is an unsigned, caller-held dictionary — it detects
+/// CHANGE relative to a pin, not that the pin itself is genuine. Cryptographic signing is a separate capability,
+/// not provided here.</item>
+/// <item><b>Not wired to a runtime seam.</b> Nothing invokes this automatically — a caller must remember to call
+/// <see cref="CheckDrift"/>; a caller who never does, or who rug-pulls a tool between capture and the next check,
+/// is unprotected. A construction-time enforcement wrapper (mirroring <c>PromptTemplateDriftGate</c>) is planned
+/// for when MCP tool discovery is actually wired into the runtime — no MCP client is integrated in this repo yet.
+/// </item>
+/// </list>
+/// A NEW tool absent from the baseline is already surfaced by <see cref="CheckDrift"/> as an "added" finding, so a
+/// caller can treat an unexpected addition as suspicious.
+/// </remarks>
 public static class McpToolDescriptionPoisoningGate
 {
     /// <summary>SHA-256 fingerprint of <paramref name="tool"/>'s canonical content.</summary>

--- a/src/AgentEval.MAF/Gatekeeper/ArgumentCanonicalizer.cs
+++ b/src/AgentEval.MAF/Gatekeeper/ArgumentCanonicalizer.cs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Shared foundation (F-D, Fable 5 §6/§13): produces the raw text plus its <b>decoded projections</b> so the
+/// deterministic content gates (<see cref="ArgumentPatternGate"/>, <see cref="DomainAllowListGate"/>,
+/// <see cref="TaintTrackingGate"/>) can match an encoding the downstream tool will later decode — closing the
+/// evasion where a percent-, HTML-entity-, unicode-escape-, or base64-encoded payload slips past a scan of the
+/// single raw surface. Layers are peeled recursively up to <see cref="DefaultMaxDepth"/> (to catch
+/// double-encoding), deduplicated, and each projection is capped at <see cref="DefaultMaxLength"/> — a decode that
+/// would expand past the cap is dropped, so a decode bomb cannot turn canonicalization into a DoS.
+/// <para>Deterministic and allocation-bounded; safe on the hot path. Decoding is best-effort and conservative: a
+/// projection is emitted only when it actually differs from its input, and base64 is decoded only for a long
+/// candidate run whose bytes are valid, largely-printable UTF-8 (so random alphanumerics don't manufacture noise
+/// that spuriously matches a pattern).</para>
+/// </summary>
+public static class ArgumentCanonicalizer
+{
+    /// <summary>Default recursion depth for peeling nested encodings (raw = depth 0).</summary>
+    public const int DefaultMaxDepth = 2;
+
+    /// <summary>Default per-projection length cap; a decode expanding past this is dropped (decode-bomb guard).</summary>
+    public const int DefaultMaxLength = 64 * 1024;
+
+    /// <summary>Hard cap on the number of projections returned (raw included), bounding fan-out.</summary>
+    public const int DefaultMaxProjections = 24;
+
+    private static readonly Regex UnicodeEscape = new(@"\\u([0-9A-Fa-f]{4})", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+    private static readonly Regex Base64Candidate = new(@"[A-Za-z0-9+/]{16,}={0,2}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+
+    /// <summary>
+    /// Returns <paramref name="raw"/> and its decoded projections. The first element is always <paramref name="raw"/>.
+    /// Never throws for malformed input — a decoder that fails is simply skipped.
+    /// </summary>
+    public static IReadOnlyList<string> Canonicalize(
+        string raw, int maxDepth = DefaultMaxDepth, int maxLength = DefaultMaxLength, int maxProjections = DefaultMaxProjections)
+    {
+        ArgumentNullException.ThrowIfNull(raw);
+
+        var results = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var frontier = new Queue<(string Text, int Depth)>();
+
+        void Add(string s, int depth)
+        {
+            if (s.Length > maxLength || results.Count >= maxProjections || !seen.Add(s))
+            {
+                return;
+            }
+
+            results.Add(s);
+            if (depth < maxDepth)
+            {
+                frontier.Enqueue((s, depth));
+            }
+        }
+
+        Add(raw, 0);
+        while (frontier.Count > 0 && results.Count < maxProjections)
+        {
+            var (text, depth) = frontier.Dequeue();
+            foreach (var decoded in DecodeOneLayer(text))
+            {
+                Add(decoded, depth + 1);
+            }
+        }
+
+        return results;
+    }
+
+    private static IEnumerable<string> DecodeOneLayer(string text)
+    {
+        // Percent-decoding (URL): %2F → '/', %68%74%74%70 → 'http'. Uri.UnescapeDataString is lenient (leaves a
+        // malformed % as-is) and never throws.
+        if (text.IndexOf('%') >= 0)
+        {
+            string percent;
+            try { percent = Uri.UnescapeDataString(text); }
+            catch (UriFormatException) { percent = text; }
+            if (!string.Equals(percent, text, StringComparison.Ordinal))
+            {
+                yield return percent;
+            }
+        }
+
+        // HTML entities: &#x2f; / &amp; → decoded.
+        if (text.IndexOf('&') >= 0)
+        {
+            var html = WebUtility.HtmlDecode(text);
+            if (!string.Equals(html, text, StringComparison.Ordinal))
+            {
+                yield return html;
+            }
+        }
+
+        // Literal unicode escapes in the text (/ → '/') — the shape a JSON value carries when the model
+        // hides a char as a backslash-u sequence in the argument string itself.
+        if (text.Contains("\\u", StringComparison.Ordinal))
+        {
+            string unescaped;
+            try
+            {
+                unescaped = UnicodeEscape.Replace(text, m => ((char)Convert.ToInt32(m.Groups[1].Value, 16)).ToString());
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                unescaped = text;
+            }
+
+            if (!string.Equals(unescaped, text, StringComparison.Ordinal))
+            {
+                yield return unescaped;
+            }
+        }
+
+        // Base64-candidate runs decoded to printable UTF-8 text.
+        foreach (var decoded in DecodeBase64Candidates(text))
+        {
+            yield return decoded;
+        }
+    }
+
+    private static IEnumerable<string> DecodeBase64Candidates(string text)
+    {
+        MatchCollection matches;
+        try
+        {
+            matches = Base64Candidate.Matches(text);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            yield break;
+        }
+
+        foreach (Match match in matches)
+        {
+            var candidate = match.Value;
+            if (candidate.Length % 4 != 0)
+            {
+                continue;   // real base64 is a multiple of 4 (with padding) — skip arbitrary alphanumerics
+            }
+
+            byte[] bytes;
+            try
+            {
+                bytes = Convert.FromBase64String(candidate);
+            }
+            catch (FormatException)
+            {
+                continue;
+            }
+
+            if (bytes.Length == 0)
+            {
+                continue;
+            }
+
+            string text8;
+            try
+            {
+                text8 = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(bytes);
+            }
+            catch (DecoderFallbackException)
+            {
+                continue;   // not valid UTF-8 → almost certainly not a smuggled text payload
+            }
+
+            // Require mostly-printable so decoded binary doesn't manufacture pattern-matching noise.
+            if (IsMostlyPrintable(text8))
+            {
+                yield return text8;
+            }
+        }
+    }
+
+    private static bool IsMostlyPrintable(string s)
+    {
+        if (s.Length == 0)
+        {
+            return false;
+        }
+
+        var printable = 0;
+        foreach (var c in s)
+        {
+            if (!char.IsControl(c) || c is '\t' or '\n' or '\r')
+            {
+                printable++;
+            }
+        }
+
+        return printable >= s.Length * 0.9;
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/Coverage/AnalyzeOptions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Coverage/AnalyzeOptions.cs
@@ -28,4 +28,25 @@ public sealed class AnalyzeOptions
     /// <see langword="false"/> only when a compensating control outside the gate pipeline governs these tools.
     /// </summary>
     public bool TreatArbitraryCapabilityOpaqueToolsAsHighRisk { get; init; } = true;
+
+    /// <summary>
+    /// Tool <b>names</b> of provider-hosted tools whose risk you <b>explicitly accept</b> — each is exempted from
+    /// the <see cref="TreatArbitraryCapabilityOpaqueToolsAsHighRisk"/> auto-escalation, so
+    /// <see cref="GatekeeperCoverageAnalyzer.AnalyzeOrThrow(Microsoft.Agents.AI.AIAgent,System.Collections.Generic.IReadOnlyList{IToolGate}?,AnalyzeOptions?)"/>
+    /// will admit them. This is the sanctioned escape hatch (Fable 5 §2 follow-up) for a code-interpreter / MCP
+    /// tool you have a compensating control for — a greppable, auditable opt-in rather than turning the whole
+    /// escalation off. Names match by this set's own comparer (pass a case-insensitive set if you want that).
+    /// </summary>
+    public IReadOnlySet<string>? AcknowledgeProviderHostedTools { get; init; }
+
+    /// <summary>
+    /// Declare that the agent can contribute tools <b>dynamically</b> at invocation time via an
+    /// <see cref="Microsoft.Agents.AI.AIContextProvider"/> (Agent Skills, a memory provider). The analyzer reads
+    /// only the static <c>ChatOptions.Tools</c> list, so an agent whose tools come ONLY from such a provider would
+    /// otherwise report a vacuous 100% coverage and <c>AnalyzeOrThrow</c> would silently certify it (Fable 5 §1, a
+    /// high-severity fail-open). When this is set (or a provider is detected) and the static list is empty, the
+    /// report is marked inventory-unavailable so <c>AnalyzeOrThrow</c> refuses to certify — "couldn't verify" fails
+    /// the same direction as "verified-bad". Default <see langword="false"/> (unchanged for static-tools agents).
+    /// </summary>
+    public bool HasDynamicToolProvider { get; init; }
 }

--- a/src/AgentEval.MAF/Gatekeeper/Coverage/AnalyzeOptions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Coverage/AnalyzeOptions.cs
@@ -17,4 +17,15 @@ public sealed class AnalyzeOptions
     /// the tool's name/description). Override this when the default heuristic misclassifies your tools.
     /// </summary>
     public Func<AITool, bool> IsHighRisk { get; init; } = ToolRiskClassifier.IsHighRisk;
+
+    /// <summary>
+    /// When <see langword="true"/> (the default), a provider-hosted opaque tool with <b>arbitrary capability</b>
+    /// (a hosted code interpreter or a hosted MCP server) is classified <see cref="ToolRiskLevel.HighRisk"/>
+    /// regardless of the keyword heuristic. Such a tool is <b>structurally uninterceptable</b> by any tool gate
+    /// yet can execute arbitrary code / expose an arbitrary tool surface, so leaving it Standard-risk let
+    /// <see cref="GatekeeperCoverageAnalyzer.AnalyzeOrThrow(Microsoft.Agents.AI.AIAgent,System.Collections.Generic.IReadOnlyList{IToolGate}?,AnalyzeOptions?)"/>
+    /// silently admit the single most dangerous class of tool (a fail-open the Fable 5 review confirmed). Set
+    /// <see langword="false"/> only when a compensating control outside the gate pipeline governs these tools.
+    /// </summary>
+    public bool TreatArbitraryCapabilityOpaqueToolsAsHighRisk { get; init; } = true;
 }

--- a/src/AgentEval.MAF/Gatekeeper/Coverage/GatekeeperCoverageAnalyzer.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Coverage/GatekeeperCoverageAnalyzer.cs
@@ -54,13 +54,26 @@ public static class GatekeeperCoverageAnalyzer
     public static GatekeeperCoverageReport Analyze(AIAgent agent, IReadOnlyList<IToolGate>? toolGates = null, AnalyzeOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(agent);
+        options ??= AnalyzeOptions.Default;
 
         if (agent.GetService(typeof(ChatOptions)) is not ChatOptions chatOptions)
         {
             return new GatekeeperCoverageReport(Array.Empty<ToolCoverageEntry>(), GateNames(toolGates), ToolInventoryAvailable: false);
         }
 
-        return AnalyzeCore(chatOptions.Tools ?? Array.Empty<AITool>(), toolGates, options, toolInventoryAvailable: true);
+        var tools = chatOptions.Tools ?? (IList<AITool>)Array.Empty<AITool>();
+
+        // P1-12 (§1): an AIContextProvider can inject tools at invocation time that never appear in the static
+        // Tools list. If the agent has one (caller-declared, or detected) and the static list is empty, we cannot
+        // enumerate the real inventory — fail closed (inventory-unavailable) so AnalyzeOrThrow refuses to certify a
+        // vacuous 100% rather than silently green-light an unverified agent.
+        var hasDynamicProvider = options.HasDynamicToolProvider || agent.GetService(typeof(AIContextProvider)) is not null;
+        if (hasDynamicProvider && tools.Count == 0)
+        {
+            return new GatekeeperCoverageReport(Array.Empty<ToolCoverageEntry>(), GateNames(toolGates), ToolInventoryAvailable: false);
+        }
+
+        return AnalyzeCore(tools, toolGates, options, toolInventoryAvailable: true);
     }
 
     /// <summary>Analyzes an explicit tool list (the same list you passed to <see cref="ChatOptions.Tools"/>).</summary>
@@ -136,7 +149,9 @@ public static class GatekeeperCoverageAnalyzer
     // these two on purpose: hosted web/file/image search are opaque too but far narrower, so they stay on the
     // keyword heuristic and don't over-trip AnalyzeOrThrow.
     private static bool IsArbitraryCapabilityOpaque(AITool tool, AnalyzeOptions options)
-        => options.TreatArbitraryCapabilityOpaqueToolsAsHighRisk && tool is HostedCodeInterpreterTool or HostedMcpServerTool;
+        => options.TreatArbitraryCapabilityOpaqueToolsAsHighRisk
+           && tool is HostedCodeInterpreterTool or HostedMcpServerTool
+           && !(options.AcknowledgeProviderHostedTools?.Contains(tool.Name) ?? false);   // P1-3: explicit opt-out
 #pragma warning restore MEAI001
 
     private static IReadOnlyList<string> GateNames(IReadOnlyList<IToolGate>? toolGates)

--- a/src/AgentEval.MAF/Gatekeeper/Coverage/GatekeeperCoverageAnalyzer.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Coverage/GatekeeperCoverageAnalyzer.cs
@@ -104,7 +104,8 @@ public static class GatekeeperCoverageAnalyzer
         foreach (var tool in tools)
         {
             var model = Classify(tool);
-            var risk = options.IsHighRisk(tool) ? ToolRiskLevel.HighRisk : ToolRiskLevel.Standard;
+            var risk = options.IsHighRisk(tool) || IsArbitraryCapabilityOpaque(tool, options)
+                ? ToolRiskLevel.HighRisk : ToolRiskLevel.Standard;
             var isProtected = model == ToolExecutionModel.InterceptedLocalFunction && hasToolGate;
             entries.Add(new ToolCoverageEntry(tool.Name, tool.Description, model, risk, isProtected, NoteFor(model, isProtected)));
         }
@@ -129,6 +130,13 @@ public static class GatekeeperCoverageAnalyzer
             or HostedFileSearchTool or HostedImageGenerationTool or HostedToolSearchTool => ToolExecutionModel.ProviderHostedOpaque,
         _ => ToolExecutionModel.UnknownExecutionModel,
     };
+
+    // A provider-hosted opaque tool that is ALSO arbitrary-capability (runs arbitrary code, or fronts an
+    // arbitrary MCP tool surface) — the class that is both uninterceptable AND maximally dangerous. Narrowed to
+    // these two on purpose: hosted web/file/image search are opaque too but far narrower, so they stay on the
+    // keyword heuristic and don't over-trip AnalyzeOrThrow.
+    private static bool IsArbitraryCapabilityOpaque(AITool tool, AnalyzeOptions options)
+        => options.TreatArbitraryCapabilityOpaqueToolsAsHighRisk && tool is HostedCodeInterpreterTool or HostedMcpServerTool;
 #pragma warning restore MEAI001
 
     private static IReadOnlyList<string> GateNames(IReadOnlyList<IToolGate>? toolGates)

--- a/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using AgentEval.Guardrails;
+using AgentEval.Guardrails.Judges;
 using AgentEval.MAF.Skills;
 using AgentEval.Tracing;
 using Microsoft.Extensions.AI;
@@ -52,6 +53,60 @@ public sealed class GatekeeperOptions
 
     /// <summary>Adds a tool-approval gate. Sugar for <c>ApprovalGates.Add(gate)</c>.</summary>
     public void AddApprovalGate(IToolApprovalGate gate) => ApprovalGates.Add(gate ?? throw new ArgumentNullException(nameof(gate)));
+
+#pragma warning disable AGENTEVAL_GATEKEEPER_PREVIEW001 // ICalibrationReportStore/CalibrationReport are preview; P1-1 opts into them deliberately.
+
+    /// <summary>Optional calibration-report store used by <see cref="ValidateInlineJudgesAsync"/> to prove an inline
+    /// LLM judge (any <see cref="IRequiresCalibration"/> pre/post gate) has earned the right to block.</summary>
+    public ICalibrationReportStore? CalibrationReportStore { get; set; }
+
+    /// <summary>Escape hatch (Fable 5 §9 / P1-1): when <see langword="true"/>, <see cref="ValidateInlineJudgesAsync"/>
+    /// skips the inline-judge calibration check. A loud, greppable opt-out — the fabrication-prone default is to
+    /// REFUSE an un-proven inline judge.</summary>
+    public bool AllowUncalibratedInlineJudge { get; set; }
+
+    /// <summary>
+    /// Refuses to promote an inline LLM judge that has not earned the right to block. For every registered pre/post
+    /// gate implementing <see cref="IRequiresCalibration"/>, loads its axis's latest report from
+    /// <see cref="CalibrationReportStore"/> and throws <see cref="UncalibratedInlineJudgeException"/> unless the
+    /// report exists and is <see cref="CalibrationReport.IsInlineReady"/>. Async by design (the store is I/O-bound,
+    /// so this is NOT folded into the synchronous <c>UseGatekeeper</c> preflight) — call it before you trust a judge
+    /// fleet inline. A no-op when <see cref="AllowUncalibratedInlineJudge"/> is set or no such judge is registered.
+    /// </summary>
+    public async Task ValidateInlineJudgesAsync(CancellationToken cancellationToken = default)
+    {
+        if (AllowUncalibratedInlineJudge)
+        {
+            return;
+        }
+
+        foreach (var gate in PreGates.Concat(PostGates))
+        {
+            if (gate is not IRequiresCalibration calibratable)
+            {
+                continue;
+            }
+
+            if (CalibrationReportStore is null)
+            {
+                throw new UncalibratedInlineJudgeException(calibratable.AxisName,
+                    "no CalibrationReportStore is configured, so this inline judge cannot be proven calibration-ready");
+            }
+
+            var report = await CalibrationReportStore.LoadLatestAsync(calibratable.AxisName, cancellationToken).ConfigureAwait(false);
+            if (report is null)
+            {
+                throw new UncalibratedInlineJudgeException(calibratable.AxisName, "no calibration report was found for this axis");
+            }
+
+            if (!report.IsInlineReady)
+            {
+                throw new UncalibratedInlineJudgeException(calibratable.AxisName,
+                    "the latest calibration report is not inline-ready (it has not beaten its deterministic baseline on a gold set)");
+            }
+        }
+    }
+#pragma warning restore AGENTEVAL_GATEKEEPER_PREVIEW001
 
     /// <summary>
     /// Whether to establish an <see cref="AgentRunScope"/> for every run (via <c>UseAgentEvalGate</c>), even

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternGate.cs
@@ -22,6 +22,7 @@ public sealed class ArgumentPatternGate : IToolGate
     private static readonly JsonSerializerOptions ScanOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
     private readonly Regex _forbidden;
+    private readonly bool _canonicalize;
 
     /// <inheritdoc/>
     public string PolicyName { get; }
@@ -30,13 +31,16 @@ public sealed class ArgumentPatternGate : IToolGate
     public GateCost Cost => GateCost.Bounded;
 
     /// <summary>Creates the gate from a pattern, compiled with a bounded (100 ms) match timeout (ReDoS-safe).</summary>
-    public ArgumentPatternGate(string forbiddenPattern, string? policyName = null)
-        : this(new Regex(forbiddenPattern, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100)), policyName)
+    public ArgumentPatternGate(string forbiddenPattern, string? policyName = null, bool canonicalize = false)
+        : this(new Regex(forbiddenPattern, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100)), policyName, canonicalize)
     {
     }
 
-    /// <summary>Creates the gate from a caller-supplied <see cref="Regex"/> (must have a bounded MatchTimeout).</summary>
-    public ArgumentPatternGate(Regex forbiddenPattern, string? policyName = null)
+    /// <summary>Creates the gate from a caller-supplied <see cref="Regex"/> (must have a bounded MatchTimeout). Set
+    /// <paramref name="canonicalize"/> to also scan decoded projections (percent / HTML-entity / unicode-escape /
+    /// base64) of the arguments via <see cref="ArgumentCanonicalizer"/>, so a payload the tool later decodes cannot
+    /// evade the pattern by arriving encoded (Fable 5 §13).</summary>
+    public ArgumentPatternGate(Regex forbiddenPattern, string? policyName = null, bool canonicalize = false)
     {
         ArgumentNullException.ThrowIfNull(forbiddenPattern);
         if (forbiddenPattern.MatchTimeout == Regex.InfiniteMatchTimeout)
@@ -46,6 +50,7 @@ public sealed class ArgumentPatternGate : IToolGate
         }
 
         _forbidden = forbiddenPattern;
+        _canonicalize = canonicalize;
         PolicyName = policyName ?? "ArgumentPatternGate";
     }
 
@@ -70,7 +75,12 @@ public sealed class ArgumentPatternGate : IToolGate
                 ToolGateVerdict.Block(PolicyName, $"tool '{call.FunctionName}' arguments could not be serialized for inspection"));
         }
 
-        var hit = ForbiddenPatternScanner.ScanForForbiddenPattern(serialized, _forbidden);
+        // Default: scan the raw serialized surface. With canonicalize: also scan each decoded projection so an
+        // encoded payload the tool later decodes cannot slip past (the raw surface is the first projection).
+        var hit = _canonicalize
+            ? ArgumentCanonicalizer.Canonicalize(serialized).Any(p => ForbiddenPatternScanner.ScanForForbiddenPattern(p, _forbidden))
+            : ForbiddenPatternScanner.ScanForForbiddenPattern(serialized, _forbidden);
+
         return new ValueTask<ToolGateVerdict>(hit
             ? ToolGateVerdict.Block(PolicyName, $"tool '{call.FunctionName}' arguments matched a forbidden pattern")
             : ToolGateVerdict.Allow(PolicyName));

--- a/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
@@ -18,10 +18,11 @@ namespace AgentEval.MAF.Gatekeeper;
 /// also matches its subdomains (<c>example.com</c> allows <c>api.example.com</c>). Uses the relaxed JSON encoder
 /// so a URL isn't hidden behind escaping, and is <b>fail-closed</b>: arguments that can't be serialized, or a scan
 /// that times out, block the call.</para>
-/// <para><b>Scope / limits.</b> It gates URLs it can extract from the arguments. It does <i>not</i> detect a
-/// <b>bare hostname</b> with no <c>"//"</c> (e.g. a tool that takes <c>host</c> and adds the scheme itself) or a
-/// <c>data:</c> URI — validate those in the tool, or pair with an <see cref="ArgumentPatternGate"/>. It is a
-/// strong egress layer over URL arguments, not a complete network firewall.</para>
+/// <para><b>Bare hosts &amp; <c>data:</c> URIs (Fable 5 §14).</b> Pass <paramref name="hostArguments"/> (see the
+/// constructor) to also validate named arguments whose VALUE is a <b>bare hostname</b> with no <c>"//"</c> (e.g.
+/// a tool that takes <c>host</c> and adds the scheme itself) against the same allow-list. And a <c>data:</c> URI —
+/// which has no host and so can never be host-allow-listed — is blocked by default (un-vettable inline/exfil
+/// egress). It remains a strong egress layer over arguments, not a complete network firewall.</para>
 /// </summary>
 public sealed class DomainAllowListGate : IToolGate
 {
@@ -34,7 +35,15 @@ public sealed class DomainAllowListGate : IToolGate
     private static readonly Regex UrlAuthority = new(
         @"(?:[a-z][a-z0-9+.\-]*:)?//([^/\s""'<>\\)}?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
 
+    // A data: URI (data:[<mediatype>][;base64],<data>) has no host and so can never be host-allow-listed — in an
+    // egress-controlled context it is un-vettable inline/exfil content. Conservative: requires the trailing comma
+    // of a real data URI, so the literal word "data:" in prose does not false-positive. Bounded (ReDoS-safe).
+    private static readonly Regex DataUri = new(
+        @"\bdata:(?:[a-z][a-z0-9.+\-]*/[a-z0-9.+\-]+)?(?:;[a-z0-9\-]+(?:=[a-z0-9.\-]+)?)*,",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+
     private readonly HashSet<string> _allowed;
+    private readonly string[] _hostArguments;
 
     /// <inheritdoc/>
     public string PolicyName { get; }
@@ -45,12 +54,15 @@ public sealed class DomainAllowListGate : IToolGate
     /// <summary>
     /// Creates the gate from the allowed domains — bare hosts, e.g. <c>"api.example.com"</c> (an IPv6 literal must
     /// be bracketed, e.g. <c>"[::1]"</c>; a bare <c>"::1"</c> is mis-parsed as host:port and ignored). Default-deny:
-    /// at least one is required.
+    /// at least one is required. Pass <paramref name="hostArguments"/> to also validate the VALUE of the named
+    /// arguments as a bare hostname (no <c>"//"</c>) against the same allow-list — for a tool whose parameter is a
+    /// host rather than a full URL.
     /// </summary>
-    public DomainAllowListGate(IEnumerable<string> allowedDomains, string? policyName = null)
+    public DomainAllowListGate(IEnumerable<string> allowedDomains, string? policyName = null, IEnumerable<string>? hostArguments = null)
     {
         _allowed = HostAllowList.Build(allowedDomains, nameof(allowedDomains));
         PolicyName = policyName ?? "DomainAllowListGate";
+        _hostArguments = hostArguments?.Where(a => !string.IsNullOrEmpty(a)).ToArray() ?? Array.Empty<string>();
     }
 
     /// <inheritdoc/>
@@ -76,6 +88,11 @@ public sealed class DomainAllowListGate : IToolGate
 
         try
         {
+            if (DataUri.IsMatch(serialized))
+            {
+                return Blocked($"tool '{call.FunctionName}' targets a data: URI, which has no host and cannot be domain-allow-listed");
+            }
+
             foreach (Match m in UrlAuthority.Matches(serialized))
             {
                 var host = HostAllowList.ExtractHost(m.Groups[1].Value);
@@ -90,7 +107,49 @@ public sealed class DomainAllowListGate : IToolGate
             return Blocked($"tool '{call.FunctionName}' arguments could not be scanned for URLs (timeout)");
         }
 
+        // Bare-hostname arguments (opt-in): the "//" scan above misses a host written without a scheme, so
+        // validate the VALUE of each caller-declared host argument directly against the same allow-list.
+        foreach (var argName in _hostArguments)
+        {
+            if (!call.Arguments.TryGetValue(argName, out var value) || value is null)
+            {
+                continue;
+            }
+
+            var host = HostFromArgumentValue(value.ToString());
+            if (host is not null && !HostAllowList.IsAllowed(host, _allowed))
+            {
+                return Blocked($"tool '{call.FunctionName}' argument '{argName}' targets a non-allow-listed host '{host}'");
+            }
+        }
+
         return Allow();
+    }
+
+    // Extract a host from a host-argument value that may be a bare host, host:port, or a full URL. Strips an
+    // optional scheme "//", then path/query/fragment, delegating the userinfo@host:port / IPv6 parse to
+    // HostAllowList.ExtractHost so that handling stays in one place.
+    private static string? HostFromArgumentValue(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var authority = raw.Trim();
+        var slashSlash = authority.IndexOf("//", StringComparison.Ordinal);
+        if (slashSlash >= 0)
+        {
+            authority = authority[(slashSlash + 2)..];
+        }
+
+        var cut = authority.IndexOfAny(new[] { '/', '?', '#', '\\' });
+        if (cut >= 0)
+        {
+            authority = authority[..cut];
+        }
+
+        return HostAllowList.ExtractHost(authority);
     }
 
     private ValueTask<ToolGateVerdict> Allow() => new(ToolGateVerdict.Allow(PolicyName));

--- a/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
@@ -44,6 +44,7 @@ public sealed class DomainAllowListGate : IToolGate
 
     private readonly HashSet<string> _allowed;
     private readonly string[] _hostArguments;
+    private readonly bool _canonicalize;
 
     /// <inheritdoc/>
     public string PolicyName { get; }
@@ -56,13 +57,17 @@ public sealed class DomainAllowListGate : IToolGate
     /// be bracketed, e.g. <c>"[::1]"</c>; a bare <c>"::1"</c> is mis-parsed as host:port and ignored). Default-deny:
     /// at least one is required. Pass <paramref name="hostArguments"/> to also validate the VALUE of the named
     /// arguments as a bare hostname (no <c>"//"</c>) against the same allow-list — for a tool whose parameter is a
-    /// host rather than a full URL.
+    /// host rather than a full URL. Set <paramref name="canonicalize"/> to also scan decoded projections
+    /// (percent / HTML-entity / unicode-escape / base64) of the arguments via <see cref="ArgumentCanonicalizer"/>,
+    /// so an encoded URL the tool later decodes cannot evade the allow-list (Fable 5 §13).
     /// </summary>
-    public DomainAllowListGate(IEnumerable<string> allowedDomains, string? policyName = null, IEnumerable<string>? hostArguments = null)
+    public DomainAllowListGate(
+        IEnumerable<string> allowedDomains, string? policyName = null, IEnumerable<string>? hostArguments = null, bool canonicalize = false)
     {
         _allowed = HostAllowList.Build(allowedDomains, nameof(allowedDomains));
         PolicyName = policyName ?? "DomainAllowListGate";
         _hostArguments = hostArguments?.Where(a => !string.IsNullOrEmpty(a)).ToArray() ?? Array.Empty<string>();
+        _canonicalize = canonicalize;
     }
 
     /// <inheritdoc/>
@@ -86,19 +91,27 @@ public sealed class DomainAllowListGate : IToolGate
             return Blocked($"tool '{call.FunctionName}' arguments could not be serialized for URL inspection");
         }
 
+        // Default: scan the raw serialized surface (the first projection). With canonicalize: also scan decoded
+        // projections so an encoded URL the tool later decodes cannot evade the allow-list.
+        var surfaces = _canonicalize
+            ? ArgumentCanonicalizer.Canonicalize(serialized)
+            : (IReadOnlyList<string>)new[] { serialized };
         try
         {
-            if (DataUri.IsMatch(serialized))
+            foreach (var surface in surfaces)
             {
-                return Blocked($"tool '{call.FunctionName}' targets a data: URI, which has no host and cannot be domain-allow-listed");
-            }
-
-            foreach (Match m in UrlAuthority.Matches(serialized))
-            {
-                var host = HostAllowList.ExtractHost(m.Groups[1].Value);
-                if (host is not null && !HostAllowList.IsAllowed(host, _allowed))
+                if (DataUri.IsMatch(surface))
                 {
-                    return Blocked($"tool '{call.FunctionName}' targets a non-allow-listed domain '{host}'");
+                    return Blocked($"tool '{call.FunctionName}' targets a data: URI, which has no host and cannot be domain-allow-listed");
+                }
+
+                foreach (Match m in UrlAuthority.Matches(surface))
+                {
+                    var host = HostAllowList.ExtractHost(m.Groups[1].Value);
+                    if (host is not null && !HostAllowList.IsAllowed(host, _allowed))
+                    {
+                        return Blocked($"tool '{call.FunctionName}' targets a non-allow-listed domain '{host}'");
+                    }
                 }
             }
         }

--- a/src/AgentEval.MAF/Gatekeeper/Gates/IdentifierRecognizers.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/IdentifierRecognizers.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Ready-made <c>isIdentifier</c> predicates for <see cref="ReferentialIntegrityGate"/> (Fable 5 §7). The gate's
+/// default only flags tokens that contain a <b>digit</b>, so an <b>all-letter</b> id — a username, a slug, an
+/// <c>admin_backup</c> your backend accepts — is not validated by default, and since an injection chooses the id
+/// shape that is a deterministic gap. These give a caller whose ids can be alpha-only a first-class way to close
+/// it <b>without</b> hand-writing a predicate and without changing the (safe, low-false-alarm) default.
+/// <para>Prefer <see cref="Matching"/> with your id's real shape; reach for <see cref="AlphanumericMinLength"/>
+/// only when you cannot express the shape and accept its higher false-alarm rate. Run the gate
+/// <see cref="ToolGatePolicy.WarnOnly"/> first to measure alarms before enforcing, per the gate's guidance.
+/// All returned predicates are pure and safe to share across gate instances.</para>
+/// </summary>
+public static class IdentifierRecognizers
+{
+    /// <summary>The gate's DEFAULT, exposed for reuse/composition: a token of length ≥ <paramref name="minLength"/>
+    /// that contains at least one digit (fires on <c>A-1042</c> / <c>FAKE-9931</c>, not on plain words). The
+    /// permissive baseline — it does not validate alpha-only ids.</summary>
+    public static Func<string, bool> ContainsDigit(int minLength = 4)
+    {
+        if (minLength < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minLength), "must be at least 1.");
+        }
+
+        return token => token.Length >= minLength && token.Any(char.IsDigit);
+    }
+
+    /// <summary>Precise (recommended for alpha-only ids): a token is an id iff it matches <paramref name="pattern"/>
+    /// — use your id's real shape, e.g. <c>new Regex("^(usr|ord)_[a-z0-9]{6,}$", RegexOptions.None,
+    /// TimeSpan.FromMilliseconds(100))</c>. Supply a bounded, anchored pattern (the gate applies it per token and
+    /// does not impose its own timeout on a caller-supplied regex).</summary>
+    public static Func<string, bool> Matching(Regex pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return token => pattern.IsMatch(token);
+    }
+
+    /// <summary>Stricter length-only: ANY token of length ≥ <paramref name="minLength"/> is treated as an id,
+    /// letters-only included (so <c>admin_backup</c> / a long slug is validated). Highest recall, highest
+    /// false-alarm rate — flags ordinary long words too, so measure under <c>WarnOnly</c> before enforcing. Use
+    /// only when the id shape can't be expressed as a <see cref="Matching"/> pattern.</summary>
+    public static Func<string, bool> AlphanumericMinLength(int minLength = 8)
+    {
+        if (minLength < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minLength), "must be at least 1.");
+        }
+
+        return token => token.Length >= minLength;
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/Gates/RateLimitGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/RateLimitGate.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using AgentEval.Guardrails;
 using Microsoft.Agents.AI;
@@ -16,10 +17,14 @@ namespace AgentEval.MAF.Gatekeeper;
 /// <see cref="ConditionalWeakTable{TKey,TValue}"/>, guarded by a per-session lock) rather than in the session
 /// <c>StateBag</c> — the StateBag has no atomic increment, so a read-modify-write counter there would lose
 /// updates under concurrent/shared sessions and become a <em>bypass</em> of the cap it implements.</para>
-/// <para>⚠️ <b>Object-identity keying.</b> The counter is keyed by the <see cref="AgentSession"/> <i>object</i>.
-/// This enforces correctly for a long-lived in-memory session, but a deployment that reloads a persisted session
-/// into a <b>fresh</b> object each turn will reset the counter (a bypass). For persisted-session deployments,
-/// enforce rate limits at a layer that has a stable logical session id, or supply one out of band.</para>
+/// <para>⚠️ <b>Object-identity keying (default), and how to survive a reload.</b> By default the counter is keyed
+/// by the <see cref="AgentSession"/> <i>object</i>. This enforces correctly for a long-lived in-memory session,
+/// but a deployment that reloads a persisted session into a <b>fresh</b> object each turn (or load-balances a
+/// logical session across workers) would reset the counter — a bypass. Supply a <c>sessionKeySelector</c> that
+/// returns a <b>stable logical session id</b> (e.g. off the session's <c>StateBag</c>, a claim, or a store key)
+/// and the counter is instead kept in a process-wide table keyed by that id, so the cap survives a reload. A
+/// selector that returns <see langword="null"/>/empty for a given session falls back to object identity for that
+/// session (so a partial deployment degrades gracefully rather than throwing).</para>
 /// <para>Time comes from an injectable <see cref="TimeProvider"/> so tests are deterministic (no wall-clock flake).</para>
 /// </summary>
 public sealed class RateLimitGate : SessionContextGate
@@ -27,13 +32,18 @@ public sealed class RateLimitGate : SessionContextGate
     private readonly int _maxRuns;
     private readonly TimeSpan _window;
     private readonly TimeProvider _time;
-    private readonly ConditionalWeakTable<AgentSession, Cell> _cells = new();
+    private readonly Func<AgentSession, string?>? _sessionKeySelector;
+    private readonly ConditionalWeakTable<AgentSession, Cell> _cells = new();                             // object-identity path (GC-evicted)
+    private readonly ConcurrentDictionary<string, Cell> _keyedCells = new(StringComparer.Ordinal);        // stable-id path (survives reload)
 
     /// <inheritdoc/>
     public override string PolicyName => "RateLimitGate";
 
-    /// <summary>Creates the gate: at most <paramref name="maxRuns"/> runs per <paramref name="window"/> per session.</summary>
-    public RateLimitGate(int maxRuns, TimeSpan window, TimeProvider? timeProvider = null)
+    /// <summary>Creates the gate: at most <paramref name="maxRuns"/> runs per <paramref name="window"/> per session.
+    /// Pass <paramref name="sessionKeySelector"/> to key the counter on a stable logical session id (surviving a
+    /// persisted-session reload) instead of the session object's identity — see the class remarks. The keyed table
+    /// is bounded by the number of distinct logical session ids the process observes.</summary>
+    public RateLimitGate(int maxRuns, TimeSpan window, TimeProvider? timeProvider = null, Func<AgentSession, string?>? sessionKeySelector = null)
     {
         if (maxRuns < 1)
         {
@@ -49,12 +59,13 @@ public sealed class RateLimitGate : SessionContextGate
         _maxRuns = maxRuns;
         _window = window;
         _time = timeProvider ?? TimeProvider.System;
+        _sessionKeySelector = sessionKeySelector;
     }
 
     /// <inheritdoc/>
     protected override ValueTask<GateVerdict> CheckSessionAsync(AgentSession session, CancellationToken cancellationToken)
     {
-        var cell = _cells.GetOrCreateValue(session);
+        var cell = ResolveCell(session);
         var now = _time.GetUtcNow();
 
         bool over;
@@ -73,6 +84,22 @@ public sealed class RateLimitGate : SessionContextGate
         return new ValueTask<GateVerdict>(over
             ? GateVerdict.Block(PolicyName, $"rate limit exceeded ({_maxRuns} run(s) per {_window.TotalSeconds:F0}s)")
             : GateVerdict.Allow(PolicyName));
+    }
+
+    // Stable-id path when a selector is supplied and yields a non-empty id (counter survives a session reload);
+    // otherwise the GC-evicted object-identity table, preserving the exact default behavior.
+    private Cell ResolveCell(AgentSession session)
+    {
+        if (_sessionKeySelector is not null)
+        {
+            var key = _sessionKeySelector(session);
+            if (!string.IsNullOrEmpty(key))
+            {
+                return _keyedCells.GetOrAdd(key, static _ => new Cell());
+            }
+        }
+
+        return _cells.GetOrCreateValue(session);
     }
 
     private sealed class Cell

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ReferentialIntegrityGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ReferentialIntegrityGate.cs
@@ -25,7 +25,10 @@ namespace AgentEval.MAF.Gatekeeper;
 /// <para><b>A tripwire, not a proof.</b> "Is this token an id" is a heuristic — the default (<c>isIdentifier</c>)
 /// only flags tokens that contain a <b>digit</b>, so an <b>all-letter</b> id (a username / slug / <c>admin_backup</c>
 /// your backend accepts) is <i>not</i> validated by default, and since the attacker chooses the injected id this is
-/// a deterministic gap — supply a custom <c>isIdentifier</c> when your guarded ids can be alpha-only. Run
+/// a deterministic gap. Close it by passing a ready-made recogniser from <see cref="IdentifierRecognizers"/> —
+/// <see cref="IdentifierRecognizers.Matching"/> with your id's real shape (recommended), or
+/// <see cref="IdentifierRecognizers.AlphanumericMinLength"/> when you can't express the shape. The default is left
+/// unchanged deliberately: flagging every alpha token by default would false-alarm on ordinary words. Run
 /// <see cref="ToolGatePolicy.WarnOnly"/> first to measure false alarms, then promote to <c>ReplaceResult</c> /
 /// <c>Terminate</c>.</para>
 /// <para><b>Stateless.</b> Observed ids are recomputed per call from <c>call.Messages</c> (the run's history) — no
@@ -58,9 +61,11 @@ public sealed class ReferentialIntegrityGate : IToolGate
     /// must come from the <b>user</b> only. Do NOT list web/RAG tools an injection can poison.
     /// </param>
     /// <param name="isIdentifier">
-    /// Predicate deciding whether a token is an id worth validating. Default: length ≥ 4 and contains at least one
-    /// digit (fires on <c>A-1042</c> / <c>FAKE-9931</c>, not on plain words). Supply your own if guarded ids can be
-    /// all-letter — the default does NOT validate alpha-only ids.
+    /// Predicate deciding whether a token is an id worth validating. Default:
+    /// <see cref="IdentifierRecognizers.ContainsDigit"/> (length ≥ 4 and contains a digit — fires on <c>A-1042</c> /
+    /// <c>FAKE-9931</c>, not on plain words). The default does NOT validate alpha-only ids; pass a recogniser from
+    /// <see cref="IdentifierRecognizers"/> (e.g. <see cref="IdentifierRecognizers.Matching"/>) when your guarded ids
+    /// can be all-letter.
     /// </param>
     public ReferentialIntegrityGate(
         IEnumerable<string> idArgNames,
@@ -77,7 +82,7 @@ public sealed class ReferentialIntegrityGate : IToolGate
 
         _guarded = ToSetOrNull(guardedTools);        // null ⇒ apply to every tool
         _trusted = ToSetOrNull(trustedSourceTools);  // null ⇒ only user turns confer legitimacy
-        _isId = isIdentifier ?? DefaultIsIdentifier;
+        _isId = isIdentifier ?? IdentifierRecognizers.ContainsDigit();   // single source of truth for the default
     }
 
     private static HashSet<string>? ToSetOrNull(IEnumerable<string>? values)
@@ -90,8 +95,6 @@ public sealed class ReferentialIntegrityGate : IToolGate
         var set = new HashSet<string>(values, StringComparer.OrdinalIgnoreCase);
         return set.Count > 0 ? set : null;
     }
-
-    private static bool DefaultIsIdentifier(string token) => token.Length >= 4 && token.Any(char.IsDigit);
 
     /// <inheritdoc/>
     public ValueTask<ToolGateVerdict> InspectAsync(GatedToolCall call, CancellationToken cancellationToken = default)

--- a/src/AgentEval.MAF/Gatekeeper/Gates/SameBatchOrderingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/SameBatchOrderingGate.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Deterministic tool gate that blocks a forbidden trigger→guarded pair emitted in the <b>same</b> model
+/// iteration — the concurrency seam <see cref="SequenceGate"/> documents it cannot cover. When the model requests
+/// several tool calls at once (one assistant turn, multiple <see cref="FunctionCallContent"/>) they may be
+/// invoked concurrently with no happens-before, so a <c>read_secrets</c> + <c>send_email</c> pair in a single
+/// batch slips past a cross-invocation sequence check. This gate inspects the current iteration's sibling calls
+/// (the most recent assistant tool-call message in <see cref="GatedToolCall.Messages"/>) and blocks a guarded call
+/// whenever a trigger tool is present in the same batch — conservatively, regardless of which would run first
+/// (concurrent same-batch calls cannot be proven safe).
+/// <para>Pairs with <see cref="SequenceGate"/> (cross-iteration ordering); register both for full coverage.
+/// Stateless (reads only the current batch), so it needs no run scope. Matching is case-insensitive.</para>
+/// </summary>
+public sealed class SameBatchOrderingGate : IToolGate
+{
+    private readonly HashSet<string> _triggers;
+    private readonly HashSet<string> _guarded;
+
+    /// <inheritdoc/>
+    public string PolicyName { get; }
+
+    /// <inheritdoc/>
+    public GateCost Cost => GateCost.PureCode;
+
+    /// <summary>Creates the gate: a <paramref name="guardedTools"/> call is blocked when any
+    /// <paramref name="triggerTools"/> call is requested in the same model turn.</summary>
+    public SameBatchOrderingGate(IEnumerable<string> triggerTools, IEnumerable<string> guardedTools, string? policyName = null)
+    {
+        ArgumentNullException.ThrowIfNull(triggerTools);
+        ArgumentNullException.ThrowIfNull(guardedTools);
+        _triggers = new HashSet<string>(triggerTools, StringComparer.OrdinalIgnoreCase);
+        _guarded = new HashSet<string>(guardedTools, StringComparer.OrdinalIgnoreCase);
+        PolicyName = policyName ?? "SameBatchOrderingGate";
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<ToolGateVerdict> InspectAsync(GatedToolCall call, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(call);
+
+        if (_guarded.Contains(call.FunctionName))
+        {
+            foreach (var siblingName in CurrentBatchToolNames(call.Messages))
+            {
+                if (_triggers.Contains(siblingName))
+                {
+                    return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(
+                        PolicyName,
+                        $"tool '{call.FunctionName}' is blocked: a trigger tool ('{siblingName}') was requested in the same model turn — a same-batch ordering that cannot be proven safe"));
+                }
+            }
+        }
+
+        return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
+    }
+
+    // The current iteration's tool calls live in the most recent assistant message that carries any
+    // FunctionCallContent (that is the turn the model just emitted and the harness is now invoking). Earlier
+    // assistant batches are prior iterations — cross-iteration ordering is SequenceGate's job, not this gate's.
+    private static IEnumerable<string> CurrentBatchToolNames(IReadOnlyList<ChatMessage>? messages)
+    {
+        if (messages is null)
+        {
+            yield break;
+        }
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            var message = messages[i];
+            if (message.Role != ChatRole.Assistant)
+            {
+                continue;
+            }
+
+            var any = false;
+            foreach (var content in message.Contents)
+            {
+                if (content is FunctionCallContent fc)
+                {
+                    any = true;
+                    yield return fc.Name;
+                }
+            }
+
+            if (any)
+            {
+                yield break;   // only the most recent assistant batch is "this turn"
+            }
+        }
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
@@ -23,7 +23,9 @@ namespace AgentEval.MAF.Gatekeeper;
 /// <para><b>Per-call, from history.</b> Taint is recomputed from the run's tool results in <c>call.Messages</c>, so
 /// it needs no cross-run state — but a source result must have returned (be present in the history) before the sink
 /// call for the flow to be caught. A source result is attributed to its tool by <b>CallId</b>; a result whose CallId
-/// is missing/unpaired is not tainted (a fail-open edge — keep source CallIds intact through any history reducer).</para>
+/// was stripped (some history reducers drop <c>tool_call_id</c> pairing) falls back to the nearest preceding call's
+/// source-ness, so a CallId-nulling reducer no longer silently disables the gate. Keep source CallIds intact through
+/// any history reducer for the most precise attribution.</para>
 /// </summary>
 public sealed class TaintTrackingGate : IToolGate
 {
@@ -158,31 +160,60 @@ public sealed class TaintTrackingGate : IToolGate
             }
         }
 
+        // Second pass: taint the value tokens of every SOURCE result. Primary attribution is by CallId; a
+        // CallId-less result (Fable 5 §16 — the shape a history reducer produces when it strips tool_call_id
+        // pairing, which would otherwise silently disable the gate) falls back to the nearest preceding call's
+        // source-ness. The fallback is additive: it never taints a result whose nearest preceding call was a
+        // non-source, so it cannot over-block a legitimately-reduced benign result.
+        string? lastCallName = null;
         foreach (var message in messages)
         {
             foreach (var content in message.Contents)
             {
-                if (content is FunctionResultContent fr && fr.CallId is not null && sourceCallIds.Contains(fr.CallId))
+                switch (content)
                 {
-                    foreach (var text in TaintTexts(fr.Result))
-                    {
-                        foreach (Match match in Token.Matches(text))
+                    case FunctionCallContent fcCall:
+                        lastCallName = fcCall.Name;
+                        break;
+
+                    case FunctionResultContent fr when IsSourceResult(fr, sourceCallIds, lastCallName):
+                        foreach (var text in TaintTexts(fr.Result))
                         {
-                            if (match.Value.Length >= _minTaintLength)
+                            foreach (Match match in Token.Matches(text))
                             {
-                                tainted.Add(match.Value);
-                                if (tainted.Count >= MaxTaintedTokens)
+                                if (match.Value.Length >= _minTaintLength)
                                 {
-                                    return tainted;   // cap hit — the caller fails closed rather than scan unboundedly
+                                    tainted.Add(match.Value);
+                                    if (tainted.Count >= MaxTaintedTokens)
+                                    {
+                                        return tainted;   // cap hit — the caller fails closed rather than scan unboundedly
+                                    }
                                 }
                             }
                         }
-                    }
+
+                        break;
                 }
             }
         }
 
         return tainted;
+    }
+
+    private bool IsSourceResult(FunctionResultContent result, HashSet<string> sourceCallIds, string? nearestPrecedingCall)
+    {
+        // Primary: the result's CallId pairs to a source call seen this run.
+        if (result.CallId is not null && sourceCallIds.Contains(result.CallId))
+        {
+            return true;
+        }
+
+        // Fallback (§16): a CallId-less result is attributed to the nearest preceding call and treated as a source
+        // only if THAT call was a source. Scoped to the empty-CallId case, so a legitimately non-source result
+        // (CallId present but not a source) is never mis-tainted — additive, cannot over-block.
+        return string.IsNullOrEmpty(result.CallId)
+            && nearestPrecedingCall is not null
+            && _sources.Contains(nearestPrecedingCall);
     }
 
     // The text a source result contributes to the taint set. When the result is (or serializes to) JSON, only the

--- a/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
@@ -14,12 +14,14 @@ namespace AgentEval.MAF.Gatekeeper;
 /// tool (e.g. <c>http_post</c>, <c>send_email</c>). It taints the value-like tokens in each source tool's result
 /// and blocks a sink call whose arguments carry any of them — closing the exfiltration path that is the payoff of
 /// most indirect injection, without a keyword list.
-/// <para><b>Coarse — a tripwire, not a proof.</b> It matches tainted <i>tokens</i> by <b>case-sensitive substring</b>,
-/// so a value that is transformed (re-encoded, summarized, split, or case-folded) before the sink can slip past, and
-/// an incidental long token shared between a source result and a benign sink argument can false-alarm. Tune
-/// <c>minTaintLength</c> to trade recall for precision, and run it <see cref="ToolGatePolicy.WarnOnly"/> first to
-/// measure false alarms before enforcing. The block reason never echoes the tainted value (that would itself leak
-/// the secret into the trace).</para>
+/// <para><b>Coarse — a tripwire, not a proof.</b> It matches tainted <i>tokens</i> by <b>case-INsensitive
+/// substring</b> — a re-cased copy of a tainted value no longer slips past (Fable 5 §6). Set <c>canonicalize</c> to
+/// also scan decoded projections (percent / HTML-entity / unicode-escape / base64) of each sink argument, catching
+/// a <i>re-encoded</i> copy too. A value transformed in other ways (summarized, split) before the sink can still
+/// slip past, and an incidental long token shared between a source result and a benign sink argument can
+/// false-alarm. Tune <c>minTaintLength</c> to trade recall for precision, and run it
+/// <see cref="ToolGatePolicy.WarnOnly"/> first to measure false alarms before enforcing. The block reason never
+/// echoes the tainted value (that would itself leak the secret into the trace).</para>
 /// <para><b>Per-call, from history.</b> Taint is recomputed from the run's tool results in <c>call.Messages</c>, so
 /// it needs no cross-run state — but a source result must have returned (be present in the history) before the sink
 /// call for the flow to be caught. A source result is attributed to its tool by <b>CallId</b>; a result whose CallId
@@ -42,6 +44,7 @@ public sealed class TaintTrackingGate : IToolGate
     private readonly HashSet<string> _sources;
     private readonly HashSet<string> _sinks;
     private readonly int _minTaintLength;
+    private readonly bool _canonicalize;
 
     /// <inheritdoc/>
     public string PolicyName => "TaintTrackingGate";
@@ -56,10 +59,11 @@ public sealed class TaintTrackingGate : IToolGate
     /// Minimum length of a tainted token to track. Shorter tokens (trivial numbers, short words) are ignored to
     /// curb false alarms. Default 8. Lower it for shorter secrets at the cost of precision.
     /// </param>
-    public TaintTrackingGate(IEnumerable<string> sourceTools, IEnumerable<string> sinkTools, int minTaintLength = 8)
+    public TaintTrackingGate(IEnumerable<string> sourceTools, IEnumerable<string> sinkTools, int minTaintLength = 8, bool canonicalize = false)
     {
         ArgumentNullException.ThrowIfNull(sourceTools);
         ArgumentNullException.ThrowIfNull(sinkTools);
+        _canonicalize = canonicalize;
         _sources = new HashSet<string>(sourceTools, StringComparer.OrdinalIgnoreCase);
         _sinks = new HashSet<string>(sinkTools, StringComparer.OrdinalIgnoreCase);
         if (_sources.Count == 0)
@@ -124,13 +128,23 @@ public sealed class TaintTrackingGate : IToolGate
                 continue;
             }
 
-            foreach (var token in tainted)
+            // Default: the raw arg surface. With canonicalize: also its decoded projections, so a re-encoded copy
+            // of a tainted value (base64/percent/…) is caught too. Matching is case-INsensitive (§6): a re-cased
+            // copy must not slip past.
+            var surfaces = _canonicalize
+                ? ArgumentCanonicalizer.Canonicalize(argText)
+                : (IReadOnlyList<string>)new[] { argText };
+
+            foreach (var surface in surfaces)
             {
-                if (argText.Contains(token, StringComparison.Ordinal))
+                foreach (var token in tainted)
                 {
-                    // Deliberately does NOT include the tainted value — echoing it would leak the secret into the trace.
-                    return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(PolicyName,
-                        $"argument '{kv.Key}' carries data tainted by a confidential source tool to external sink '{call.FunctionName}'"));
+                    if (surface.Contains(token, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Deliberately does NOT include the tainted value — echoing it would leak the secret into the trace.
+                        return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(PolicyName,
+                            $"argument '{kv.Key}' carries data tainted by a confidential source tool to external sink '{call.FunctionName}'"));
+                    }
                 }
             }
         }

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
@@ -15,8 +15,11 @@ namespace AgentEval.MAF.Gatekeeper;
 /// verbatim can carry a secret the caller never intended to hand to the model (or, downstream, to whatever
 /// consumes the model's output).
 /// <para>Each pattern is compiled with a bounded <see cref="Regex.MatchTimeout"/> (the repo's ReDoS guard —
-/// same discipline as <c>RegexPiiGate</c>/<c>ArgumentPatternGate</c>); a timeout on one pattern is treated as
-/// "no match" for that pattern only — the others still run. 300ms (not the 100ms sibling gates use) —
+/// same discipline as <c>RegexPiiGate</c>/<c>ArgumentPatternGate</c>). A timeout is handled <b>fail-CLOSED</b>
+/// (a pattern that could not finish has not proven the result secret-free): the <c>PrivateKey_Block</c> pattern
+/// — the only one that empirically times out — falls back to a ReDoS-immune linear scan that completely and
+/// precisely masks any PEM key block, and a timeout on any other pattern withholds the whole result. Every
+/// timeout is recorded in the verdict reason, never swallowed silently. 300ms (not the 100ms sibling gates use) —
 /// empirically, 100ms occasionally lost the race under CI-runner contention on the multi-line
 /// <c>PrivateKey_Block</c> pattern (a real, non-deterministic timeout on a call that normally completes in
 /// microseconds — pure scheduling jitter under a loaded parallel test run, not a change in the ReDoS threat
@@ -28,20 +31,44 @@ namespace AgentEval.MAF.Gatekeeper;
 /// </summary>
 public sealed class ToolResultSecretGate : IToolResultGate
 {
-    private static readonly TimeSpan SecretTimeout = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan DefaultSecretTimeout = TimeSpan.FromMilliseconds(300);
 
-    private static readonly (string Name, Regex Pattern)[] Patterns =
+    private static readonly (string Name, Regex Pattern)[] DefaultPatterns = BuildPatterns(DefaultSecretTimeout);
+
+    private readonly (string Name, Regex Pattern)[] _patterns;
+
+    /// <summary>Creates the gate. <paramref name="matchTimeout"/> overrides the per-pattern ReDoS
+    /// <see cref="Regex.MatchTimeout"/> (default 300ms); a timeout is handled fail-closed (see the class remarks),
+    /// so tuning it down on constrained hardware is safe. Must be positive.</summary>
+    public ToolResultSecretGate(TimeSpan? matchTimeout = null)
     {
-        ("AWS_AccessKeyId", new Regex(@"\b(AKIA|ASIA)[0-9A-Z]{16}\b", RegexOptions.Compiled, SecretTimeout)),
-        ("GitHub_Token", new Regex(@"\bgh[pousr]_[A-Za-z0-9]{36,}\b", RegexOptions.Compiled, SecretTimeout)),
-        ("Slack_Token", new Regex(@"\bxox[baprs]-[0-9A-Za-z-]{10,48}\b", RegexOptions.Compiled, SecretTimeout)),
-        ("Google_ApiKey", new Regex(@"\bAIza[0-9A-Za-z\-_]{35}\b", RegexOptions.Compiled, SecretTimeout)),
-        ("Stripe_SecretKey", new Regex(@"\bsk_live_[0-9a-zA-Z]{16,}\b", RegexOptions.Compiled, SecretTimeout)),
+        if (matchTimeout is { } t)
+        {
+            if (t <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(matchTimeout), t, "matchTimeout must be positive.");
+            }
+
+            _patterns = t == DefaultSecretTimeout ? DefaultPatterns : BuildPatterns(t);
+        }
+        else
+        {
+            _patterns = DefaultPatterns;
+        }
+    }
+
+    private static (string Name, Regex Pattern)[] BuildPatterns(TimeSpan timeout) => new (string, Regex)[]
+    {
+        ("AWS_AccessKeyId", new Regex(@"\b(AKIA|ASIA)[0-9A-Z]{16}\b", RegexOptions.Compiled, timeout)),
+        ("GitHub_Token", new Regex(@"\bgh[pousr]_[A-Za-z0-9]{36,}\b", RegexOptions.Compiled, timeout)),
+        ("Slack_Token", new Regex(@"\bxox[baprs]-[0-9A-Za-z-]{10,48}\b", RegexOptions.Compiled, timeout)),
+        ("Google_ApiKey", new Regex(@"\bAIza[0-9A-Za-z\-_]{35}\b", RegexOptions.Compiled, timeout)),
+        ("Stripe_SecretKey", new Regex(@"\bsk_live_[0-9a-zA-Z]{16,}\b", RegexOptions.Compiled, timeout)),
         // Matches the WHOLE PEM block (BEGIN..END, non-greedy over the body) so the actual key material gets
         // masked too — matching only the header line would mask a label while leaving the key bytes exposed.
-        ("PrivateKey_Block", new Regex(@"-----BEGIN\s?((RSA|EC|OPENSSH|DSA|PGP)\s)?PRIVATE KEY-----[\s\S]*?-----END\s?((RSA|EC|OPENSSH|DSA|PGP)\s)?PRIVATE KEY-----", RegexOptions.Compiled, SecretTimeout)),
-        ("JWT", new Regex(@"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b", RegexOptions.Compiled, SecretTimeout)),
-        ("Bearer_Token", new Regex(@"\bBearer\s+[A-Za-z0-9\-_.=]{20,}", RegexOptions.Compiled | RegexOptions.IgnoreCase, SecretTimeout)),
+        ("PrivateKey_Block", new Regex(@"-----BEGIN\s?((RSA|EC|OPENSSH|DSA|PGP)\s)?PRIVATE KEY-----[\s\S]*?-----END\s?((RSA|EC|OPENSSH|DSA|PGP)\s)?PRIVATE KEY-----", RegexOptions.Compiled, timeout)),
+        ("JWT", new Regex(@"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b", RegexOptions.Compiled, timeout)),
+        ("Bearer_Token", new Regex(@"\bBearer\s+[A-Za-z0-9\-_.=]{20,}", RegexOptions.Compiled | RegexOptions.IgnoreCase, timeout)),
     };
 
     /// <inheritdoc/>
@@ -61,8 +88,9 @@ public sealed class ToolResultSecretGate : IToolResultGate
         }
 
         var matchedNames = new List<string>();
+        var timedOutNames = new List<string>();
         var redacted = text;
-        foreach (var (name, pattern) in Patterns)
+        foreach (var (name, pattern) in _patterns)
         {
             try
             {
@@ -76,7 +104,38 @@ public sealed class ToolResultSecretGate : IToolResultGate
             }
             catch (RegexMatchTimeoutException)
             {
-                // Treat a timeout as no-match for this pattern (ReDoS guard); other patterns still run.
+                // SEC (Fable 5 review — fail-open fix): a pattern that could not finish scanning has NOT proven
+                // the result secret-free. The old behavior (treat a timeout as no-match) fails OPEN and leaks
+                // exactly the secret the pattern guards — and the multi-line PrivateKey_Block pattern is the one
+                // that empirically times out under load. Record the timeout and fail CLOSED below, never silently.
+                timedOutNames.Add(name);
+            }
+        }
+
+        if (timedOutNames.Count > 0)
+        {
+            // Fail CLOSED for a timed-out scan. For the realistic case (the PEM block pattern) a ReDoS-immune
+            // linear scan is a COMPLETE detector for BEGIN…END…PRIVATE KEY----- spans — so it masks any real key
+            // precisely and, crucially, leaves a genuinely clean result (a spurious jitter timeout on
+            // secret-free text) untouched rather than destroying it.
+            if (timedOutNames.Contains("PrivateKey_Block"))
+            {
+                redacted = MaskPemPrivateKeyBlocksLinear(redacted, out var maskedPem);
+                if (maskedPem)
+                {
+                    matchedNames.Add("PrivateKey_Block");
+                }
+            }
+
+            // A NON-block pattern timing out is not expected (the others are simple single-line shapes). If one
+            // does, we cannot localize the potential secret, so withhold the whole result — the safe direction
+            // over utility, deliberately.
+            if (timedOutNames.Any(n => !string.Equals(n, "PrivateKey_Block", StringComparison.Ordinal)))
+            {
+                var withheld = $"█[redacted: secret scan timed out on {string.Join("/", timedOutNames)} — result withheld]";
+                return new ValueTask<ToolResultVerdict>(ToolResultVerdict.Redact(
+                    PolicyName, withheld,
+                    $"tool '{result.FunctionName}' result withheld: secret scan timed out and could not be verified safe"));
             }
         }
 
@@ -88,5 +147,47 @@ public sealed class ToolResultSecretGate : IToolResultGate
         var verdict = ToolResultVerdict.Redact(
             PolicyName, redacted, $"tool '{result.FunctionName}' result contained secret shape(s): {string.Join(", ", matchedNames)}");
         return new ValueTask<ToolResultVerdict>(verdict);
+    }
+
+    // ReDoS-immune (pure IndexOf, no backtracking) complete detector/masker for PEM PRIVATE KEY blocks — the
+    // fail-closed fallback when the regex-based PrivateKey_Block scan times out. Masks the full span from
+    // "-----BEGIN" through the closing "…PRIVATE KEY-----" so the key body is masked, not just the header label.
+    private static string MaskPemPrivateKeyBlocksLinear(string text, out bool masked)
+    {
+        masked = false;
+        const string Begin = "-----BEGIN";
+        const string End = "-----END";
+        const string KeyTail = "PRIVATE KEY-----";
+
+        var search = 0;
+        while (true)
+        {
+            var begin = text.IndexOf(Begin, search, StringComparison.Ordinal);
+            if (begin < 0)
+            {
+                break;
+            }
+
+            // Anchor the close on "-----END" first so the OPENING header line's own "PRIVATE KEY-----" is never
+            // mistaken for the block end (which would mask only the label and leave the key body exposed).
+            var end = text.IndexOf(End, begin + Begin.Length, StringComparison.Ordinal);
+            if (end < 0)
+            {
+                break;
+            }
+
+            var keyTail = text.IndexOf(KeyTail, end, StringComparison.Ordinal);
+            if (keyTail < 0)
+            {
+                break;
+            }
+
+            var blockEnd = keyTail + KeyTail.Length;
+            text = text.Substring(0, begin) + new string('█', blockEnd - begin) + text.Substring(blockEnd);
+            masked = true;
+            search = blockEnd;
+        }
+
+        return text;
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
@@ -149,6 +149,34 @@ public sealed class ToolResultSecretGate : IToolResultGate
         return new ValueTask<ToolResultVerdict>(verdict);
     }
 
+    /// <summary>Masks any recognized credential SHAPE (the same patterns this gate applies to a tool result) in
+    /// <paramref name="text"/> with block characters — exposed for reuse by diagnostic capture sinks (Fable 5 §12 /
+    /// P1-5) so a captured fixture doesn't persist a live secret in plaintext. Best-effort: a per-pattern timeout
+    /// skips that pattern rather than throwing (a diagnostic sink must never throw); pair with owner-only file
+    /// permissions for defense in depth.</summary>
+    public static string MaskSecrets(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var masked = text;
+        foreach (var (_, pattern) in DefaultPatterns)
+        {
+            try
+            {
+                masked = pattern.Replace(masked, m => new string('█', m.Length));
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Diagnostic capture, not an enforcement gate — skip a slow pattern rather than throw.
+            }
+        }
+
+        return masked;
+    }
+
     // ReDoS-immune (pure IndexOf, no backtracking) complete detector/masker for PEM PRIVATE KEY blocks — the
     // fail-closed fallback when the regex-based PrivateKey_Block scan times out. Masks the full span from
     // "-----BEGIN" through the closing "…PRIVATE KEY-----" so the key body is masked, not just the header label.

--- a/src/AgentEval.MAF/Gatekeeper/UncalibratedInlineJudgeException.cs
+++ b/src/AgentEval.MAF/Gatekeeper/UncalibratedInlineJudgeException.cs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Thrown by <see cref="GatekeeperOptions.ValidateInlineJudgesAsync"/> when an inline LLM judge has not earned the
+/// right to block — no calibration report exists for its axis, or the latest report is not inline-ready (Fable 5
+/// §9 / P1-1). Mirrors the fail-loud posture of <c>PromptTemplateDriftException</c> / <c>SkillDriftException</c>:
+/// an un-proven judge that hard-blocks is a fabrication risk the toolkit argues is worse than no gate at all.
+/// </summary>
+public sealed class UncalibratedInlineJudgeException : Exception
+{
+    /// <summary>The calibration axis of the judge that failed the readiness check.</summary>
+    public string AxisName { get; }
+
+    /// <summary>Creates the exception for <paramref name="axisName"/> with the given <paramref name="reason"/>.</summary>
+    public UncalibratedInlineJudgeException(string axisName, string reason)
+        : base($"inline judge '{axisName}' may not block: {reason}. Calibrate it (GateCalibrationHarness) and persist "
+               + "an inline-ready report to the CalibrationReportStore, or set GatekeeperOptions.AllowUncalibratedInlineJudge to override.")
+    {
+        AxisName = axisName;
+    }
+}

--- a/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCapturingChatClientTests.cs
+++ b/tests/AgentEval.Tests/Cli/Infrastructure/FixtureCapturingChatClientTests.cs
@@ -56,6 +56,33 @@ public class FixtureCapturingChatClientTests
     }
 
     [Fact]
+    public async Task GetResponseAsync_MasksSecretShapes_ByDefault()
+    {
+        // Fable 5 §12 / P1-5: a captured fixture must not persist a live secret in plaintext.
+        var scripted = new ScriptedChatClient().AddText("here is the key AKIAABCDEFGHIJKLMNOP for you");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink);
+
+        await client.GetResponseAsync(Conversation());
+
+        var raw = sink.ToString();
+        Assert.DoesNotContain("AKIAABCDEFGHIJKLMNOP", raw);   // the AWS-key shape was masked before writing
+        Assert.Contains("here is the key", raw);               // surrounding text preserved
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_RedactSecretsFalse_KeepsRawValues()
+    {
+        var scripted = new ScriptedChatClient().AddText("here is the key AKIAABCDEFGHIJKLMNOP for you");
+        var sink = new StringWriter();
+        var client = new FixtureCapturingChatClient(scripted, sink, redactSecrets: false);
+
+        await client.GetResponseAsync(Conversation());
+
+        Assert.Contains("AKIAABCDEFGHIJKLMNOP", sink.ToString());   // explicit opt-out preserves raw values
+    }
+
+    [Fact]
     public async Task GetResponseAsync_ToolCall_CapturesCallIdNameAndArguments()
     {
         var scripted = new ScriptedChatClient().AddToolCall("c1", "SearchFlights", new Dictionary<string, object?> { ["to"] = "NRT" });

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/BeachheadGatesTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/BeachheadGatesTests.cs
@@ -234,4 +234,60 @@ public class BeachheadGatesTests
         var v = await gate.InspectAsync(Call("fetch", new Dictionary<string, object?> { ["url"] = "https://api.example.com?token=abc" }));
         Assert.Equal(ToolGateAction.Allow, v.Action);
     }
+
+    // ─────────── DomainAllowListGate — bare hosts & data: URIs (Fable 5 §14 / P1-8) ───────────
+
+    [Fact]
+    public async Task DomainAllowList_BareHostArgument_OffList_Blocks()
+    {
+        // A tool that takes a bare host (no "//") and adds the scheme itself: the URL scan misses it, so the
+        // caller declares it via hostArguments and its VALUE is validated against the same allow-list.
+        var gate = new DomainAllowListGate(["example.com"], hostArguments: ["host"]);
+        var v = await gate.InspectAsync(Call("connect", new Dictionary<string, object?> { ["host"] = "attacker.example" }));
+        Assert.Equal(ToolGateAction.Block, v.Action);
+    }
+
+    [Fact]
+    public async Task DomainAllowList_BareHostArgument_OnList_Allows()
+    {
+        var gate = new DomainAllowListGate(["example.com"], hostArguments: ["host"]);
+        var v = await gate.InspectAsync(Call("connect", new Dictionary<string, object?> { ["host"] = "api.example.com" }));
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task DomainAllowList_BareHostArgument_WithPort_ExtractsHost()
+    {
+        var gate = new DomainAllowListGate(["example.com"], hostArguments: ["host"]);
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(Call("connect", new Dictionary<string, object?> { ["host"] = "api.example.com:8443" }))).Action);
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(Call("connect", new Dictionary<string, object?> { ["host"] = "evil.example:8443" }))).Action);
+    }
+
+    [Fact]
+    public async Task DomainAllowList_BareHost_WithoutHostArguments_Allows_PreservesDefault()
+    {
+        // Default (no hostArguments): a bare host with no "//" is NOT scanned — the pre-P1-8 behavior, preserved
+        // so the change is non-breaking. This documents exactly why hostArguments must be opt-in.
+        var gate = new DomainAllowListGate(["example.com"]);
+        var v = await gate.InspectAsync(Call("connect", new Dictionary<string, object?> { ["host"] = "attacker.example" }));
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task DomainAllowList_DataUri_Blocks()
+    {
+        var gate = new DomainAllowListGate(["example.com"]);
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(Call("render", new Dictionary<string, object?> { ["src"] = "data:text/html,<script>steal()</script>" }))).Action);
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(Call("render", new Dictionary<string, object?> { ["src"] = "data:;base64,SGVsbG8=" }))).Action);
+    }
+
+    [Fact]
+    public async Task DomainAllowList_LiteralDataWordInProse_DoesNotFalsePositive()
+    {
+        // The conservative data: matcher requires a real data-URI comma directly after the (optional) mediatype;
+        // the word "data:" in prose must NOT block.
+        var gate = new DomainAllowListGate(["example.com"]);
+        var v = await gate.InspectAsync(Call("note", new Dictionary<string, object?> { ["text"] = "see the data: section below, then continue" }));
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/CanonicalizationTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/CanonicalizationTests.cs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using AgentEval.MAF.Gatekeeper;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>F-D + P1-2 (§6/§13): ArgumentCanonicalizer and the deterministic gates that opt into it.</summary>
+public class CanonicalizationTests
+{
+    private static string B64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s));
+
+    // ── F-D: ArgumentCanonicalizer ──
+
+    [Fact]
+    public void RawIsAlwaysTheFirstProjection()
+    {
+        var p = ArgumentCanonicalizer.Canonicalize("plain text with no encoding");
+        Assert.Equal("plain text with no encoding", p[0]);
+    }
+
+    [Fact]
+    public void PercentEncoding_Decoded()
+        => Assert.Contains(ArgumentCanonicalizer.Canonicalize("http%3A%2F%2Fevil.com%2Fx"), s => s.Contains("http://evil.com/x", StringComparison.Ordinal));
+
+    [Fact]
+    public void HtmlEntities_Decoded()
+        => Assert.Contains(ArgumentCanonicalizer.Canonicalize("&lt;script&gt;alert(1)&lt;/script&gt;"), s => s.Contains("<script>", StringComparison.Ordinal));
+
+    [Fact]
+    public void UnicodeEscapes_Decoded()
+        => Assert.Contains(ArgumentCanonicalizer.Canonicalize(@"../../etc/passwd"), s => s.Contains("../../etc/passwd", StringComparison.Ordinal));
+
+    [Fact]
+    public void Base64Candidate_DecodedToPrintableText()
+        => Assert.Contains(ArgumentCanonicalizer.Canonicalize($"payload={B64("exfiltrate-this-secret")}"), s => s.Contains("exfiltrate-this-secret", StringComparison.Ordinal));
+
+    [Fact]
+    public void PlainAlphanumerics_NotFalseDecodedAsBase64()
+    {
+        // A short/non-multiple-of-4 alphanumeric run isn't treated as base64; a plain string yields only itself.
+        var p = ArgumentCanonicalizer.Canonicalize("orderid ABC123 lookup");
+        Assert.Single(p);
+    }
+
+    [Fact]
+    public void OversizedProjection_DroppedToBoundDecodeBombs()
+    {
+        // A projection that would exceed maxLength is dropped — the raw still returns.
+        var raw = "%41" + new string('B', 100);   // decodes ~same length; force a tiny cap
+        var p = ArgumentCanonicalizer.Canonicalize(raw, maxLength: 10);
+        Assert.All(p, s => Assert.True(s.Length <= 10));
+    }
+
+    // ── ArgumentPatternGate (§13) ──
+
+    private static GatedToolCall Args(string tool, params (string k, object? v)[] args)
+        => new(tool, args.ToDictionary(a => a.k, a => a.v), "A", 0, 0, 1, false, null);
+
+    [Fact]
+    public async Task ArgumentPattern_EncodedTraversal_CaughtOnlyWithCanonicalize()
+    {
+        var pattern = new Regex(@"\.\./", RegexOptions.None, TimeSpan.FromMilliseconds(100));
+        var encoded = Args("read_file", ("path", "..%2f..%2fetc%2fpasswd"));
+
+        var plain = new ArgumentPatternGate(pattern);                       // raw surface only
+        Assert.Equal(ToolGateAction.Allow, (await plain.InspectAsync(encoded)).Action);
+
+        var canon = new ArgumentPatternGate(pattern, canonicalize: true);   // + decoded projections
+        Assert.Equal(ToolGateAction.Block, (await canon.InspectAsync(encoded)).Action);
+    }
+
+    // ── DomainAllowListGate (§13) ──
+
+    [Fact]
+    public async Task DomainAllowList_PercentEncodedOffListUrl_CaughtOnlyWithCanonicalize()
+    {
+        var encoded = Args("fetch", ("url", "http%3A%2F%2Fevil.com%2Fcollect"));
+
+        var plain = new DomainAllowListGate(["example.com"]);
+        Assert.Equal(ToolGateAction.Allow, (await plain.InspectAsync(encoded)).Action);
+
+        var canon = new DomainAllowListGate(["example.com"], canonicalize: true);
+        Assert.Equal(ToolGateAction.Block, (await canon.InspectAsync(encoded)).Action);
+    }
+
+    // ── TaintTrackingGate (§6 case-fold + canonicalize) ──
+
+    private static ChatMessage AssistantCall(string callId, string name)
+        => new(ChatRole.Assistant, [new FunctionCallContent(callId, name, new Dictionary<string, object?>())]);
+
+    private static ChatMessage ToolResult(string callId, object? result)
+        => new(ChatRole.Tool, [new FunctionResultContent(callId, result)]);
+
+    private static GatedToolCall Sink(string tool, string body, params ChatMessage[] history)
+        => new(tool, new Dictionary<string, object?> { ["body"] = body }, "A", 0, 0, 1, false, history);
+
+    [Fact]
+    public async Task Taint_CaseFoldedTaintedValue_NowBlocked()
+    {
+        // §6: a re-cased copy of the tainted value must not slip past (source UPPER, sink lower).
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        var call = Sink("http_post", "here: demo-9a8b7c6d5e4f",
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=DEMO-9A8B7C6D5E4F"));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(call)).Action);
+    }
+
+    [Fact]
+    public async Task Taint_Base64EncodedTaintedValue_CaughtOnlyWithCanonicalize()
+    {
+        var secret = "exfiltrate-this-secret";
+        var source = AssistantCall("c1", "read_secrets");
+        var result = ToolResult("c1", $"SECRET={secret}");
+
+        var plain = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        Assert.Equal(ToolGateAction.Allow, (await plain.InspectAsync(Sink("http_post", B64(secret), source, result))).Action);
+
+        var canon = new TaintTrackingGate(["read_secrets"], ["http_post"], canonicalize: true);
+        Assert.Equal(ToolGateAction.Block, (await canon.InspectAsync(Sink("http_post", B64(secret), source, result))).Action);
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperCoverageAnalyzerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperCoverageAnalyzerTests.cs
@@ -155,6 +155,47 @@ public class GatekeeperCoverageAnalyzerTests
     }
 
     [Fact]
+    public void AcknowledgeProviderHostedTools_ExemptsNamedOpaqueTool()
+    {
+        // P1-3: the sanctioned escape hatch — an explicitly acknowledged code-interpreter is admitted.
+        var tool = new HostedCodeInterpreterTool();
+        var options = new AnalyzeOptions { AcknowledgeProviderHostedTools = new HashSet<string> { tool.Name } };
+        var report = GatekeeperCoverageAnalyzer.AnalyzeOrThrow(BuildAgent(tool), options: options);
+        Assert.False(report.HasUnprotectedHighRiskTools);
+    }
+
+    [Fact]
+    public void UnacknowledgedOpaqueTool_StillThrows()
+    {
+        var options = new AnalyzeOptions { AcknowledgeProviderHostedTools = new HashSet<string> { "a-different-tool" } };
+        Assert.Throws<UnprotectedHighRiskToolException>(
+            () => GatekeeperCoverageAnalyzer.AnalyzeOrThrow(BuildAgent(new HostedCodeInterpreterTool()), options: options));
+    }
+
+    [Fact]
+    public void DynamicToolProvider_EmptyStaticTools_FailsClosed_NotVacuous100()
+    {
+        // P1-12 (§1): an agent whose tools come only from an AIContextProvider (declared here) must NOT be
+        // certified as vacuously 100%-covered — AnalyzeOrThrow refuses rather than green-light an unverified agent.
+        var options = new AnalyzeOptions { HasDynamicToolProvider = true };
+        var report = GatekeeperCoverageAnalyzer.Analyze(BuildAgent(), options: options);   // no static tools
+        Assert.False(report.ToolInventoryAvailable);
+        Assert.Throws<ToolInventoryUnavailableException>(() => GatekeeperCoverageAnalyzer.AnalyzeOrThrow(BuildAgent(), options: options));
+    }
+
+    [Fact]
+    public void DynamicToolProvider_WithStaticTools_StillAnalyzedNormally()
+    {
+        // The flag only fails closed when the static list is EMPTY; a declared provider alongside static tools does
+        // not disable ordinary analysis of those static tools.
+        var options = new AnalyzeOptions { HasDynamicToolProvider = true };
+        var tool = AIFunctionFactory.Create((string x) => x, "lookup");
+        var report = GatekeeperCoverageAnalyzer.Analyze(BuildAgent(tool), [new ForbiddenToolGate("x")], options);
+        Assert.True(report.ToolInventoryAvailable);
+        Assert.Single(report.Tools);
+    }
+
+    [Fact]
     public void CustomRiskHeuristic_OverridesDefault()
     {
         var tool = AIFunctionFactory.Create((string x) => x, "lookup_order");   // Standard by default

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperCoverageAnalyzerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperCoverageAnalyzerTests.cs
@@ -127,6 +127,34 @@ public class GatekeeperCoverageAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeOrThrow_UnprotectedHostedCodeInterpreter_Throws_ByDefault()
+    {
+        // Fable 5 fix: a hosted code interpreter is uninterceptable AND arbitrary-capability, so it must be
+        // treated as unprotected-high-risk by default — the old behavior classified it Standard and admitted it.
+        var report = GatekeeperCoverageAnalyzer.Analyze(BuildAgent(new HostedCodeInterpreterTool()));
+        Assert.True(report.HasUnprotectedHighRiskTools);
+        Assert.Throws<UnprotectedHighRiskToolException>(
+            () => GatekeeperCoverageAnalyzer.AnalyzeOrThrow(BuildAgent(new HostedCodeInterpreterTool())));
+    }
+
+    [Fact]
+    public void HostedCodeInterpreter_OptOut_NotFlaggedHighRisk()
+    {
+        var options = new AnalyzeOptions { TreatArbitraryCapabilityOpaqueToolsAsHighRisk = false };
+        var report = GatekeeperCoverageAnalyzer.Analyze(BuildAgent(new HostedCodeInterpreterTool()), options: options);
+        Assert.False(report.HasUnprotectedHighRiskTools);   // explicit opt-out restores the lenient behavior
+    }
+
+    [Fact]
+    public void HostedWebSearch_NotAutoHighRisk_NarrowingPreserved()
+    {
+        // Narrowing: only arbitrary-capability opaque tools auto-escalate. A hosted web search (far narrower)
+        // stays on the keyword heuristic and does NOT trip AnalyzeOrThrow.
+        var report = GatekeeperCoverageAnalyzer.AnalyzeOrThrow(BuildAgent(new HostedWebSearchTool()));
+        Assert.False(report.HasUnprotectedHighRiskTools);
+    }
+
+    [Fact]
     public void CustomRiskHeuristic_OverridesDefault()
     {
         var tool = AIFunctionFactory.Create((string x) => x, "lookup_order");   // Standard by default

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/InlineJudgeReadinessTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/InlineJudgeReadinessTests.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails.Judges;
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>P1-1 / §9 — an inline LLM judge must be proven calibration-ready before it may block.</summary>
+public class InlineJudgeReadinessTests
+{
+    private sealed class StubRubric : IJudgeRubric
+    {
+        public string Axis => "stub-axis";
+        public bool Prefilter(string text) => false;   // never reaches the model; behavior is irrelevant to the guard
+        public string BuildPrompt(string text) => text;
+        public JudgeVerdict Parse(string modelReply) => JudgeVerdict.Inconclusive();
+    }
+
+    private static CompositeJudgeGate<StubRubric> Judge() => new(new StubRubric(), new ScriptedChatClient().AddText("x"));
+
+    [Fact]
+    public void CompositeJudgeGate_ExposesAxisName_ForTheCalibrationGuard()
+    {
+        IRequiresCalibration gate = Judge();
+        Assert.Equal("stub-axis", gate.AxisName);
+    }
+
+    [Fact]
+    public async Task ValidateInlineJudges_UncalibratedInlineJudge_NoStore_Throws()
+    {
+        var options = new GatekeeperOptions();
+        options.PreGates.Add(Judge());
+        var ex = await Assert.ThrowsAsync<UncalibratedInlineJudgeException>(() => options.ValidateInlineJudgesAsync());
+        Assert.Equal("stub-axis", ex.AxisName);
+    }
+
+    [Fact]
+    public async Task ValidateInlineJudges_EscapeHatch_Passes()
+    {
+        var options = new GatekeeperOptions { AllowUncalibratedInlineJudge = true };
+        options.PostGates.Add(Judge());
+        await options.ValidateInlineJudgesAsync();   // loud opt-out honored — does not throw
+    }
+
+    [Fact]
+    public async Task ValidateInlineJudges_NoInlineJudges_Passes()
+    {
+        var options = new GatekeeperOptions();
+        await options.ValidateInlineJudgesAsync();   // trivially passes when nothing needs calibration
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/ReferentialIntegrityGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/ReferentialIntegrityGateTests.cs
@@ -54,6 +54,41 @@ public class ReferentialIntegrityGateTests
         Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(call)).Action);
     }
 
+    // ── P1-9 / §7 — alpha-only id coverage via IdentifierRecognizers (default deliberately unchanged) ──
+
+    [Fact]
+    public async Task Default_DoesNotValidateAlphaOnlyId_GapPreserved()
+    {
+        // The default recogniser (ContainsDigit) does NOT flag an all-letter id — the deliberate, non-breaking
+        // default (flagging every alpha token would false-alarm on ordinary words).
+        var gate = new ReferentialIntegrityGate(["user"], ["promote"]);
+        var call = Call("promote", new Dictionary<string, object?> { ["user"] = "admin_backup" },
+            User("Promote alice please."));
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(call)).Action);
+    }
+
+    [Fact]
+    public async Task MatchingRecognizer_BlocksInventedAlphaId_AllowsObserved()
+    {
+        var idShape = new System.Text.RegularExpressions.Regex(
+            "^(usr|adm)_[a-z0-9]{3,}$", System.Text.RegularExpressions.RegexOptions.None, TimeSpan.FromMilliseconds(100));
+        var gate = new ReferentialIntegrityGate(["user"], ["promote"], isIdentifier: IdentifierRecognizers.Matching(idShape));
+
+        var invented = Call("promote", new Dictionary<string, object?> { ["user"] = "adm_backup" }, User("Promote usr_alice."));
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(invented)).Action);   // adm_backup never surfaced
+
+        var observed = Call("promote", new Dictionary<string, object?> { ["user"] = "usr_alice" }, User("Promote usr_alice."));
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(observed)).Action);    // usr_alice came from the user
+    }
+
+    [Fact]
+    public async Task AlphanumericMinLengthRecognizer_ValidatesLongAlphaIds()
+    {
+        var gate = new ReferentialIntegrityGate(["user"], ["promote"], isIdentifier: IdentifierRecognizers.AlphanumericMinLength(6));
+        var call = Call("promote", new Dictionary<string, object?> { ["user"] = "adminbackup" }, User("Promote someoneelse."));
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(call)).Action);   // long alpha token, never observed
+    }
+
     [Fact]
     public async Task Allows_Id_FromTrustedLookupResult()
     {

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/SameBatchOrderingGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/SameBatchOrderingGateTests.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>P1-8/§12 — SameBatchOrderingGate closes the same-iteration concurrency seam SequenceGate can't cover.</summary>
+public class SameBatchOrderingGateTests
+{
+    private static ChatMessage AssistantBatch(params string[] toolNames)
+    {
+        var contents = new List<AIContent>();
+        for (var i = 0; i < toolNames.Length; i++)
+        {
+            contents.Add(new FunctionCallContent($"call-{i}", toolNames[i], arguments: null));
+        }
+
+        return new ChatMessage(ChatRole.Assistant, contents);
+    }
+
+    private static GatedToolCall Call(string name, params ChatMessage[] messages)
+        => new(name, Arguments: null, AgentName: "A", Iteration: 0, FunctionCallIndex: 0, FunctionCount: 1,
+               IsStreaming: false, Messages: messages);
+
+    [Fact]
+    public async Task TriggerAndGuardedInOneTurn_BlocksGuarded()
+    {
+        var gate = new SameBatchOrderingGate(["read_secrets"], ["send_email"]);
+        // Both requested in one assistant turn — the read→exfil combo SequenceGate cannot order.
+        var v = await gate.InspectAsync(Call("send_email", AssistantBatch("read_secrets", "send_email")));
+        Assert.Equal(ToolGateAction.Block, v.Action);
+    }
+
+    [Fact]
+    public async Task GuardedAlone_Allows()
+    {
+        var gate = new SameBatchOrderingGate(["read_secrets"], ["send_email"]);
+        var v = await gate.InspectAsync(Call("send_email", AssistantBatch("send_email")));
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task TriggerInPriorTurnOnly_Allows_ThatIsSequenceGatesJob()
+    {
+        // A trigger in a PRIOR assistant turn is cross-iteration ordering (SequenceGate's job); only the CURRENT
+        // batch counts for this gate.
+        var gate = new SameBatchOrderingGate(["read_secrets"], ["send_email"]);
+        var prior = AssistantBatch("read_secrets");
+        var toolResult = new ChatMessage(ChatRole.Tool, [new FunctionResultContent("call-0", "secret-value")]);
+        var current = AssistantBatch("send_email");
+        var v = await gate.InspectAsync(Call("send_email", prior, toolResult, current));
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task NonGuardedCall_AlwaysAllows()
+    {
+        var gate = new SameBatchOrderingGate(["read_secrets"], ["send_email"]);
+        var v = await gate.InspectAsync(Call("read_secrets", AssistantBatch("read_secrets", "send_email")));
+        Assert.Equal(ToolGateAction.Allow, v.Action);   // this call is the trigger, not the guarded one
+    }
+
+    [Fact]
+    public async Task NullMessages_Allows_FailsafeNoBatchVisible()
+    {
+        var gate = new SameBatchOrderingGate(["read_secrets"], ["send_email"]);
+        var v = await gate.InspectAsync(Call("send_email"));   // no messages → no batch to inspect
+        Assert.Equal(ToolGateAction.Allow, v.Action);
+    }
+
+    [Fact]
+    public async Task Matching_IsCaseInsensitive()
+    {
+        var gate = new SameBatchOrderingGate(["Read_Secrets"], ["Send_Email"]);
+        var v = await gate.InspectAsync(Call("send_email", AssistantBatch("READ_SECRETS", "send_email")));
+        Assert.Equal(ToolGateAction.Block, v.Action);
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/SameBatchOrderingGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/SameBatchOrderingGateTests.cs
@@ -3,8 +3,13 @@
 // Licensed under the MIT License.
 
 using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using AgentEval.Tracing;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Xunit;
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+using ChatRole = Microsoft.Extensions.AI.ChatRole;
 
 namespace AgentEval.Tests.MAF.Gatekeeper;
 
@@ -78,5 +83,36 @@ public class SameBatchOrderingGateTests
         var gate = new SameBatchOrderingGate(["Read_Secrets"], ["Send_Email"]);
         var v = await gate.InspectAsync(Call("send_email", AssistantBatch("READ_SECRETS", "send_email")));
         Assert.Equal(ToolGateAction.Block, v.Action);
+    }
+
+    [Fact]
+    public async Task Inline_BlocksGuarded_WhenTriggerIsInTheSameParallelTurn()
+    {
+        // Integration: a real agent emits read_secrets + send_email as PARALLEL calls in ONE turn. Confirms MAF
+        // surfaces the current batch's sibling calls in call.Messages, so the gate fires end-to-end (not just at
+        // the unit level).
+        var sent = 0;
+        var read = AIFunctionFactory.Create(() => "secret", "read_secrets");
+        var send = AIFunctionFactory.Create((string to, string body) => { Interlocked.Increment(ref sent); return "ok"; }, "send_email");
+        var scripted = new ScriptedChatClient()
+            .AddParallelToolCalls(
+                ("c1", "read_secrets", new Dictionary<string, object?>()),
+                ("c2", "send_email", new Dictionary<string, object?> { ["to"] = "x@evil.com", ["body"] = "leak" }))
+            .AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions
+        {
+            Name = "T",
+            ChatOptions = new ChatOptions { Tools = [read, send] },
+        });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate()
+            .UseAgentEvalToolGate([new SameBatchOrderingGate(["read_secrets"], ["send_email"])], ToolGatePolicy.ReplaceResult, trace)
+            .Build();
+
+        await gated.RunAsync("read and send in one turn");
+
+        Assert.Equal(0, sent);   // the guarded send_email, requested in the same batch as the trigger, was blocked
+        Assert.True(GlassBoxEvidence.FromTrace(trace)!.GateBlockCount >= 1);
     }
 }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/SessionGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/SessionGateTests.cs
@@ -87,6 +87,54 @@ public class SessionGateTests
         Assert.Equal("b", r3.Text);   // 2nd scripted turn (the blocked run never reached the model)
     }
 
+    private const string TestSessionIdKey = "test.session.id";
+
+    private static string? StableIdFromStateBag(AgentSession s)
+        => s.StateBag.TryGetValue<string>(TestSessionIdKey, out var id, JsonSerializerOptions.Default) ? id : null;
+
+    [Fact]
+    public async Task Rate_StableKeySelector_CounterSurvivesSessionReload()
+    {
+        // Fable 5 security fix: with a stable-id selector, the cap must survive a persisted-session reload
+        // (a fresh AgentSession OBJECT carrying the same logical id) instead of resetting.
+        const string stableId = "logical-session-42";
+        var clock = new FakeClock { Now = DateTimeOffset.UnixEpoch };
+        var scripted = new ScriptedChatClient().AddText("a").AddText("b").AddText("c");
+        var gate = new RateLimitGate(maxRuns: 1, window: TimeSpan.FromMinutes(1), timeProvider: clock,
+            sessionKeySelector: StableIdFromStateBag);
+        var agent = GatedWith(scripted, gate);
+
+        var session1 = await agent.CreateSessionAsync();
+        session1.StateBag.SetValue(TestSessionIdKey, stableId, JsonSerializerOptions.Default);
+        var r1 = await agent.RunAsync("go", session1);
+        Assert.Equal("a", r1.Text);   // first run of the logical session → allowed
+
+        // "reload": a brand-new session object, same logical id → the counter carried over → blocked.
+        var session2 = await agent.CreateSessionAsync();
+        session2.StateBag.SetValue(TestSessionIdKey, stableId, JsonSerializerOptions.Default);
+        var ex = await Record.ExceptionAsync(() => agent.RunAsync("go", session2));
+        Assert.IsType<EvalGateRefusalException>(ex);
+    }
+
+    [Fact]
+    public async Task Rate_DefaultObjectIdentity_ReloadResetsCounter_KnownLimit()
+    {
+        // Documents the DEFAULT (no selector) behavior the fix preserves: object-identity keying, so a fresh
+        // session object resets the counter. This is exactly why the selector above exists for persisted sessions.
+        var clock = new FakeClock { Now = DateTimeOffset.UnixEpoch };
+        var scripted = new ScriptedChatClient().AddText("a").AddText("b").AddText("c");
+        var gate = new RateLimitGate(maxRuns: 1, window: TimeSpan.FromMinutes(1), timeProvider: clock);
+        var agent = GatedWith(scripted, gate);
+
+        var session1 = await agent.CreateSessionAsync();
+        var r1 = await agent.RunAsync("go", session1);
+        Assert.Equal("a", r1.Text);
+
+        var session2 = await agent.CreateSessionAsync();   // fresh object → counter resets (default behavior)
+        var r2 = await agent.RunAsync("go", session2);
+        Assert.Equal("b", r2.Text);   // allowed — NOT blocked, because object identity differs
+    }
+
     // ── streaming path: session gates must see the run scope on the streaming branch too ──
 
     [Fact]

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
@@ -42,6 +42,35 @@ public class TaintTrackingGateTests
         Assert.DoesNotContain("demo-9a8b7c6d5e4f", verdict.Reason!);   // the secret must NOT be echoed into the trace
     }
 
+    private static ChatMessage ToolResultNoCallId(object? result)
+        => new(ChatRole.Tool, [new FunctionResultContent(string.Empty, result)]);   // reducer-stripped CallId
+
+    [Fact]
+    public async Task Blocks_TaintedSecret_WhenReducerStrippedTheSourceResultCallId()
+    {
+        // Fable 5 §16 fallback: a history reducer nulled the source result's CallId, so primary CallId attribution
+        // fails — but the nearest preceding call (read_secrets) is a source, so the result is still tainted.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        var call = Call("http_post", new Dictionary<string, object?> { ["body"] = "here you go: demo-9a8b7c6d5e4f" },
+            AssistantCall("c1", "read_secrets"),
+            ToolResultNoCallId("API_KEY=demo-9a8b7c6d5e4f"));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(call)).Action);
+    }
+
+    [Fact]
+    public async Task Allows_CallIdLessResult_WhenNearestPrecedingCallIsNotASource()
+    {
+        // The fallback is additive: a CallId-less result whose nearest preceding call was a NON-source is NOT
+        // tainted — it must never over-block a legitimately-reduced benign result.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        var call = Call("http_post", new Dictionary<string, object?> { ["body"] = "value demo-9a8b7c6d5e4f" },
+            AssistantCall("c1", "get_weather"),          // non-source call
+            ToolResultNoCallId("temp demo-9a8b7c6d5e4f"));
+
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(call)).Action);
+    }
+
     [Fact]
     public async Task Allows_Sink_WithNoTaintedData()
     {

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/ToolResultGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/ToolResultGateTests.cs
@@ -489,6 +489,29 @@ public class ToolResultGateTests
     }
 
     [Fact]
+    public async Task ToolResultSecretGate_ScanTimeout_FailsClosed_DoesNotLeakSecret()
+    {
+        // Fail-open regression (Fable 5 review): before the fix, a RegexMatchTimeoutException was swallowed and
+        // treated as "no match" — so a PEM private key in a result that timed out the scan flowed to the model
+        // UNMASKED. Force the timeout deterministically with a 1-tick budget over a large input, and assert the
+        // gate fails CLOSED: the key never appears in what the model would see, and the verdict is not Allow.
+        var pemKey = "-----BEGIN RSA PRIVATE KEY-----\n" + new string('M', 2048) + "\n-----END RSA PRIVATE KEY-----";
+        var bigResult = new string('x', 200_000) + "\n" + pemKey + "\n" + new string('y', 200_000);
+
+        var gate = new ToolResultSecretGate(matchTimeout: TimeSpan.FromTicks(1));
+        var verdict = await gate.InspectAsync(MakeResult(bigResult));
+
+        Assert.NotEqual(ToolResultAction.Allow, verdict.Action);   // must NOT pass the secret through
+        var shown = verdict.RedactedResult as string ?? string.Empty;
+        Assert.DoesNotContain("-----BEGIN RSA PRIVATE KEY-----", shown, StringComparison.Ordinal);
+        Assert.DoesNotContain(new string('M', 2048), shown, StringComparison.Ordinal);   // the key body itself
+    }
+
+    [Fact]
+    public void ToolResultSecretGate_NonPositiveMatchTimeout_Throws()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new ToolResultSecretGate(matchTimeout: TimeSpan.Zero));
+
+    [Fact]
     public async Task ToolResultSecretGate_EndToEnd_MasksSecretBeforeItReachesFinalResponse_ToolStillExecuted()
     {
         var executed = 0;


### PR DESCRIPTION
## Gatekeeper security hardening — Fable 5 review (Phase 1 COMPLETE)

Closes the confirmed **fail-open / evasion / unverified** class the Fable 5 review found in the Gatekeeper.
Every fix fails **closed** and ships with regression tests. **Full test project: 8313 passed, 2 skipped, 0 failed**
(net8/9/10 build clean).

### Fixes (Phase 0 + Phase 1)
| Task | Fix | § |
|---|---|---|
| F1 | `ToolResultSecretGate` fails **closed** on regex timeout (ReDoS-immune PEM mask) | 3 |
| F2 | Opaque code-interpreter/MCP tools → HighRisk so `AnalyzeOrThrow` refuses them | 2 |
| F3 | `RateLimitGate` counter survives a session reload (opt-in stable-id selector) | 4/5 |
| P1-1 | **`InlineJudgeReadinessGuard`** — `ValidateInlineJudgesAsync` refuses an un-calibrated inline judge | 9 |
| P1-2 | **`ArgumentCanonicalizer`** (F-D) + opt-in `canonicalize`; TaintTracking case-insensitive | 6/13 |
| P1-3 | `AnalyzeOptions.AcknowledgeProviderHostedTools` — audited escape hatch for F2 | 2 |
| P1-5 | `--capture-fixture` masks secrets (`ToolResultSecretGate.MaskSecrets`) | 12 |
| P1-6 | `McpToolDescriptionPoisoningGate` honest-limits docs (TOFU/unsigned/unwired) | 15 |
| P1-7 | **`SameBatchOrderingGate`** — blocks a same-turn trigger→guarded pair | 12 |
| P1-8 | `DomainAllowListGate` bare-host (`hostArguments`) + `data:` coverage | 14 |
| P1-9 | **`IdentifierRecognizers`** — ready-made predicates for alpha-only ids | 7 |
| P1-11 | `TaintTrackingGate` CallId fail-open fallback | 16 |
| P1-12 | Coverage analyzer fails **closed** for an AIContextProvider-only agent | 1 |

Deferred (with rationale in the plan): **P1-4** (budget gates are per-run — no reload bug; the §4/§5 rate-limit fix
is F3; the shared session-identity primitive belongs to the Bulkhead track) · **P1-10** (guards a case that can't
occur in the current MEAI version).

### Breaking changes (⚠️ merge under a minor — 0.18.0-beta)
- **F2** / **P1-12**: `AnalyzeOrThrow` / `RefuseUnprotectedHighRiskTools` now **throw** for an unprotected
  code-interpreter/MCP tool, and for an AIContextProvider-only agent with an empty static tool list. Correct secure
  defaults (both have explicit opt-outs: `AcknowledgeProviderHostedTools`, `HasDynamicToolProvider`), but
  behavior-changing. Everything else is non-breaking (opt-in params / additive security on WarnOnly-first gates).

### Audit
Full Phase-1 audit performed. It surfaced one gap — `SameBatchOrderingGate` relied on an unverified assumption
that MAF surfaces the current batch in `call.Messages`; added an end-to-end test (`AddParallelToolCalls`)
confirming it. No other issues.

Full plan + live tracker in `strategy/fable5review/` (local-only). Phase 2 (enforcement-semantics, breaking) next,
on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01221nyEWUvsPQSR3AmJ3Lro
