### PR TITLE
Gatekeeper reporting to humans — Fable 5 review (Phase 3)

### DIFF
--- a/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
@@ -67,7 +67,7 @@ public sealed class JudgeVerdictCache : IChatGate
         if (_allowed.TryGetValue(key, out var cached))
         {
             Interlocked.Increment(ref _hits);
-            _onLookup?.Invoke(new JudgeCacheEvent(PolicyName, Hit: true, cached.FirstSeenUtc));   // precedent: served the original allow
+            NotifyLookup(new JudgeCacheEvent(PolicyName, Hit: true, cached.FirstSeenUtc));   // precedent: served the original allow
             return cached.Verdict;
         }
 
@@ -80,8 +80,27 @@ public sealed class JudgeVerdictCache : IChatGate
             _allowed.TryAdd(key, (verdict, _timeProvider.GetUtcNow()));
         }
 
-        _onLookup?.Invoke(new JudgeCacheEvent(PolicyName, Hit: false, OriginalTimestampUtc: null));
+        NotifyLookup(new JudgeCacheEvent(PolicyName, Hit: false, OriginalTimestampUtc: null));
         return verdict;
+    }
+
+    // The precedent hook is pure observability — a throw from it must never propagate out of InspectAsync, where
+    // the gate loop would convert it into a fail-closed Block and turn a genuine cached Allow into a refusal.
+    private void NotifyLookup(JudgeCacheEvent cacheEvent)
+    {
+        if (_onLookup is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _onLookup(cacheEvent);
+        }
+        catch
+        {
+            // Swallow — observability must not change the verdict.
+        }
     }
 
     private static string HashOf(string text)

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
@@ -24,13 +24,28 @@ public sealed class JudgeVerdictCache : IChatGate
 {
     private readonly IChatGate _inner;
     private readonly int _maxEntries;
-    private readonly ConcurrentDictionary<string, GateVerdict> _allowed = new(StringComparer.Ordinal);
+    private readonly TimeProvider _timeProvider;
+    private readonly Action<JudgeCacheEvent>? _onLookup;
+    private readonly ConcurrentDictionary<string, (GateVerdict Verdict, DateTimeOffset FirstSeenUtc)> _allowed = new(StringComparer.Ordinal);
+    private long _hits;
+    private long _misses;
 
     /// <inheritdoc/>
     public string PolicyName => _inner.PolicyName;
 
-    /// <summary>Wraps <paramref name="inner"/> with an allow-verdict cache of at most <paramref name="maxEntries"/> entries.</summary>
-    public JudgeVerdictCache(IChatGate inner, int maxEntries = 4096)
+    /// <summary>Cache hits served so far (P3-7).</summary>
+    public long Hits => Interlocked.Read(ref _hits);
+
+    /// <summary>Lookups that missed and re-litigated the inner judge (P3-7).</summary>
+    public long Misses => Interlocked.Read(ref _misses);
+
+    /// <summary>Wraps <paramref name="inner"/> with an allow-verdict cache.</summary>
+    /// <param name="inner">The judge whose Allow verdicts are memoized.</param>
+    /// <param name="maxEntries">Soft cap on cached entries (default 4096).</param>
+    /// <param name="onLookup">Optional cache-precedent hook (P3-7) invoked on every lookup — a caller wires it to
+    /// emit <c>gate.cache.*</c> evidence (AllowCached, the original timestamp, hit/miss).</param>
+    /// <param name="timeProvider">Clock stamped onto a first-seen allow (testability); defaults to <see cref="TimeProvider.System"/>.</param>
+    public JudgeVerdictCache(IChatGate inner, int maxEntries = 4096, Action<JudgeCacheEvent>? onLookup = null, TimeProvider? timeProvider = null)
     {
         ArgumentNullException.ThrowIfNull(inner);
         if (maxEntries < 1)
@@ -40,6 +55,8 @@ public sealed class JudgeVerdictCache : IChatGate
 
         _inner = inner;
         _maxEntries = maxEntries;
+        _onLookup = onLookup;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <inheritdoc/>
@@ -49,17 +66,21 @@ public sealed class JudgeVerdictCache : IChatGate
         var key = HashOf(safe);
         if (_allowed.TryGetValue(key, out var cached))
         {
-            return cached;
+            Interlocked.Increment(ref _hits);
+            _onLookup?.Invoke(new JudgeCacheEvent(PolicyName, Hit: true, cached.FirstSeenUtc));   // precedent: served the original allow
+            return cached.Verdict;
         }
 
+        Interlocked.Increment(ref _misses);
         var verdict = await _inner.InspectAsync(safe, cancellationToken).ConfigureAwait(false);
 
         // Cache only Allow (see class remarks). Stop admitting once full — never evict a proven-safe entry.
         if (verdict.Action == GateAction.Allow && _allowed.Count < _maxEntries)
         {
-            _allowed.TryAdd(key, verdict);
+            _allowed.TryAdd(key, (verdict, _timeProvider.GetUtcNow()));
         }
 
+        _onLookup?.Invoke(new JudgeCacheEvent(PolicyName, Hit: false, OriginalTimestampUtc: null));
         return verdict;
     }
 
@@ -69,3 +90,14 @@ public sealed class JudgeVerdictCache : IChatGate
         return Convert.ToHexString(bytes);
     }
 }
+
+/// <summary>
+/// A cache-precedent event (Phase 3, P3-7) surfaced by <see cref="JudgeVerdictCache"/> on each lookup. On a
+/// <see cref="Hit"/>, <see cref="OriginalTimestampUtc"/> is when the served allow was FIRST evaluated — the
+/// precedent's age — so a caller can emit a <c>gate.cache.*</c> record showing the verdict was memoized, not
+/// freshly litigated. On a miss it is null (the inner judge ran).
+/// </summary>
+/// <param name="Policy">The judge's policy name.</param>
+/// <param name="Hit">True when the verdict was served from cache; false when the inner judge was invoked.</param>
+/// <param name="OriginalTimestampUtc">When the served allow was first evaluated (hits only).</param>
+public sealed record JudgeCacheEvent(string Policy, bool Hit, DateTimeOffset? OriginalTimestampUtc);

--- a/src/AgentEval.Core/Trust/TrustScoreBreakdown.cs
+++ b/src/AgentEval.Core/Trust/TrustScoreBreakdown.cs
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Trust;
+
+/// <summary>A trust band (Phase 3, P3-10) — the qualitative reading of a 0-100 <see cref="TrustScoreResult.Score"/>.</summary>
+public enum TrustBand
+{
+    /// <summary>No signal contributed — nothing to score (score was null).</summary>
+    Unknown,
+
+    /// <summary>Below 30 — distrust dominates; investigate before relying on the subject.</summary>
+    Critical,
+
+    /// <summary>30 to under 60 — meaningfully degraded trust.</summary>
+    Low,
+
+    /// <summary>60 to under 85 — generally trustworthy with some soft signals.</summary>
+    Moderate,
+
+    /// <summary>85 and above — strongly trusted.</summary>
+    High,
+}
+
+/// <summary>
+/// One signal's contribution to the composite (P3-10) — its raw score/weight, the POINTS it added to the 0-100
+/// composite (0 when excluded), and whether/why it was excluded. The <see cref="WeightedContribution"/> of the
+/// included signals sums to the composite score, so the breakdown is fully reconstructable.
+/// </summary>
+/// <param name="Name">The signal's name.</param>
+/// <param name="Score">Its raw 0..1 score.</param>
+/// <param name="Weight">Its weight.</param>
+/// <param name="WeightedContribution">Points it added to the 0-100 composite (0 when excluded).</param>
+/// <param name="Included">Whether it contributed to the composite.</param>
+/// <param name="ExclusionReason">Why it was excluded (skipped / error / non-positive weight), or null when included.</param>
+public sealed record TrustSignalContribution(
+    string Name,
+    double Score,
+    double Weight,
+    double WeightedContribution,
+    bool Included,
+    string? ExclusionReason);
+
+/// <summary>The composite trust <see cref="Result"/>, its qualitative <see cref="Band"/>, and the per-signal breakdown (P3-10).</summary>
+/// <param name="Result">The underlying <see cref="TrustScoreResult"/>.</param>
+/// <param name="Band">The band the score falls in.</param>
+/// <param name="Contributions">Per-signal contributions, in the order supplied.</param>
+public sealed record TrustScoreBreakdown(
+    TrustScoreResult Result,
+    TrustBand Band,
+    IReadOnlyList<TrustSignalContribution> Contributions);
+
+/// <summary>Extends <see cref="TrustScoreCalculator"/> with the P3-10 per-signal breakdown + band classification.</summary>
+public static class TrustScoreBreakdownCalculator
+{
+    /// <summary>Maps a 0-100 composite (or null) to a <see cref="TrustBand"/>.</summary>
+    public static TrustBand ClassifyBand(double? score) => score switch
+    {
+        null => TrustBand.Unknown,
+        >= 85.0 => TrustBand.High,
+        >= 60.0 => TrustBand.Moderate,
+        >= 30.0 => TrustBand.Low,
+        _ => TrustBand.Critical,
+    };
+
+    /// <summary>Computes the composite AND the per-signal breakdown + band — the same exclusion discipline as <see cref="TrustScoreCalculator.Compute"/>.</summary>
+    public static TrustScoreBreakdown ComputeBreakdown(IReadOnlyList<TrustSignal> signals)
+    {
+        ArgumentNullException.ThrowIfNull(signals);
+        var result = TrustScoreCalculator.Compute(signals);
+
+        var weightSum = signals
+            .Where(s => s.Label is not ("skipped" or "error") && s.Weight > 0)
+            .Sum(s => s.Weight);
+
+        var contributions = new List<TrustSignalContribution>(signals.Count);
+        foreach (var signal in signals)
+        {
+            if (signal.Label is "skipped" or "error")
+            {
+                contributions.Add(new(signal.Name, signal.Score, signal.Weight, 0.0, Included: false, signal.Label));
+                continue;
+            }
+
+            if (signal.Weight <= 0)
+            {
+                contributions.Add(new(signal.Name, signal.Score, signal.Weight, 0.0, Included: false, "non-positive weight"));
+                continue;
+            }
+
+            var points = weightSum > 0 ? Math.Clamp(signal.Score, 0.0, 1.0) * signal.Weight / weightSum * 100.0 : 0.0;
+            contributions.Add(new(signal.Name, signal.Score, signal.Weight, points, Included: true, ExclusionReason: null));
+        }
+
+        return new TrustScoreBreakdown(result, ClassifyBand(result.Score), contributions);
+    }
+}

--- a/src/AgentEval.Core/Trust/TrustScoreRenderer.cs
+++ b/src/AgentEval.Core/Trust/TrustScoreRenderer.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text;
+
+namespace AgentEval.Trust;
+
+/// <summary>Renders a <see cref="TrustScoreBreakdown"/> as readable text (Phase 3, P3-10) — the CLI/report adapter.</summary>
+public static class TrustScoreRenderer
+{
+    /// <summary>One-line header + per-signal breakdown (included signals first, by descending contribution).</summary>
+    public static string Render(TrustScoreBreakdown breakdown)
+    {
+        ArgumentNullException.ThrowIfNull(breakdown);
+        var sb = new StringBuilder();
+
+        var score = breakdown.Result.Score is { } s ? s.ToString("F0", CultureInfo.InvariantCulture) + "/100" : "n/a";
+        sb.Append("Trust: ").Append(score).Append("  [").Append(breakdown.Band).Append(']').AppendLine();
+        sb.AppendLine(breakdown.Result.Explanation);
+
+        foreach (var contribution in breakdown.Contributions.OrderByDescending(c => c.Included).ThenByDescending(c => c.WeightedContribution))
+        {
+            sb.Append("  ").Append(contribution.Included ? '•' : '×').Append(' ').Append(contribution.Name)
+              .Append(": score=").Append(contribution.Score.ToString("F2", CultureInfo.InvariantCulture))
+              .Append(" weight=").Append(contribution.Weight.ToString("F2", CultureInfo.InvariantCulture));
+
+            if (contribution.Included)
+            {
+                sb.Append(" → +").Append(contribution.WeightedContribution.ToString("F1", CultureInfo.InvariantCulture)).Append(" pts");
+            }
+            else
+            {
+                sb.Append(" (excluded: ").Append(contribution.ExclusionReason).Append(')');
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalGatekeeperExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalGatekeeperExtensions.cs
@@ -252,7 +252,8 @@ public static class AgentEvalGatekeeperExtensions
                 pre: options.PreGates.Count > 0 ? options.PreGates.ToArray() : null,
                 post: options.PostGates.Count > 0 ? options.PostGates.ToArray() : null,
                 policy: evalPolicy,
-                trace: options.Trace);
+                trace: options.Trace,
+                evidenceSink: options.EvidenceSink);
         }
 
         // P0-3: a result-gate-only configuration (ToolGates empty, ToolResultGates non-empty) is valid —
@@ -262,7 +263,8 @@ public static class AgentEvalGatekeeperExtensions
         {
             result = result.UseAgentEvalToolGate(
                 options.ToolGates.ToArray(), toolPolicy, options.Trace, options.Telemetry, options.MutationCaptureMode,
-                options.ToolResultGates.Count > 0 ? options.ToolResultGates.ToArray() : null);
+                options.ToolResultGates.Count > 0 ? options.ToolResultGates.ToArray() : null,
+                options.EvidenceSink);
         }
 
         if (options.ApprovalGates.Count > 0)

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
@@ -90,12 +90,17 @@ public static class AgentEvalRunGateExtensions
 
         var seq = new int[1];   // shared block-seq counter across both branches
 
+        // F-C / P3-6: fingerprint the pre/post gate configuration once; every run-gate evidence record is stamped
+        // with it. AgentName / RunId are filled from AgentRunScope at record time (the run gate establishes it).
+        var evidenceContext = new GateEvidenceContext(null, null, null,
+            GateConfigFingerprint.Compute(chatGates: preGates.Concat(postGates).ToArray()));
+
         return builder.Use(
             runFunc: async (messages, session, options, innerAgent, ct) =>
             {
                 using var scope = AgentRunScope.Begin(session, innerAgent.Name, trace);
 
-                var preOutcome = await RunGatesAsync(preGates, ConcatText(messages), "run-pre", isPreStage: true, effectivePolicy, trace, seq, ct).ConfigureAwait(false);
+                var preOutcome = await RunGatesAsync(preGates, ConcatText(messages), "run-pre", isPreStage: true, effectivePolicy, trace, seq, evidenceContext, ct).ConfigureAwait(false);
                 if (preOutcome.ReturnBody is not null)
                 {
                     return Refusal(innerAgent, preOutcome.ReturnBody);
@@ -106,21 +111,21 @@ public static class AgentEvalRunGateExtensions
 
                 var response = await innerAgent.RunAsync(effectiveMessages, session, options, ct).ConfigureAwait(false);
 
-                var postOutcome = await RunGatesAsync(postGates, response.Text, "run-post", isPreStage: false, effectivePolicy, trace, seq, ct).ConfigureAwait(false);
+                var postOutcome = await RunGatesAsync(postGates, response.Text, "run-post", isPreStage: false, effectivePolicy, trace, seq, evidenceContext, ct).ConfigureAwait(false);
                 if (postOutcome.ReturnBody is not null)
                 {
                     // P2-3: an enforced run-post Block/Redact swapped what the CALLER sees, but the model's original
                     // (unsafe) response is already persisted in the session and would re-enter context next turn.
                     // Reconcile the persisted turn to the caller-safe text (for sessions that expose the seam) and
                     // emit divergence evidence either way.
-                    ReconcileSession(session, safeText: postOutcome.ReturnBody, withheldText: response.Text, trace, seq);
+                    ReconcileSession(session, safeText: postOutcome.ReturnBody, withheldText: response.Text, trace, seq, evidenceContext);
                     return Refusal(innerAgent, postOutcome.ReturnBody);
                 }
 
                 return response;
             },
             runStreamingFunc: (messages, session, options, innerAgent, ct) =>
-                StreamCore(messages, session, options, innerAgent, preGates, postGates, effectivePolicy, trace, seq, ct));
+                StreamCore(messages, session, options, innerAgent, preGates, postGates, effectivePolicy, trace, seq, evidenceContext, ct));
     }
 
     private static async IAsyncEnumerable<AgentResponseUpdate> StreamCore(
@@ -133,6 +138,7 @@ public static class AgentEvalRunGateExtensions
         EvalGatePolicy policy,
         AgentTrace? trace,
         int[] seq,
+        GateEvidenceContext evidence,
         [EnumeratorCancellation] CancellationToken ct)
     {
         // A run-post gate cannot BLOCK a streamed response without buffering the whole stream (which destroys
@@ -151,7 +157,7 @@ public static class AgentEvalRunGateExtensions
         // SessionContextGate pre-gate sees the session, exactly as on the non-streaming path).
         using var runScope = AgentRunScope.Begin(session, innerAgent.Name, trace);
 
-        var preOutcome = await RunGatesAsync(preGates, ConcatText(messages), "run-pre", isPreStage: true, policy, trace, seq, ct).ConfigureAwait(false);
+        var preOutcome = await RunGatesAsync(preGates, ConcatText(messages), "run-pre", isPreStage: true, policy, trace, seq, evidence, ct).ConfigureAwait(false);
         if (preOutcome.ReturnBody is not null)
         {
             var synth = new AgentResponse(new ChatMessage(ChatRole.Assistant, preOutcome.ReturnBody)) { AgentId = innerAgent.Id };
@@ -196,7 +202,7 @@ public static class AgentEvalRunGateExtensions
         {
             using (runScope.Enter())
             {
-                await RunGatesAsync(postGates, accumulated.ToString(), "run-post", isPreStage: false, policy, trace, seq, ct).ConfigureAwait(false);
+                await RunGatesAsync(postGates, accumulated.ToString(), "run-post", isPreStage: false, policy, trace, seq, evidence, ct).ConfigureAwait(false);
             }
         }
     }
@@ -224,7 +230,7 @@ public static class AgentEvalRunGateExtensions
         => outcome.RewrittenInput is null ? original : [new ChatMessage(ChatRole.User, outcome.RewrittenInput)];
 
     private static async ValueTask<GateStageOutcome> RunGatesAsync(
-        IReadOnlyList<IChatGate> gates, string text, string stage, bool isPreStage, EvalGatePolicy policy, AgentTrace? trace, int[] seq, CancellationToken ct)
+        IReadOnlyList<IChatGate> gates, string text, string stage, bool isPreStage, EvalGatePolicy policy, AgentTrace? trace, int[] seq, GateEvidenceContext evidence, CancellationToken ct)
     {
         foreach (var gate in gates)
         {
@@ -239,7 +245,7 @@ public static class AgentEvalRunGateExtensions
                 // block regardless of policy (mirrors the tool gate).
                 var failVerdict = GateVerdict.Block(gate.PolicyName, $"gate evaluation threw ({ex.GetType().Name}) — failing closed");
                 var throwReferenceId = GateReferenceId.New();
-                RecordGate(trace, Interlocked.Increment(ref seq[0]), stage, failVerdict, "Block", throwReferenceId);
+                RecordGate(trace, Interlocked.Increment(ref seq[0]), stage, failVerdict, "Block", throwReferenceId, evidence, failedClosedOnThrow: true);
                 return GateStageOutcome.Return(GateReferenceId.RefusalBody(throwReferenceId));
             }
 
@@ -252,7 +258,7 @@ public static class AgentEvalRunGateExtensions
             // run that proceeded). Under WarnOnly the block is recorded as action="Warn".
             var enforced = policy != EvalGatePolicy.WarnOnly;
             var referenceId = GateReferenceId.New();
-            RecordGate(trace, Interlocked.Increment(ref seq[0]), stage, verdict, enforced ? "Block" : "Warn", referenceId);
+            RecordGate(trace, Interlocked.Increment(ref seq[0]), stage, verdict, enforced ? "Block" : "Warn", referenceId, evidence);
 
             if (policy == EvalGatePolicy.ThrowOnFail)
             {
@@ -293,7 +299,7 @@ public static class AgentEvalRunGateExtensions
     // actually saw and record the divergence. The scrub itself is only possible for a session that opts into the
     // IReconcilableSession seam (directly or via GetService) — MAF's built-in session exposes no mutable history,
     // so it is left untouched and the evidence honestly records scrubbed=false (never a false success).
-    private static void ReconcileSession(AgentSession? session, string safeText, string withheldText, AgentTrace? trace, int[] seq)
+    private static void ReconcileSession(AgentSession? session, string safeText, string withheldText, AgentTrace? trace, int[] seq, GateEvidenceContext evidence)
     {
         var reconciler = session as IReconcilableSession;
         if (reconciler is null && session is not null)
@@ -342,15 +348,17 @@ public static class AgentEvalRunGateExtensions
 
         // Per-turn hash-divergence record: the caller-safe text vs. the withheld model text, so an auditor can
         // confirm a scrub happened (or see, honestly, that it could not) without either text stored verbatim.
-        trace.SetMetadata($"gate.session.{Interlocked.Increment(ref seq[0])}.reconciliation", new Dictionary<string, object?>
-        {
-            ["action"] = "Reconcile",
-            ["scrubbed"] = scrubbed,
-            ["safeHash"] = ShortHash(safeText),
-            ["withheldHash"] = ShortHash(withheldText),
-            ["diverged"] = !string.Equals(safeText, withheldText, StringComparison.Ordinal),
-            ["reason"] = reason,
-        });
+        var record = evidence.Build(
+            stage: "session", policy: "reconciliation", action: "Reconcile", referenceId: GateReferenceId.New(),
+            reason: reason, severity: GateSeverity.Suspicious,
+            extra: new Dictionary<string, object?>
+            {
+                ["scrubbed"] = scrubbed,
+                ["safeHash"] = ShortHash(safeText),
+                ["withheldHash"] = ShortHash(withheldText),
+                ["diverged"] = !string.Equals(safeText, withheldText, StringComparison.Ordinal),
+            });
+        trace.SetMetadata(record.TraceKey(Interlocked.Increment(ref seq[0])), record.ToMetadata());
     }
 
     private static string ShortHash(string text)
@@ -359,7 +367,7 @@ public static class AgentEvalRunGateExtensions
     // #12: the full policy name (the metadata key itself) and reason live ONLY here — audit-visible trace
     // evidence, never returned as run-refusal content (see GateReferenceId.RefusalBody). referenceId is the
     // ONLY thing the two are allowed to share, so an auditor can correlate what was returned with what happened.
-    private static void RecordGate(AgentTrace? trace, int seq, string stage, GateVerdict verdict, string action, string referenceId)
+    private static void RecordGate(AgentTrace? trace, int seq, string stage, GateVerdict verdict, string action, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
         if (trace is null)
         {
@@ -374,13 +382,16 @@ public static class AgentEvalRunGateExtensions
         // arguments. Redact both fields unconditionally for these two axes; audit-visible for every other gate.
         var sensitive = SensitiveJudgeAxes.IsSensitive(verdict.PolicyName);
 
-        trace.SetMetadata($"gate.{stage}.{seq}.{verdict.PolicyName}", new Dictionary<string, object?>
-        {
-            ["action"] = action,   // "Block" (enforced) or "Warn" (WarnOnly — recorded but the run proceeded)
-            ["reason"] = sensitive ? "[redacted — sensitive judge axis; see SensitiveJudgeAxes.RedactAxes]" : verdict.Reason,
-            ["matches"] = sensitive ? null : verdict.Matches,
-            ["correlationId"] = ToolCorrelationScope.Current,
-            ["referenceId"] = referenceId,
-        });
+        // F-C / P3-3: persist the verdict's GateProvenance for the first time (a judge's threshold/actual/evidence),
+        // sensitive-axis-redacted like Reason/Matches so a sensitive judge's rationale is never leaked into the trace.
+        var provenance = sensitive ? null : verdict.Provenance;
+
+        var record = evidence.Build(
+            stage: stage, policy: verdict.PolicyName, action: action, referenceId: referenceId,
+            reason: sensitive ? "[redacted — sensitive judge axis; see SensitiveJudgeAxes.RedactAxes]" : verdict.Reason,
+            severity: GateSeverityClassifier.Classify(verdict.PolicyName, failedClosedOnThrow),
+            correlationId: ToolCorrelationScope.Current, provenance: provenance,
+            extra: new Dictionary<string, object?> { ["matches"] = sensitive ? null : verdict.Matches });
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
@@ -123,6 +123,7 @@ public static class AgentEvalRunGateExtensions
                     return Refusal(innerAgent, postOutcome.ReturnBody);
                 }
 
+                EmitRunReceipt(trace, seq, evidenceContext);   // P3-11: summarize the completed run
                 return response;
             },
             runStreamingFunc: (messages, session, options, innerAgent, ct) =>
@@ -374,6 +375,28 @@ public static class AgentEvalRunGateExtensions
     {
         evidence.Emit(record, seq);
         trace?.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+    }
+
+    // P3-11: at the end of a completed (non-refused) run, summarize the run's RunLedger into a receipt and emit it
+    // as a gate.receipt.* record on the same F-C stream. Skipped entirely when there is nowhere to record it.
+    private static void EmitRunReceipt(AgentTrace? trace, int[] seq, GateEvidenceContext evidence)
+    {
+        if (trace is null && !evidence.HasSink)
+        {
+            return;
+        }
+
+        var scope = AgentRunScope.Current;
+        var receipt = RunLedger.ForCurrentRun().Summarize(scope?.RunId, scope?.AgentName, evidence.ConfigFingerprint, DateTimeOffset.UtcNow);
+        var record = evidence.Build(
+            stage: "receipt", policy: "run", action: "Receipt", referenceId: GateReferenceId.New(), reason: null,
+            severity: GateSeverity.Routine,
+            extra: new Dictionary<string, object?>
+            {
+                ["totalToolCalls"] = receipt.TotalToolCalls,
+                ["toolCallCounts"] = receipt.ToolCallCounts,
+            });
+        EmitEvidence(trace, evidence, Interlocked.Increment(ref seq[0]), record);
     }
 
     private static void RecordGate(AgentTrace? trace, int seq, string stage, GateVerdict verdict, string action, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
@@ -46,7 +46,8 @@ public static class AgentEvalRunGateExtensions
         IReadOnlyList<IChatGate>? pre = null,
         IReadOnlyList<IChatGate>? post = null,
         EvalGatePolicy? policy = null,
-        AgentTrace? trace = null)
+        AgentTrace? trace = null,
+        IGateEvidenceSink? evidenceSink = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -93,7 +94,7 @@ public static class AgentEvalRunGateExtensions
         // F-C / P3-6: fingerprint the pre/post gate configuration once; every run-gate evidence record is stamped
         // with it. AgentName / RunId are filled from AgentRunScope at record time (the run gate establishes it).
         var evidenceContext = new GateEvidenceContext(null, null, null,
-            GateConfigFingerprint.Compute(chatGates: preGates.Concat(postGates).ToArray()));
+            GateConfigFingerprint.Compute(chatGates: preGates.Concat(postGates).ToArray()), evidenceSink);
 
         return builder.Use(
             runFunc: async (messages, session, options, innerAgent, ct) =>
@@ -341,7 +342,7 @@ public static class AgentEvalRunGateExtensions
             }
         }
 
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -358,7 +359,7 @@ public static class AgentEvalRunGateExtensions
                 ["withheldHash"] = ShortHash(withheldText),
                 ["diverged"] = !string.Equals(safeText, withheldText, StringComparison.Ordinal),
             });
-        trace.SetMetadata(record.TraceKey(Interlocked.Increment(ref seq[0])), record.ToMetadata());
+        EmitEvidence(trace, evidence, Interlocked.Increment(ref seq[0]), record);
     }
 
     private static string ShortHash(string text)
@@ -367,9 +368,17 @@ public static class AgentEvalRunGateExtensions
     // #12: the full policy name (the metadata key itself) and reason live ONLY here — audit-visible trace
     // evidence, never returned as run-refusal content (see GateReferenceId.RefusalBody). referenceId is the
     // ONLY thing the two are allowed to share, so an auditor can correlate what was returned with what happened.
+    // F-C: write one record to the trace (audit projection) AND fan it out to any registered extra sink
+    // (ledger / alerting). The trace write is null-safe so evidence still reaches the sink with tracing off.
+    private static void EmitEvidence(AgentTrace? trace, GateEvidenceContext evidence, int seq, GateEvidence record)
+    {
+        evidence.Emit(record, seq);
+        trace?.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+    }
+
     private static void RecordGate(AgentTrace? trace, int seq, string stage, GateVerdict verdict, string action, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -392,6 +401,6 @@ public static class AgentEvalRunGateExtensions
             severity: GateSeverityClassifier.Classify(verdict.PolicyName, failedClosedOnThrow),
             correlationId: ToolCorrelationScope.Current, provenance: provenance,
             extra: new Dictionary<string, object?> { ["matches"] = sensitive ? null : verdict.Matches });
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalRunGateExtensions.cs
@@ -92,9 +92,13 @@ public static class AgentEvalRunGateExtensions
         var seq = new int[1];   // shared block-seq counter across both branches
 
         // F-C / P3-6: fingerprint the pre/post gate configuration once; every run-gate evidence record is stamped
-        // with it. AgentName / RunId are filled from AgentRunScope at record time (the run gate establishes it).
-        var evidenceContext = new GateEvidenceContext(null, null, null,
-            GateConfigFingerprint.Compute(chatGates: preGates.Concat(postGates).ToArray()), evidenceSink);
+        // with it. Pre and post are fingerprinted SEPARATELY and combined (Phase 3 review #7) so that moving a gate
+        // across the pre/post boundary — a different configuration — yields a different fingerprint. AgentName /
+        // RunId are filled from AgentRunScope at record time (the run gate establishes it).
+        var runConfigFingerprint = ManifestFingerprint.Hash(
+            "pre|" + GateConfigFingerprint.Compute(chatGates: preGates.Count > 0 ? preGates : null) +
+            "|post|" + GateConfigFingerprint.Compute(chatGates: postGates.Count > 0 ? postGates : null));
+        var evidenceContext = new GateEvidenceContext(null, null, null, runConfigFingerprint, evidenceSink);
 
         return builder.Use(
             runFunc: async (messages, session, options, innerAgent, ct) =>
@@ -206,6 +210,12 @@ public static class AgentEvalRunGateExtensions
             {
                 await RunGatesAsync(postGates, accumulated.ToString(), "run-post", isPreStage: false, policy, trace, seq, evidence, ct).ConfigureAwait(false);
             }
+        }
+
+        // P3-11 (Phase 3 review #4): a streamed run must emit the same end-of-run receipt as a non-streaming one.
+        using (runScope.Enter())
+        {
+            EmitRunReceipt(trace, seq, evidence);
         }
     }
 

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -423,10 +423,13 @@ public static class AgentEvalToolGateExtensions
                             // result-gate family exists to prevent (a withheld result must never read as a successful
                             // empty one). Fall back to the same stable, non-revealing refusal body a Block uses —
                             // never null — and record the referenceId embedded in it so an auditor can correlate.
+                            // Recorded as action="Block" (Phase 3 review): the model receives a REFUSAL here (the
+                            // result is withheld), so this is a block — counted by GateBlockCount and, crucially,
+                            // written to the durable reference index (which only persists model-facing refusals).
                             var redactReferenceId = GateReferenceId.New();
                             RecordResultBlock(trace, Interlocked.Increment(ref gateSeq), resultVerdict.PolicyName,
                                 resultVerdict.Reason ?? "result redacted with no replacement supplied — failing closed to a non-revealing refusal",
-                                action: "Redact", terminating: false, referenceId: redactReferenceId, evidence);
+                                action: "Block", terminating: false, referenceId: redactReferenceId, evidence);
                             toolResult = GateReferenceId.RefusalBody(redactReferenceId);
                         }
                         else

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -95,7 +95,8 @@ public static class AgentEvalToolGateExtensions
         AgentTrace? trace = null,
         GateTelemetry? telemetry = null,
         TraceCaptureMode mutationCaptureMode = TraceCaptureMode.Redacted,
-        IReadOnlyList<IToolResultGate>? resultGates = null)
+        IReadOnlyList<IToolResultGate>? resultGates = null,
+        IGateEvidenceSink? evidenceSink = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(gates);
@@ -143,7 +144,7 @@ public static class AgentEvalToolGateExtensions
         return builder.Use(async (agent, context, next, ct) =>
         {
             // F-C / P3-2: the per-call enrichment context stamped onto every record from this invocation.
-            var evidence = new GateEvidenceContext(agent.Name, context.Function.Name, context.Iteration, configFingerprint);
+            var evidence = new GateEvidenceContext(agent.Name, context.Function.Name, context.Iteration, configFingerprint, evidenceSink);
 
             if (scopeRequiringGateNames.Length > 0 && AgentRunScope.Current is null &&
                 Interlocked.CompareExchange(ref missingScopeWarned, 1, 0) == 0)
@@ -549,9 +550,17 @@ public static class AgentEvalToolGateExtensions
     // #12: the full policy name (the metadata key itself) and reason live ONLY here — audit-visible trace
     // evidence, never returned to the model. referenceId is the ONLY thing the two are allowed to share, so an
     // auditor can correlate what the model saw with what actually happened.
+    // F-C: write one record to the trace (audit projection) AND fan it out to any registered extra sink
+    // (ledger / alerting). The trace write is null-safe so evidence still reaches the sink with tracing off.
+    private static void EmitEvidence(AgentTrace? trace, GateEvidenceContext evidence, int seq, GateEvidence record)
+    {
+        evidence.Emit(record, seq);
+        trace?.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+    }
+
     private static void RecordBlock(AgentTrace? trace, int seq, ToolGateVerdict verdict, string action, bool terminating, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -567,7 +576,7 @@ public static class AgentEvalToolGateExtensions
             stage: "tool", policy: verdict.PolicyName, action: action, referenceId: referenceId, reason: verdict.Reason,
             severity: GateSeverityClassifier.Classify(verdict.PolicyName, failedClosedOnThrow),
             correlationId: ToolCorrelationScope.Current, extra: extra);
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 
     // P0-3: same shape as RecordBlock, stage token "tool-result" (not "tool") so a result-gate block is
@@ -577,7 +586,7 @@ public static class AgentEvalToolGateExtensions
     // called from the fail-closed catch block, which has no ToolResultVerdict to hand in.
     private static void RecordResultBlock(AgentTrace? trace, int seq, string policyName, string? reason, string action, bool terminating, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -592,7 +601,7 @@ public static class AgentEvalToolGateExtensions
             stage: "tool-result", policy: policyName, action: action, referenceId: referenceId, reason: reason,
             severity: GateSeverityClassifier.Classify(policyName, failedClosedOnThrow),
             correlationId: ToolCorrelationScope.Current, extra: extra);
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 
     // P0-3: a Redact verdict is recorded (action="Redact", NOT counted as a block) — deliberately does NOT
@@ -603,7 +612,7 @@ public static class AgentEvalToolGateExtensions
     // (mirroring MutationEvidenceRenderer/TraceCaptureMode) is deliberately deferred, not an oversight.
     private static void RecordResultRedact(AgentTrace? trace, int seq, ToolResultVerdict verdict, bool applied, GateEvidenceContext evidence)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -614,7 +623,7 @@ public static class AgentEvalToolGateExtensions
             reason: verdict.Reason, severity: GateSeverityClassifier.Classify(verdict.PolicyName),
             correlationId: ToolCorrelationScope.Current,
             extra: new Dictionary<string, object?> { ["applied"] = applied });
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 
     // #4-revisit: the best-effort RUNTIME missing-run-scope signal — see the field comment where
@@ -623,7 +632,7 @@ public static class AgentEvalToolGateExtensions
     // GlassBoxEvidence.CountGateBlocks only counts action="Block").
     private static void RecordMissingScopeWarning(AgentTrace? trace, int seq, IReadOnlyList<string> offenders, GateEvidenceContext evidence)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -636,7 +645,7 @@ public static class AgentEvalToolGateExtensions
             stage: "warning", policy: "MissingRunScope", action: "Warn", referenceId: GateReferenceId.New(), reason: reason,
             severity: GateSeverity.Suspicious, correlationId: ToolCorrelationScope.Current,
             extra: new Dictionary<string, object?> { ["matches"] = null });
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 
     // A Mutate is recorded (action="Mutate", NOT counted as a block) with before/after args so the change is
@@ -680,7 +689,7 @@ public static class AgentEvalToolGateExtensions
         AgentTrace? trace, int seq, ToolGateVerdict verdict,
         IReadOnlyDictionary<string, object?>? argsBefore, IReadOnlyDictionary<string, object?>? argsAfter, TraceCaptureMode captureMode, bool applied, GateEvidenceContext evidence)
     {
-        if (trace is null)
+        if (trace is null && !evidence.HasSink)
         {
             return;
         }
@@ -698,6 +707,6 @@ public static class AgentEvalToolGateExtensions
                 ["argsAfter"] = MutationEvidenceRenderer.Render(argsAfter, captureMode),
                 ["captureMode"] = captureMode.ToString(),
             });
-        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
+        EmitEvidence(trace, evidence, seq, record);
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -136,12 +136,19 @@ public static class AgentEvalToolGateExtensions
 
         var gateSeq = 0;
 
+        // F-C / P3-6: fingerprint the frozen gate configuration ONCE — every evidence record this pipeline writes
+        // is stamped with it, tying the record to the exact gate list (and order) that produced it.
+        var configFingerprint = GateConfigFingerprint.Compute(frozenGates, frozenResultGates);
+
         return builder.Use(async (agent, context, next, ct) =>
         {
+            // F-C / P3-2: the per-call enrichment context stamped onto every record from this invocation.
+            var evidence = new GateEvidenceContext(agent.Name, context.Function.Name, context.Iteration, configFingerprint);
+
             if (scopeRequiringGateNames.Length > 0 && AgentRunScope.Current is null &&
                 Interlocked.CompareExchange(ref missingScopeWarned, 1, 0) == 0)
             {
-                RecordMissingScopeWarning(trace, Interlocked.Increment(ref gateSeq), scopeRequiringGateNames);
+                RecordMissingScopeWarning(trace, Interlocked.Increment(ref gateSeq), scopeRequiringGateNames, evidence);
             }
 
             var call = new GatedToolCall(
@@ -202,7 +209,8 @@ public static class AgentEvalToolGateExtensions
                         var throwReferenceId = GateReferenceId.New();
                         RecordBlock(trace, Interlocked.Increment(ref gateSeq),
                             ToolGateVerdict.Block(gate.PolicyName, $"gate evaluation threw ({ex.GetType().Name}) — failing closed"),
-                            action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: throwReferenceId);
+                            action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: throwReferenceId,
+                            evidence, failedClosedOnThrow: true);
                         if (policy == ToolGatePolicy.Terminate)
                         {
                             context.Terminate = true;
@@ -269,7 +277,7 @@ public static class AgentEvalToolGateExtensions
                             if (changesArgs || !applied)
                             {
                                 RecordMutate(trace, Interlocked.Increment(ref gateSeq), verdict, before,
-                                    verdict.NewArguments ?? context.Arguments, mutationCaptureMode, applied);
+                                    verdict.NewArguments ?? context.Arguments, mutationCaptureMode, applied, evidence);
                             }
 
                             if (changesArgs)
@@ -289,7 +297,7 @@ public static class AgentEvalToolGateExtensions
                             // Honest evidence: only an ENFORCED block records action="Block" (so GlassBoxEvidence's
                             // GateBlockCount never counts a call that actually ran). WarnOnly records action="Warn".
                             RecordBlock(trace, seq, verdict, action: enforced ? "Block" : "Warn",
-                                terminating: policy == ToolGatePolicy.Terminate, referenceId: referenceId);
+                                terminating: policy == ToolGatePolicy.Terminate, referenceId: referenceId, evidence);
 
                             if (!enforced)
                             {
@@ -326,7 +334,8 @@ public static class AgentEvalToolGateExtensions
                     RecordBlock(trace, Interlocked.Increment(ref gateSeq),
                         ToolGateVerdict.Block("MutationRevalidation",
                             $"tool-call arguments did not converge after {maxMutationRevalidations} mutation re-validations — failing closed"),
-                        action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: refId);
+                        action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: refId, evidence,
+                        failedClosedOnThrow: true);
                     if (policy == ToolGatePolicy.Terminate)
                     {
                         context.Terminate = true;
@@ -377,7 +386,8 @@ public static class AgentEvalToolGateExtensions
                     var throwReferenceId = GateReferenceId.New();
                     RecordResultBlock(trace, Interlocked.Increment(ref gateSeq), resultGate.PolicyName,
                         $"result gate evaluation threw ({ex.GetType().Name}) — failing closed",
-                        action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: throwReferenceId);
+                        action: "Block", terminating: policy == ToolGatePolicy.Terminate, referenceId: throwReferenceId,
+                        evidence, failedClosedOnThrow: true);
 
                     if (policy == ToolGatePolicy.Terminate)
                     {
@@ -400,7 +410,7 @@ public static class AgentEvalToolGateExtensions
                         // The real result flows through unchanged; the evidence shows a redaction WOULD have fired.
                         if (policy == ToolGatePolicy.WarnOnly)
                         {
-                            RecordResultRedact(trace, Interlocked.Increment(ref gateSeq), resultVerdict, applied: false);
+                            RecordResultRedact(trace, Interlocked.Increment(ref gateSeq), resultVerdict, applied: false, evidence);
                             continue;
                         }
 
@@ -415,13 +425,13 @@ public static class AgentEvalToolGateExtensions
                             var redactReferenceId = GateReferenceId.New();
                             RecordResultBlock(trace, Interlocked.Increment(ref gateSeq), resultVerdict.PolicyName,
                                 resultVerdict.Reason ?? "result redacted with no replacement supplied — failing closed to a non-revealing refusal",
-                                action: "Redact", terminating: false, referenceId: redactReferenceId);
+                                action: "Redact", terminating: false, referenceId: redactReferenceId, evidence);
                             toolResult = GateReferenceId.RefusalBody(redactReferenceId);
                         }
                         else
                         {
                             toolResult = resultVerdict.RedactedResult;
-                            RecordResultRedact(trace, Interlocked.Increment(ref gateSeq), resultVerdict, applied: true);
+                            RecordResultRedact(trace, Interlocked.Increment(ref gateSeq), resultVerdict, applied: true, evidence);
                         }
 
                         continue;
@@ -434,7 +444,7 @@ public static class AgentEvalToolGateExtensions
 
                         RecordResultBlock(trace, seq, resultVerdict.PolicyName, resultVerdict.Reason,
                             action: enforced ? "Block" : "Warn", terminating: policy == ToolGatePolicy.Terminate,
-                            referenceId: referenceId);
+                            referenceId: referenceId, evidence);
 
                         if (!enforced)
                         {
@@ -539,27 +549,25 @@ public static class AgentEvalToolGateExtensions
     // #12: the full policy name (the metadata key itself) and reason live ONLY here — audit-visible trace
     // evidence, never returned to the model. referenceId is the ONLY thing the two are allowed to share, so an
     // auditor can correlate what the model saw with what actually happened.
-    private static void RecordBlock(AgentTrace? trace, int seq, ToolGateVerdict verdict, string action, bool terminating, string referenceId)
+    private static void RecordBlock(AgentTrace? trace, int seq, ToolGateVerdict verdict, string action, bool terminating, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
         if (trace is null)
         {
             return;
         }
 
-        var value = new Dictionary<string, object?>
-        {
-            ["action"] = action,   // "Block" (enforced) or "Warn" (WarnOnly — recorded but the tool ran)
-            ["reason"] = verdict.Reason,
-            ["matches"] = null,
-            ["correlationId"] = ToolCorrelationScope.Current,
-            ["referenceId"] = referenceId,
-        };
+        var extra = new Dictionary<string, object?> { ["matches"] = null };
         if (terminating)
         {
-            value["terminate"] = true;
+            extra["terminate"] = true;
         }
 
-        trace.SetMetadata($"gate.tool.{seq}.{verdict.PolicyName}", value);
+        // F-C: one canonical record, projected to the same superset trace value the readers parse.
+        var record = evidence.Build(
+            stage: "tool", policy: verdict.PolicyName, action: action, referenceId: referenceId, reason: verdict.Reason,
+            severity: GateSeverityClassifier.Classify(verdict.PolicyName, failedClosedOnThrow),
+            correlationId: ToolCorrelationScope.Current, extra: extra);
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 
     // P0-3: same shape as RecordBlock, stage token "tool-result" (not "tool") so a result-gate block is
@@ -567,27 +575,24 @@ public static class AgentEvalToolGateExtensions
     // GateMetadataReader/GlassBoxEvidence.CountGateBlocks (both are stage-agnostic — any gate.{stage}.{seq}.{policy}
     // key with action="Block" counts). Reason is passed as a plain string (not a verdict) since this is also
     // called from the fail-closed catch block, which has no ToolResultVerdict to hand in.
-    private static void RecordResultBlock(AgentTrace? trace, int seq, string policyName, string? reason, string action, bool terminating, string referenceId)
+    private static void RecordResultBlock(AgentTrace? trace, int seq, string policyName, string? reason, string action, bool terminating, string referenceId, GateEvidenceContext evidence, bool failedClosedOnThrow = false)
     {
         if (trace is null)
         {
             return;
         }
 
-        var value = new Dictionary<string, object?>
-        {
-            ["action"] = action,
-            ["reason"] = reason,
-            ["matches"] = null,
-            ["correlationId"] = ToolCorrelationScope.Current,
-            ["referenceId"] = referenceId,
-        };
+        var extra = new Dictionary<string, object?> { ["matches"] = null };
         if (terminating)
         {
-            value["terminate"] = true;
+            extra["terminate"] = true;
         }
 
-        trace.SetMetadata($"gate.tool-result.{seq}.{policyName}", value);
+        var record = evidence.Build(
+            stage: "tool-result", policy: policyName, action: action, referenceId: referenceId, reason: reason,
+            severity: GateSeverityClassifier.Classify(policyName, failedClosedOnThrow),
+            correlationId: ToolCorrelationScope.Current, extra: extra);
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 
     // P0-3: a Redact verdict is recorded (action="Redact", NOT counted as a block) — deliberately does NOT
@@ -596,44 +601,42 @@ public static class AgentEvalToolGateExtensions
     // a database row) — capturing it into the trace at all, even redacted-by-default, is a bigger surface than
     // this pass scopes; only the fact that a redaction happened, and why, is recorded. Full result-capture
     // (mirroring MutationEvidenceRenderer/TraceCaptureMode) is deliberately deferred, not an oversight.
-    private static void RecordResultRedact(AgentTrace? trace, int seq, ToolResultVerdict verdict, bool applied)
+    private static void RecordResultRedact(AgentTrace? trace, int seq, ToolResultVerdict verdict, bool applied, GateEvidenceContext evidence)
     {
         if (trace is null)
         {
             return;
         }
 
-        trace.SetMetadata($"gate.tool-result.{seq}.{verdict.PolicyName}", new Dictionary<string, object?>
-        {
-            ["action"] = "Redact",
-            // P2-2: false under WarnOnly, where the redaction is recorded but the real result was NOT replaced.
-            ["applied"] = applied,
-            ["reason"] = verdict.Reason,
-            ["correlationId"] = ToolCorrelationScope.Current,
-        });
+        // P2-2: applied=false under WarnOnly, where the redaction is recorded but the real result was NOT replaced.
+        var record = evidence.Build(
+            stage: "tool-result", policy: verdict.PolicyName, action: "Redact", referenceId: GateReferenceId.New(),
+            reason: verdict.Reason, severity: GateSeverityClassifier.Classify(verdict.PolicyName),
+            correlationId: ToolCorrelationScope.Current,
+            extra: new Dictionary<string, object?> { ["applied"] = applied });
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 
     // #4-revisit: the best-effort RUNTIME missing-run-scope signal — see the field comment where
     // scopeRequiringGateNames is computed. Uses the "warning" stage token (not "tool") and action="Warn" so it
     // reads naturally alongside real gate verdicts in GateVoice/GlassBoxEvidence (never counted as a block —
     // GlassBoxEvidence.CountGateBlocks only counts action="Block").
-    private static void RecordMissingScopeWarning(AgentTrace? trace, int seq, IReadOnlyList<string> offenders)
+    private static void RecordMissingScopeWarning(AgentTrace? trace, int seq, IReadOnlyList<string> offenders, GateEvidenceContext evidence)
     {
         if (trace is null)
         {
             return;
         }
 
-        trace.SetMetadata($"gate.warning.{seq}.MissingRunScope", new Dictionary<string, object?>
-        {
-            ["action"] = "Warn",
-            ["reason"] = $"{string.Join(", ", offenders)} declare GateRequirements.RunScope, but no AgentRunScope " +
-                          "is established for this run — they fall back to shared, process-wide state (self-" +
-                          "documented on RunLedger/SequenceGate). Call UseAgentEvalGate() before this middleware, " +
-                          "or prefer UseGatekeeper(...), which refuses construction for this case instead of only warning.",
-            ["matches"] = null,
-            ["correlationId"] = ToolCorrelationScope.Current,
-        });
+        var reason = $"{string.Join(", ", offenders)} declare GateRequirements.RunScope, but no AgentRunScope " +
+                     "is established for this run — they fall back to shared, process-wide state (self-" +
+                     "documented on RunLedger/SequenceGate). Call UseAgentEvalGate() before this middleware, " +
+                     "or prefer UseGatekeeper(...), which refuses construction for this case instead of only warning.";
+        var record = evidence.Build(
+            stage: "warning", policy: "MissingRunScope", action: "Warn", referenceId: GateReferenceId.New(), reason: reason,
+            severity: GateSeverity.Suspicious, correlationId: ToolCorrelationScope.Current,
+            extra: new Dictionary<string, object?> { ["matches"] = null });
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 
     // A Mutate is recorded (action="Mutate", NOT counted as a block) with before/after args so the change is
@@ -675,24 +678,26 @@ public static class AgentEvalToolGateExtensions
 
     private static void RecordMutate(
         AgentTrace? trace, int seq, ToolGateVerdict verdict,
-        IReadOnlyDictionary<string, object?>? argsBefore, IReadOnlyDictionary<string, object?>? argsAfter, TraceCaptureMode captureMode, bool applied)
+        IReadOnlyDictionary<string, object?>? argsBefore, IReadOnlyDictionary<string, object?>? argsAfter, TraceCaptureMode captureMode, bool applied, GateEvidenceContext evidence)
     {
         if (trace is null)
         {
             return;
         }
 
-        trace.SetMetadata($"gate.tool.{seq}.{verdict.PolicyName}", new Dictionary<string, object?>
-        {
-            ["action"] = "Mutate",
-            // P2-2: honest observe evidence — false under WarnOnly, where argsAfter is the counterfactual the
-            // gate proposed but the tool did NOT receive (the live arguments were left unchanged).
-            ["applied"] = applied,
-            ["reason"] = verdict.Reason,
-            ["argsBefore"] = MutationEvidenceRenderer.Render(argsBefore, captureMode),
-            ["argsAfter"] = MutationEvidenceRenderer.Render(argsAfter, captureMode),
-            ["captureMode"] = captureMode.ToString(),
-            ["correlationId"] = ToolCorrelationScope.Current,
-        });
+        var record = evidence.Build(
+            stage: "tool", policy: verdict.PolicyName, action: "Mutate", referenceId: GateReferenceId.New(),
+            reason: verdict.Reason, severity: GateSeverityClassifier.Classify(verdict.PolicyName),
+            correlationId: ToolCorrelationScope.Current,
+            extra: new Dictionary<string, object?>
+            {
+                // P2-2: applied is false under WarnOnly, where argsAfter is the counterfactual the gate proposed
+                // but the tool did NOT receive (the live arguments were left unchanged).
+                ["applied"] = applied,
+                ["argsBefore"] = MutationEvidenceRenderer.Render(argsBefore, captureMode),
+                ["argsAfter"] = MutationEvidenceRenderer.Render(argsAfter, captureMode),
+                ["captureMode"] = captureMode.ToString(),
+            });
+        trace.SetMetadata(record.TraceKey(seq), record.ToMetadata());
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentRunScope.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentRunScope.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using AgentEval.Guardrails;
 using Microsoft.Agents.AI;
 using AgentTrace = AgentEval.Tracing.AgentTrace;
 
@@ -30,6 +31,13 @@ public sealed class AgentRunScope : IDisposable
 
     /// <summary>The Glass Box trace for this run, if any.</summary>
     public AgentTrace? Trace { get; }
+
+    /// <summary>
+    /// A stable, opaque identity for THIS run (Phase 3 / F-C), generated when the scope begins — lets gate
+    /// evidence, budgets, and the end-of-run receipt be correlated to one run without depending on object
+    /// identity. A nested sub-agent run gets its OWN id; walk <see cref="Root"/> for the run tree's outermost id.
+    /// </summary>
+    public string RunId { get; } = GateCorrelationId.New();
 
     /// <summary>
     /// The scope of the ENCLOSING run (P2-8) — the scope that was <see cref="Current"/> when this one began,

--- a/src/AgentEval.MAF/Gatekeeper/GateConfigFingerprint.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateConfigFingerprint.cs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text;
+using AgentEval.Guardrails;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Computes a stable fingerprint of the FROZEN gate configuration a run enforced (Phase 3, P3-6), so every
+/// <see cref="GateEvidence"/> record — and the end-of-run receipt — can be tied to the exact gate list that
+/// produced it. The fingerprint is <b>order-sensitive</b>: gate order is semantically significant (first-block-wins,
+/// mutate-then-revalidate), so two lists differing only in order are different configurations. Reuses the shared
+/// <see cref="ManifestFingerprint.Hash"/> (SHA-256) so it matches the rest of the toolkit's fingerprinting.
+/// </summary>
+public static class GateConfigFingerprint
+{
+    /// <summary>Fingerprints the tool / result / chat gate lists (any may be null/empty). Each gate contributes its concrete type and policy name, in order.</summary>
+    public static string Compute(
+        IReadOnlyList<IToolGate>? toolGates = null,
+        IReadOnlyList<IToolResultGate>? resultGates = null,
+        IReadOnlyList<IChatGate>? chatGates = null)
+    {
+        var sb = new StringBuilder();
+        AppendList(sb, "tool", toolGates?.Select(g => Describe(g.GetType(), g.PolicyName)));
+        AppendList(sb, "result", resultGates?.Select(g => Describe(g.GetType(), g.PolicyName)));
+        AppendList(sb, "chat", chatGates?.Select(g => Describe(g.GetType(), g.PolicyName)));
+        return ManifestFingerprint.Hash(sb.ToString());
+    }
+
+    private static string Describe(Type gateType, string policyName) => $"{gateType.FullName}#{policyName}";
+
+    private static void AppendList(StringBuilder sb, string label, IEnumerable<string>? entries)
+    {
+        sb.Append('[').Append(label).Append("]\n");
+        if (entries is null)
+        {
+            return;
+        }
+
+        foreach (var entry in entries)
+        {
+            sb.Append(entry).Append('\n');
+        }
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateEvidence.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateEvidence.cs
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// The <b>one canonical gate-evidence record</b> (Phase 3, F-C) that every Gatekeeper trace writer now projects,
+/// replacing the divergent per-writer metadata dictionaries. A single shape carries the full "reconstructable why":
+/// which gate fired, at which seam, against which tool/agent/iteration, when, how severe, and the
+/// <see cref="GateProvenance"/> behind a threshold decision. It has exactly two projections and NEVER a parallel
+/// structure: <see cref="ToMetadata"/> (the audit-visible trace value, a superset that stays compatible with
+/// <c>GateMetadataReader</c>/<c>GlassBoxEvidence</c> because it keeps the <c>action</c> vocabulary and the
+/// <c>gate.{stage}.{seq}.{policy}</c> key grammar), and — later, P4-1 — the versioned model-facing refusal envelope
+/// derived from the same fields.
+/// </summary>
+public sealed record GateEvidence
+{
+    /// <summary>Short, opaque, correlatable id — the value echoed in the model-facing refusal and looked up by the reference ledger (P3-1).</summary>
+    public required string ReferenceId { get; init; }
+
+    /// <summary>When the finding was recorded (UTC).</summary>
+    public required DateTimeOffset TimestampUtc { get; init; }
+
+    /// <summary>The seam: <c>tool</c> / <c>tool-result</c> / <c>run-pre</c> / <c>run-post</c> / <c>session</c> / <c>warning</c> / <c>approval</c>.</summary>
+    public required string Stage { get; init; }
+
+    /// <summary>The gate's stable policy name (the key's policy segment).</summary>
+    public required string Policy { get; init; }
+
+    /// <summary>What happened: <c>Block</c> / <c>Warn</c> / <c>Mutate</c> / <c>Redact</c> / <c>Reconcile</c> / <c>RequireApproval</c>. Only <c>Block</c> counts as an enforced block (readers key on this).</summary>
+    public required string Action { get; init; }
+
+    /// <summary>Triage severity, stamped at record time (P3-5).</summary>
+    public GateSeverity Severity { get; init; } = GateSeverity.Routine;
+
+    /// <summary>The run this finding belongs to (<see cref="AgentRunScope.RunId"/>), if a run scope was established.</summary>
+    public string? RunId { get; init; }
+
+    /// <summary>The invoking agent's name, if known.</summary>
+    public string? AgentName { get; init; }
+
+    /// <summary>The tool the finding concerns (tool/result seams), if any.</summary>
+    public string? ToolName { get; init; }
+
+    /// <summary>The function-calling iteration index (tool/result seams), if any.</summary>
+    public int? Iteration { get; init; }
+
+    /// <summary>Human-readable reason (audit-visible; never returned to the model). Already sensitive-axis-redacted by the writer when required.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>The reconstructable "why" behind a threshold decision (P3-3) — persisted here for the first time.</summary>
+    public GateProvenance? Provenance { get; init; }
+
+    /// <summary>Hash of the frozen gate list this run enforced (P3-6), so a record can be tied to the exact configuration that produced it.</summary>
+    public string? ConfigFingerprint { get; init; }
+
+    /// <summary>The ambient tool-call correlation id, if any (carries through the existing <c>correlationId</c> key).</summary>
+    public string? CorrelationId { get; init; }
+
+    /// <summary>Writer-specific fields that don't belong to the common schema (e.g. <c>matches</c>, <c>argsBefore/argsAfter</c>, <c>scrubbed</c>, <c>terminate</c>). Merged verbatim into the trace value.</summary>
+    public IReadOnlyDictionary<string, object?>? Extra { get; init; }
+
+    /// <summary>The trace key this evidence is written under: <c>gate.{stage}.{seq}.{policy}</c>.</summary>
+    public string TraceKey(int seq) => $"gate.{Stage}.{seq}.{Policy}";
+
+    /// <summary>
+    /// The audit-visible trace value — a SUPERSET dictionary that keeps the fields the existing readers parse
+    /// (<c>action</c>, <c>reason</c>, <c>referenceId</c>, …) and adds the F-C fields. Null-valued optional fields
+    /// are omitted so a record stays as lean as the pre-F-C writers where nothing new applies.
+    /// </summary>
+    public Dictionary<string, object?> ToMetadata()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["action"] = Action,
+            ["reason"] = Reason,
+            ["referenceId"] = ReferenceId,
+            ["severity"] = Severity.ToString(),
+            ["tsUtc"] = TimestampUtc.ToString("O"),
+        };
+
+        AddIfPresent(value, "runId", RunId);
+        AddIfPresent(value, "agentName", AgentName);
+        AddIfPresent(value, "toolName", ToolName);
+        if (Iteration is { } iteration)
+        {
+            value["iteration"] = iteration;
+        }
+
+        AddIfPresent(value, "configFingerprint", ConfigFingerprint);
+        AddIfPresent(value, "correlationId", CorrelationId);
+        if (Provenance is not null)
+        {
+            value["provenance"] = ProvenanceToValue(Provenance);
+        }
+
+        if (Extra is not null)
+        {
+            foreach (var kv in Extra)
+            {
+                value[kv.Key] = kv.Value;   // writer-specific fields win (e.g. an already-redacted matches)
+            }
+        }
+
+        return value;
+    }
+
+    private static void AddIfPresent(Dictionary<string, object?> value, string key, string? item)
+    {
+        if (!string.IsNullOrEmpty(item))
+        {
+            value[key] = item;
+        }
+    }
+
+    // Flatten provenance to plain nested dictionaries/lists so it round-trips through AgentTrace's JSON without
+    // depending on GateProvenance's type at read time.
+    private static Dictionary<string, object?> ProvenanceToValue(GateProvenance provenance)
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["ruleName"] = provenance.RuleName,
+            ["evidence"] = provenance.Evidence,
+        };
+        if (provenance.Threshold is { } threshold)
+        {
+            value["threshold"] = threshold;
+        }
+
+        if (provenance.ActualValue is { } actual)
+        {
+            value["actualValue"] = actual;
+        }
+
+        if (provenance.Contributing is { Count: > 0 } contributing)
+        {
+            value["contributing"] = contributing.Select(ProvenanceToValue).ToList();
+        }
+
+        return value;
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// The per-invocation enrichment context a Gatekeeper writer stamps onto every <see cref="GateEvidence"/> record
+/// (Phase 3, F-C / P3-2). Captured once at a pipeline seam — the fields not available from ambient state
+/// (<see cref="AgentRunScope"/> for run id, <c>ToolCorrelationScope</c> for correlation id) — and passed into the
+/// record helpers so the "complete block evidence" (agent / tool / iteration / config fingerprint) is filled in
+/// uniformly rather than each writer re-deriving it. The timestamp is stamped at <see cref="Build"/> time.
+/// </summary>
+internal readonly record struct GateEvidenceContext(string? AgentName, string? ToolName, int? Iteration, string? ConfigFingerprint)
+{
+    /// <summary>Assembles a full <see cref="GateEvidence"/> record from this context plus the per-finding fields (timestamp stamped now).</summary>
+    public GateEvidence Build(
+        string stage,
+        string policy,
+        string action,
+        string referenceId,
+        string? reason,
+        GateSeverity severity,
+        string? correlationId = null,
+        AgentEval.Guardrails.GateProvenance? provenance = null,
+        IReadOnlyDictionary<string, object?>? extra = null)
+        => new()
+        {
+            ReferenceId = referenceId,
+            TimestampUtc = DateTimeOffset.UtcNow,
+            Stage = stage,
+            Policy = policy,
+            Action = action,
+            Severity = severity,
+            RunId = AgentRunScope.Current?.RunId,
+            AgentName = AgentName ?? AgentRunScope.Current?.AgentName,
+            ToolName = ToolName,
+            Iteration = Iteration,
+            Reason = reason,
+            Provenance = provenance,
+            ConfigFingerprint = ConfigFingerprint,
+            CorrelationId = correlationId,
+            Extra = extra,
+        };
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
@@ -11,8 +11,14 @@ namespace AgentEval.MAF.Gatekeeper;
 /// record helpers so the "complete block evidence" (agent / tool / iteration / config fingerprint) is filled in
 /// uniformly rather than each writer re-deriving it. The timestamp is stamped at <see cref="Build"/> time.
 /// </summary>
-internal readonly record struct GateEvidenceContext(string? AgentName, string? ToolName, int? Iteration, string? ConfigFingerprint)
+internal readonly record struct GateEvidenceContext(string? AgentName, string? ToolName, int? Iteration, string? ConfigFingerprint, IGateEvidenceSink? Sink = null)
 {
+    /// <summary>Whether a record must be BUILT even with no trace — true when an extra sink (ledger / alerting) is registered, so evidence still flows with tracing off (P3-1).</summary>
+    public bool HasSink => Sink is not null;
+
+    /// <summary>Fan a built record out to the registered extra sink (ledger / alerting), if any. The trace write is done separately by the writer, so this never double-writes the trace.</summary>
+    public void Emit(GateEvidence record, int sequence) => Sink?.Record(record, sequence);
+
     /// <summary>Assembles a full <see cref="GateEvidence"/> record from this context plus the per-finding fields (timestamp stamped now).</summary>
     public GateEvidence Build(
         string stage,

--- a/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateEvidenceContext.cs
@@ -16,8 +16,23 @@ internal readonly record struct GateEvidenceContext(string? AgentName, string? T
     /// <summary>Whether a record must be BUILT even with no trace — true when an extra sink (ledger / alerting) is registered, so evidence still flows with tracing off (P3-1).</summary>
     public bool HasSink => Sink is not null;
 
-    /// <summary>Fan a built record out to the registered extra sink (ledger / alerting), if any. The trace write is done separately by the writer, so this never double-writes the trace.</summary>
-    public void Emit(GateEvidence record, int sequence) => Sink?.Record(record, sequence);
+    /// <summary>
+    /// Fan a built record out to the registered extra sink (ledger / alerting), if any. This runs INLINE on the
+    /// enforcement path (right before a Block returns its refusal), so a throwing sink is ISOLATED here — a broken
+    /// evidence destination must never propagate out of the gate middleware and destroy the controlled refusal or
+    /// fail the run open. The trace write is done separately by the writer, so this never double-writes the trace.
+    /// </summary>
+    public void Emit(GateEvidence record, int sequence)
+    {
+        try
+        {
+            Sink?.Record(record, sequence);
+        }
+        catch
+        {
+            // An evidence sink failing must never break enforcement — the refusal/verdict still stands.
+        }
+    }
 
     /// <summary>Assembles a full <see cref="GateEvidence"/> record from this context plus the per-finding fields (timestamp stamped now).</summary>
     public GateEvidence Build(

--- a/src/AgentEval.MAF/Gatekeeper/GateReferenceIndexAggregator.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateReferenceIndexAggregator.cs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Reads the durable, cross-run refusal index a <see cref="GateReferenceLedger"/> appends (Phase 3, P3-8) and
+/// aggregates it — block counts by tool / policy / config-fingerprint / severity / day — so an operator can see
+/// block-rate-by-tool-over-time trends across many runs. A precondition for the Bulkhead security graph. Pure and
+/// offline: it consumes the JSONL an earlier run wrote, so it needs neither a live run nor the trace.
+/// </summary>
+public static class GateReferenceIndexAggregator
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    /// <summary>Parses the JSONL refusal index from <paramref name="reader"/>, skipping blank or malformed lines.</summary>
+    public static IReadOnlyList<GateReferenceLedger.GateReferenceIndexEntry> Read(TextReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        var entries = new List<GateReferenceLedger.GateReferenceIndexEntry>();
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            GateReferenceLedger.GateReferenceIndexEntry? entry = null;
+            try
+            {
+                entry = JsonSerializer.Deserialize<GateReferenceLedger.GateReferenceIndexEntry>(line, JsonOptions);
+            }
+            catch (JsonException)
+            {
+                // A corrupt/partial line must not sink the whole aggregation — skip it (best-effort offline read).
+            }
+
+            if (entry is not null)
+            {
+                entries.Add(entry);
+            }
+        }
+
+        return entries;
+    }
+
+    /// <summary>Aggregates <paramref name="entries"/> into cross-run block-rate breakdowns.</summary>
+    public static GateBlockAggregation Aggregate(IEnumerable<GateReferenceLedger.GateReferenceIndexEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        var total = 0;
+        var byPolicy = new Dictionary<string, int>(StringComparer.Ordinal);
+        var byTool = new Dictionary<string, int>(StringComparer.Ordinal);
+        var byConfig = new Dictionary<string, int>(StringComparer.Ordinal);
+        var bySeverity = new Dictionary<string, int>(StringComparer.Ordinal);
+        var byDay = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var entry in entries)
+        {
+            total++;
+            Bump(byPolicy, entry.Policy);
+            Bump(byTool, entry.ToolName ?? "(none)");
+            Bump(byConfig, entry.ConfigFingerprint ?? "(none)");
+            Bump(bySeverity, entry.Severity);
+            Bump(byDay, entry.TsUtc.ToUniversalTime().ToString("yyyy-MM-dd"));
+        }
+
+        return new GateBlockAggregation(total, byPolicy, byTool, byConfig, bySeverity, byDay);
+    }
+
+    /// <summary>Reads and aggregates in one call.</summary>
+    public static GateBlockAggregation ReadAndAggregate(TextReader reader) => Aggregate(Read(reader));
+
+    private static void Bump(Dictionary<string, int> counts, string key)
+        => counts[key] = counts.TryGetValue(key, out var n) ? n + 1 : 1;
+}
+
+/// <summary>Cross-run refusal aggregation (P3-8): total blocks plus breakdowns by policy, tool, config fingerprint, severity, and UTC day.</summary>
+/// <param name="Total">Total refusals in the index.</param>
+/// <param name="ByPolicy">Block count per gate policy.</param>
+/// <param name="ByTool">Block count per tool (<c>"(none)"</c> for run-seam blocks with no tool).</param>
+/// <param name="ByConfigFingerprint">Block count per gate-config fingerprint — the "which configuration produced these" axis.</param>
+/// <param name="BySeverity">Block count per severity band.</param>
+/// <param name="ByDay">Block count per UTC day (<c>yyyy-MM-dd</c>) — the over-time trend.</param>
+public sealed record GateBlockAggregation(
+    int Total,
+    IReadOnlyDictionary<string, int> ByPolicy,
+    IReadOnlyDictionary<string, int> ByTool,
+    IReadOnlyDictionary<string, int> ByConfigFingerprint,
+    IReadOnlyDictionary<string, int> BySeverity,
+    IReadOnlyDictionary<string, int> ByDay);

--- a/src/AgentEval.MAF/Gatekeeper/GateReferenceLedger.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateReferenceLedger.cs
@@ -45,7 +45,7 @@ public sealed class GateReferenceLedger : IGateEvidenceSink
             var line = JsonSerializer.Serialize(
                 new GateReferenceIndexEntry(
                     evidence.ReferenceId, evidence.TimestampUtc, evidence.RunId, evidence.Policy, evidence.Stage,
-                    evidence.ToolName, evidence.AgentName, evidence.Severity.ToString()),
+                    evidence.ToolName, evidence.AgentName, evidence.Severity.ToString(), evidence.ConfigFingerprint),
                 JsonOptions);
             lock (_writeLock)
             {
@@ -55,7 +55,7 @@ public sealed class GateReferenceLedger : IGateEvidenceSink
         }
     }
 
-    /// <summary>One line of the refusal index — the minimum an operator needs to correlate and triage a reference id.</summary>
+    /// <summary>One line of the refusal index — the minimum an operator needs to correlate and triage a reference id, plus the config fingerprint for cross-run aggregation (P3-8).</summary>
     public sealed record GateReferenceIndexEntry(
         string ReferenceId,
         DateTimeOffset TsUtc,
@@ -64,5 +64,6 @@ public sealed class GateReferenceLedger : IGateEvidenceSink
         string Stage,
         string? ToolName,
         string? AgentName,
-        string Severity);
+        string Severity,
+        string? ConfigFingerprint = null);
 }

--- a/src/AgentEval.MAF/Gatekeeper/GateReferenceLedger.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateReferenceLedger.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// An <see cref="IGateEvidenceSink"/> (Phase 3, P3-1) that indexes every gate finding into a
+/// <see cref="GateVerdictResolver"/> for O(1) <c>referenceId</c> lookup, and — opt-in — appends every enforced
+/// REFUSAL (an <c>action="Block"</c> record) as one JSON line to a caller-supplied index writer. Register it as a
+/// Gatekeeper evidence sink so a refusal's opaque reference id can later be resolved back to the full record
+/// (<c>agenteval trace find-reference &lt;id&gt;</c>) even when tracing is off — the resolver is fed here directly,
+/// not from the trace.
+/// </summary>
+public sealed class GateReferenceLedger : IGateEvidenceSink
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false, PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private readonly TextWriter? _jsonlIndex;
+    private readonly object _writeLock = new();
+
+    /// <summary>Creates the ledger.</summary>
+    /// <param name="resolver">The resolver every record is indexed into (a fresh bounded/TTL one if null).</param>
+    /// <param name="jsonlIndex">Optional append-only JSONL sink for enforced refusals; null keeps the index in memory only.</param>
+    public GateReferenceLedger(GateVerdictResolver? resolver = null, TextWriter? jsonlIndex = null)
+    {
+        Resolver = resolver ?? new GateVerdictResolver();
+        _jsonlIndex = jsonlIndex;
+    }
+
+    /// <summary>The resolver this ledger feeds — call <see cref="GateVerdictResolver.TryResolve"/> on it to look a reference id up.</summary>
+    public GateVerdictResolver Resolver { get; }
+
+    /// <inheritdoc/>
+    public void Record(GateEvidence evidence, int sequence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        Resolver.Record(evidence);
+
+        // Append only enforced REFUSALS to the durable index — the records an operator triages from a reference id.
+        if (_jsonlIndex is not null && string.Equals(evidence.Action, "Block", StringComparison.Ordinal))
+        {
+            var line = JsonSerializer.Serialize(
+                new GateReferenceIndexEntry(
+                    evidence.ReferenceId, evidence.TimestampUtc, evidence.RunId, evidence.Policy, evidence.Stage,
+                    evidence.ToolName, evidence.AgentName, evidence.Severity.ToString()),
+                JsonOptions);
+            lock (_writeLock)
+            {
+                _jsonlIndex.WriteLine(line);
+                _jsonlIndex.Flush();
+            }
+        }
+    }
+
+    /// <summary>One line of the refusal index — the minimum an operator needs to correlate and triage a reference id.</summary>
+    public sealed record GateReferenceIndexEntry(
+        string ReferenceId,
+        DateTimeOffset TsUtc,
+        string? RunId,
+        string Policy,
+        string Stage,
+        string? ToolName,
+        string? AgentName,
+        string Severity);
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateReplayRenderer.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateReplayRenderer.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text;
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Turns a <see cref="GateReplayComparison"/> into a readable human diff (Phase 3, P3-9) — per captured call, what
+/// the baseline gate config did vs. what a candidate config WOULD do (allow / block / mutate), with the divergences
+/// called out. Together with <see cref="ExtractToolCalls"/> (the fixture-capture → replayer bridge) this unlocks a
+/// safe "what would this new gate have done to real traffic?" rollout check before a gate goes live.
+/// </summary>
+public static class GateReplayRenderer
+{
+    /// <summary>
+    /// Extracts the tool calls a model actually made from captured chat messages (the fixture-capture → replayer
+    /// bridge, P3-9) so they can be replayed against a candidate gate config. Reads every
+    /// <see cref="FunctionCallContent"/> across the messages, in order.
+    /// </summary>
+    public static IReadOnlyList<GatedToolCall> ExtractToolCalls(IEnumerable<ChatMessage> capturedMessages, string? agentName = null)
+    {
+        ArgumentNullException.ThrowIfNull(capturedMessages);
+        var calls = new List<GatedToolCall>();
+        var messages = capturedMessages.ToList();
+        var iteration = 0;
+        foreach (var message in messages)
+        {
+            var functionCalls = message.Contents.OfType<FunctionCallContent>().ToList();
+            for (var i = 0; i < functionCalls.Count; i++)
+            {
+                var fc = functionCalls[i];
+                calls.Add(new GatedToolCall(
+                    FunctionName: fc.Name,
+                    Arguments: fc.Arguments as IReadOnlyDictionary<string, object?>,
+                    AgentName: agentName,
+                    Iteration: iteration,
+                    FunctionCallIndex: i,
+                    FunctionCount: functionCalls.Count,
+                    IsStreaming: false,
+                    Messages: messages));
+            }
+
+            if (functionCalls.Count > 0)
+            {
+                iteration++;
+            }
+        }
+
+        return calls;
+    }
+
+    /// <summary>Renders the full comparison — one line per call, the divergences first, then a summary.</summary>
+    public static string Render(GateReplayComparison comparison)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        var sb = new StringBuilder();
+        sb.Append("Gate replay — ").Append(comparison.Rows.Count).Append(" call(s), ")
+          .Append(comparison.Diverged.Count).AppendLine(" diverged").AppendLine();
+
+        foreach (var row in comparison.Rows)
+        {
+            sb.Append(row.Diverged ? "  ✗ " : "  · ")
+              .Append(row.Call.FunctionName)
+              .Append(": baseline=").Append(Describe(row.Baseline))
+              .Append("  candidate=").Append(Describe(row.Candidate));
+            if (row.Diverged)
+            {
+                sb.Append("   ← DIVERGED");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static string Describe(ToolGateVerdict verdict) => verdict.Action switch
+    {
+        ToolGateAction.Allow => "Allow",
+        ToolGateAction.Block => $"Block({verdict.PolicyName})",
+        ToolGateAction.Mutate => $"Mutate({verdict.PolicyName})",
+        _ => verdict.Action.ToString(),
+    };
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateSeverity.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateSeverity.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// How urgently a gate finding should be triaged (Phase 3, P3-5) — a field on the unified
+/// <see cref="GateEvidence"/> record, stamped at record time so alerting / triage can route without re-deriving
+/// intent from the policy name.
+/// </summary>
+public enum GateSeverity
+{
+    /// <summary>Expected, low-stakes enforcement — a budget cap, a rate limit, an ordinary policy block.</summary>
+    Routine,
+
+    /// <summary>A finding that suggests probing or manipulation — taint/exfiltration, out-of-order sequencing, referential-integrity mismatch.</summary>
+    Suspicious,
+
+    /// <summary>A high-signal event demanding attention — a tripped canary/honeypot, or a gate that failed closed because it could not even evaluate (a defect).</summary>
+    Incident,
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateSeverityClassifier.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateSeverityClassifier.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// Default triage severity for a gate finding (Phase 3, P3-5), stamped onto <see cref="GateEvidence.Severity"/> at
+/// record time. A heuristic over the built-in gates' policy names — the plan's mapping: budgets/rate limits are
+/// <see cref="GateSeverity.Routine"/>; taint / sequence / referential-integrity / same-batch findings signal
+/// probing (<see cref="GateSeverity.Suspicious"/>); a tripped canary/honeypot OR a gate that failed closed because
+/// it could not even evaluate is an <see cref="GateSeverity.Incident"/>. Intentionally conservative: an unknown
+/// policy defaults to <see cref="GateSeverity.Routine"/> so severity never over-alarms without cause.
+/// </summary>
+public static class GateSeverityClassifier
+{
+    /// <summary>Classifies a finding by its policy name; <paramref name="failedClosedOnThrow"/> forces Incident (a gate that threw is a defect, not an ordinary block).</summary>
+    public static GateSeverity Classify(string? policyName, bool failedClosedOnThrow = false)
+    {
+        if (failedClosedOnThrow)
+        {
+            return GateSeverity.Incident;
+        }
+
+        var policy = policyName ?? string.Empty;
+
+        if (ContainsAny(policy, "Canary", "Honeypot"))
+        {
+            return GateSeverity.Incident;
+        }
+
+        if (ContainsAny(policy, "Taint", "Sequence", "SameBatch", "ReferentialIntegrity", "Exfil", "Quarantine"))
+        {
+            return GateSeverity.Suspicious;
+        }
+
+        return GateSeverity.Routine;
+    }
+
+    private static bool ContainsAny(string value, params string[] needles)
+    {
+        foreach (var needle in needles)
+        {
+            if (value.Contains(needle, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/GateVerdictResolver.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateVerdictResolver.cs
@@ -69,15 +69,14 @@ public sealed class GateVerdictResolver
         ArgumentNullException.ThrowIfNull(referenceId);
         lock (_lock)
         {
-            if (_byReference.TryGetValue(referenceId, out var entry))
+            // Do NOT remove an expired entry here: the dictionary and the FIFO queue are kept 1:1 in sync (a key is
+            // dropped ONLY via eviction, which dequeues in order), so a lazy removal would leave a phantom queue
+            // entry that could later evict a live re-inserted id (Phase 3 review #5). Expired entries are simply
+            // reported unresolvable and reclaimed in FIFO order under capacity pressure.
+            if (_byReference.TryGetValue(referenceId, out var entry) && _timeProvider.GetUtcNow() < entry.ExpiresAtUtc)
             {
-                if (_timeProvider.GetUtcNow() < entry.ExpiresAtUtc)
-                {
-                    evidence = entry.Evidence;
-                    return true;
-                }
-
-                _byReference.Remove(referenceId);   // lazily drop the expired entry
+                evidence = entry.Evidence;
+                return true;
             }
 
             evidence = null!;

--- a/src/AgentEval.MAF/Gatekeeper/GateVerdictResolver.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GateVerdictResolver.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// A bounded, TTL'd, in-memory <c>referenceId → </c><see cref="GateEvidence"/> index (Phase 3, P3-1). The
+/// model-facing refusal shows only an opaque <c>referenceId</c>; an operator (or the <c>agenteval trace
+/// find-reference</c> CLI) resolves that id back to the full audit record in O(1) here — <b>without needing the
+/// trace</b>, because the resolver is fed directly from the evidence stream. Bounded (FIFO eviction past a max
+/// count) and TTL'd so it can run continuously without unbounded growth; thread-safe.
+/// </summary>
+public sealed class GateVerdictResolver
+{
+    private readonly int _maxEntries;
+    private readonly TimeSpan _ttl;
+    private readonly TimeProvider _timeProvider;
+    private readonly object _lock = new();
+    private readonly Dictionary<string, (GateEvidence Evidence, DateTimeOffset ExpiresAtUtc)> _byReference = new(StringComparer.Ordinal);
+    private readonly Queue<string> _insertionOrder = new();
+
+    /// <summary>Creates the resolver.</summary>
+    /// <param name="maxEntries">Maximum retained records; the oldest are evicted past this (default 4096).</param>
+    /// <param name="ttl">How long a record stays resolvable (default 1 hour).</param>
+    /// <param name="timeProvider">Clock (testability); defaults to <see cref="TimeProvider.System"/>.</param>
+    public GateVerdictResolver(int maxEntries = 4096, TimeSpan? ttl = null, TimeProvider? timeProvider = null)
+    {
+        if (maxEntries < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxEntries), "must be at least 1.");
+        }
+
+        _maxEntries = maxEntries;
+        _ttl = ttl ?? TimeSpan.FromHours(1);
+        if (_ttl <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ttl), "must be positive.");
+        }
+
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>Indexes <paramref name="evidence"/> under its <see cref="GateEvidence.ReferenceId"/>, evicting the oldest entry if at capacity.</summary>
+    public void Record(GateEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        lock (_lock)
+        {
+            var expiresAt = _timeProvider.GetUtcNow() + _ttl;
+            if (!_byReference.ContainsKey(evidence.ReferenceId))
+            {
+                _insertionOrder.Enqueue(evidence.ReferenceId);
+            }
+
+            _byReference[evidence.ReferenceId] = (evidence, expiresAt);
+
+            while (_insertionOrder.Count > _maxEntries)
+            {
+                var oldest = _insertionOrder.Dequeue();
+                _byReference.Remove(oldest);
+            }
+        }
+    }
+
+    /// <summary>Resolves a <paramref name="referenceId"/> to its record, or false if unknown or expired (an expired entry is dropped).</summary>
+    public bool TryResolve(string referenceId, out GateEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(referenceId);
+        lock (_lock)
+        {
+            if (_byReference.TryGetValue(referenceId, out var entry))
+            {
+                if (_timeProvider.GetUtcNow() < entry.ExpiresAtUtc)
+                {
+                    evidence = entry.Evidence;
+                    return true;
+                }
+
+                _byReference.Remove(referenceId);   // lazily drop the expired entry
+            }
+
+            evidence = null!;
+            return false;
+        }
+    }
+
+    /// <summary>Count of currently-retained records (expired-but-not-yet-swept entries included).</summary>
+    public int Count
+    {
+        get { lock (_lock) { return _byReference.Count; } }
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GatekeeperOptions.cs
@@ -128,6 +128,13 @@ public sealed class GatekeeperOptions
     public GateTelemetry? Telemetry { get; set; }
 
     /// <summary>
+    /// Optional extra <see cref="IGateEvidenceSink"/> (Phase 3, F-C) fanned every gate finding — beyond the trace —
+    /// so a <see cref="GateReferenceLedger"/> (P3-1 reference resolution) or an alerting sink (P3-4) can be
+    /// registered. Wired into both the tool-gate and run-gate seams; works with <see cref="Trace"/> off.
+    /// </summary>
+    public IGateEvidenceSink? EvidenceSink { get; set; }
+
+    /// <summary>
     /// How much of a <see cref="ToolGateAction.Mutate"/> verdict's before/after arguments are captured into
     /// the trace (Phase 1, #13). Defaults to <see cref="TraceCaptureMode.Redacted"/>.
     /// </summary>

--- a/src/AgentEval.MAF/Gatekeeper/IGateEvidenceSink.cs
+++ b/src/AgentEval.MAF/Gatekeeper/IGateEvidenceSink.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// A destination for <see cref="GateEvidence"/> (Phase 3, F-C / P3-3) — the DIP that lets the trace writer, the
+/// reference-id ledger (P3-1), and the alerting path (P3-4) all be REGISTERED against one evidence stream instead
+/// of each editing the pipeline. Implementations must be cheap and non-throwing on the hot path (a sink that
+/// throws must not break enforcement) — the composite guards that.
+/// </summary>
+public interface IGateEvidenceSink
+{
+    /// <summary>Record one gate finding. <paramref name="sequence"/> is the per-pipeline ordering index used for the trace key.</summary>
+    void Record(GateEvidence evidence, int sequence);
+}
+
+/// <summary>Writes each <see cref="GateEvidence"/> into an <see cref="AgentTrace"/> under its <c>gate.{stage}.{seq}.{policy}</c> key — the audit projection, and the default sink.</summary>
+public sealed class TraceGateEvidenceSink : IGateEvidenceSink
+{
+    private readonly AgentTrace? _trace;
+
+    /// <summary>Creates the sink over <paramref name="trace"/> (a null trace makes every record a no-op — the tracing-off path).</summary>
+    public TraceGateEvidenceSink(AgentTrace? trace) => _trace = trace;
+
+    /// <inheritdoc/>
+    public void Record(GateEvidence evidence, int sequence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        _trace?.SetMetadata(evidence.TraceKey(sequence), evidence.ToMetadata());
+    }
+}
+
+/// <summary>
+/// Fans one <see cref="GateEvidence"/> out to several sinks (P3-3). A sink that throws is isolated — the remaining
+/// sinks still receive the record and enforcement is never broken by an evidence destination — because a broken
+/// audit destination must not become a fail-open in the enforcement path.
+/// </summary>
+public sealed class CompositeGateEvidenceSink : IGateEvidenceSink
+{
+    private readonly IReadOnlyList<IGateEvidenceSink> _sinks;
+
+    /// <summary>Creates the composite over <paramref name="sinks"/> (nulls are dropped).</summary>
+    public CompositeGateEvidenceSink(params IGateEvidenceSink?[] sinks)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        _sinks = sinks.Where(s => s is not null).Cast<IGateEvidenceSink>().ToArray();
+    }
+
+    /// <inheritdoc/>
+    public void Record(GateEvidence evidence, int sequence)
+    {
+        foreach (var sink in _sinks)
+        {
+            try
+            {
+                sink.Record(evidence, sequence);
+            }
+            catch
+            {
+                // An evidence sink failing must never break enforcement or suppress the other sinks.
+            }
+        }
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/IGatekeeperObserver.cs
+++ b/src/AgentEval.MAF/Gatekeeper/IGatekeeperObserver.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// An alerting / notification hook (Phase 3, P3-4) invoked on every actionable gate finding — an enforced block,
+/// an applied mutation or redaction, or anything the classifier rated <see cref="GateSeverity.Incident"/> (e.g. a
+/// tripped canary or a gate that failed closed because it could not evaluate). Wire it up as a
+/// <see cref="GatekeeperOptions.EvidenceSink"/> via <see cref="ObserverEvidenceSink"/> (compose with a
+/// <see cref="GateReferenceLedger"/> using <see cref="CompositeGateEvidenceSink"/> to run both). The callback runs
+/// on the enforcement path, so it must be cheap and non-throwing — the sink isolates a throw, but a slow observer
+/// slows the run.
+/// </summary>
+public interface IGatekeeperObserver
+{
+    /// <summary>Called with the full <see cref="GateEvidence"/> for one actionable finding.</summary>
+    void OnFinding(GateEvidence evidence);
+}
+
+/// <summary>
+/// Adapts an <see cref="IGatekeeperObserver"/> to an <see cref="IGateEvidenceSink"/> (P3-4): forwards only the
+/// ACTIONABLE findings — <c>Block</c> / <c>Mutate</c> / <c>Redact</c>, plus anything of
+/// <see cref="GateSeverity.Incident"/> severity — so a routine <c>Warn</c>/<c>Allow</c> record never pages anyone,
+/// but a fail-closed incident always does.
+/// </summary>
+public sealed class ObserverEvidenceSink : IGateEvidenceSink
+{
+    private readonly IGatekeeperObserver _observer;
+
+    /// <summary>Creates the sink over <paramref name="observer"/>.</summary>
+    public ObserverEvidenceSink(IGatekeeperObserver observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+        _observer = observer;
+    }
+
+    /// <inheritdoc/>
+    public void Record(GateEvidence evidence, int sequence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        if (IsActionable(evidence))
+        {
+            _observer.OnFinding(evidence);
+        }
+    }
+
+    private static bool IsActionable(GateEvidence evidence)
+        => evidence.Severity == GateSeverity.Incident
+           || evidence.Action is "Block" or "Mutate" or "Redact";
+}

--- a/src/AgentEval.MAF/Gatekeeper/IGatekeeperObserver.cs
+++ b/src/AgentEval.MAF/Gatekeeper/IGatekeeperObserver.cs
@@ -40,9 +40,18 @@ public sealed class ObserverEvidenceSink : IGateEvidenceSink
     public void Record(GateEvidence evidence, int sequence)
     {
         ArgumentNullException.ThrowIfNull(evidence);
-        if (IsActionable(evidence))
+        if (!IsActionable(evidence))
+        {
+            return;
+        }
+
+        try
         {
             _observer.OnFinding(evidence);
+        }
+        catch
+        {
+            // A throwing observer must never break enforcement (the emission path also isolates, belt-and-braces).
         }
     }
 

--- a/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
+++ b/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
@@ -104,6 +104,19 @@ public sealed class RunLedger
         get { lock (_lock) { return _totalToolCalls; } }
     }
 
+    /// <summary>
+    /// Snapshots this run's accumulated tool-call activity into a <see cref="RunReceipt"/> (P3-11) — an atomic
+    /// copy under the ledger lock, so it is consistent even if a concurrent tool call is in flight.
+    /// </summary>
+    public RunReceipt Summarize(string? runId, string? agentName, string? configFingerprint, DateTimeOffset endedAtUtc)
+    {
+        lock (_lock)
+        {
+            return new RunReceipt(runId, agentName, configFingerprint, endedAtUtc, _totalToolCalls,
+                new Dictionary<string, int>(_toolCalls, StringComparer.OrdinalIgnoreCase));
+        }
+    }
+
     /// <summary>How many times a given tool has been recorded this run.</summary>
     public int ToolCallCount(string toolName)
     {

--- a/src/AgentEval.MAF/Gatekeeper/RunReceipt.cs
+++ b/src/AgentEval.MAF/Gatekeeper/RunReceipt.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// A per-run summary exported at run end (Phase 3, P3-11) — a snapshot of what the <see cref="RunLedger"/>
+/// accumulated for one run, tied to the run's identity and the gate configuration that governed it. Emitted as a
+/// <c>gate.receipt.*</c> evidence record so it rides the same F-C stream (trace + any sink) as every other finding.
+/// </summary>
+/// <param name="RunId">The run's identity (<see cref="AgentRunScope.RunId"/>), if a scope was established.</param>
+/// <param name="AgentName">The invoking agent's name, if known.</param>
+/// <param name="ConfigFingerprint">The gate configuration in force (P3-6).</param>
+/// <param name="EndedAtUtc">When the run finished.</param>
+/// <param name="TotalToolCalls">Total tool calls the ledger recorded this run.</param>
+/// <param name="ToolCallCounts">Per-tool call counts (a snapshot copy).</param>
+public sealed record RunReceipt(
+    string? RunId,
+    string? AgentName,
+    string? ConfigFingerprint,
+    DateTimeOffset EndedAtUtc,
+    int TotalToolCalls,
+    IReadOnlyDictionary<string, int> ToolCallCounts);

--- a/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
@@ -164,4 +164,20 @@ public class JudgeCompositionTests
         Assert.True(events[1].Hit);
         Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), events[1].OriginalTimestampUtc);
     }
+
+    [Fact]
+    public async Task Cache_ThrowingOnLookup_DoesNotTurnAllowIntoBlock()
+    {
+        // Phase 3 review #2: the precedent hook is pure observability — a throw must not propagate out of
+        // InspectAsync (where the gate loop would fail-close it into a Block) and refuse a genuine cached Allow.
+        var inner = new StubGate(GateVerdict.Allow("j"), "judge:x");
+        var cache = new JudgeVerdictCache(inner, onLookup: _ => throw new InvalidOperationException("hook boom"));
+
+        var miss = await cache.InspectAsync("same");   // miss — hook throws
+        var hit = await cache.InspectAsync("same");    // hit — hook throws
+
+        Assert.Equal(GateAction.Allow, miss.Action);
+        Assert.Equal(GateAction.Allow, hit.Action);
+        Assert.Equal(1, cache.Hits);
+    }
 }

--- a/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
@@ -132,4 +132,36 @@ public class JudgeCompositionTests
     [Fact]
     public void Cache_ZeroMaxEntries_Throws()
         => Assert.Throws<ArgumentOutOfRangeException>(() => new JudgeVerdictCache(new StubGate(GateVerdict.Allow("x")), 0));
+
+    private sealed class FakeClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+
+    [Fact]
+    public async Task Cache_EmitsPrecedentEvents_HitCarriesOriginalTimestamp()
+    {
+        // P3-7: the cache surfaces hit/miss precedent events; a HIT reports when the served allow was FIRST
+        // evaluated (its precedent age), so a caller can emit gate.cache.* evidence instead of a silent memoize.
+        var clock = new FakeClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var events = new List<JudgeCacheEvent>();
+        var inner = new StubGate(GateVerdict.Allow("j"), "judge:x");
+        var cache = new JudgeVerdictCache(inner, onLookup: events.Add, timeProvider: clock);
+
+        await cache.InspectAsync("same");                 // miss → evaluates, stamps the original timestamp
+        clock.Advance(TimeSpan.FromMinutes(5));
+        await cache.InspectAsync("same");                 // hit → served from cache
+
+        Assert.Equal(1, inner.Calls);                     // the inner judge ran exactly once
+        Assert.Equal(1, cache.Hits);
+        Assert.Equal(1, cache.Misses);
+
+        Assert.Equal(2, events.Count);
+        Assert.False(events[0].Hit);
+        Assert.Null(events[0].OriginalTimestampUtc);
+        Assert.True(events[1].Hit);
+        Assert.Equal(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), events[1].OriginalTimestampUtc);
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/AgentEvalGatekeeperExtensionsTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/AgentEvalGatekeeperExtensionsTests.cs
@@ -843,7 +843,9 @@ public class AgentEvalGatekeeperExtensionsTests
 
         var key = trace.Metadata!.Keys.Single(k => k.StartsWith("gate.tool-result.", StringComparison.Ordinal));
         var entry = (IDictionary<string, object?>)trace.Metadata![key];
-        Assert.Equal("Redact", entry["action"]);
+        // Phase 3 review (#3): a null-redact fallback withholds the result and returns a REFUSAL, so it is
+        // recorded as a Block — counted by GateBlockCount and persisted to the durable reference index.
+        Assert.Equal("Block", entry["action"]);
         Assert.False(string.IsNullOrEmpty((string?)entry["referenceId"]));
     }
 

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateEvidenceTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateEvidenceTests.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using AgentEval.Tracing;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Xunit;
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>
+/// Phase 3, F-C — the unified <see cref="GateEvidence"/> record and its supporting pieces (P3-2 complete block
+/// evidence, P3-3 persisted provenance, P3-5 severity, P3-6 config fingerprint, the run identity). The key
+/// invariant: enrichment is a SUPERSET projection that stays compatible with the existing readers.
+/// </summary>
+public class GateEvidenceTests
+{
+    // ── P3-6: config fingerprint ──
+
+    [Fact]
+    public void ConfigFingerprint_IsStable_AndOrderSensitive()
+    {
+        var a = new ForbiddenToolGate("x");
+        var b = new ArgumentPatternGate("y");
+        var f1 = GateConfigFingerprint.Compute(new IToolGate[] { a, b });
+        var f2 = GateConfigFingerprint.Compute(new IToolGate[] { a, b });
+        var f3 = GateConfigFingerprint.Compute(new IToolGate[] { b, a });
+
+        Assert.Equal(f1, f2);        // deterministic
+        Assert.NotEqual(f1, f3);     // order is semantically significant
+        Assert.False(string.IsNullOrEmpty(f1));
+    }
+
+    // ── P3-5: severity taxonomy ──
+
+    [Theory]
+    [InlineData("RunBudgetGate", GateSeverity.Routine)]
+    [InlineData("MonetaryLimitGate", GateSeverity.Routine)]
+    [InlineData("TaintTrackingGate", GateSeverity.Suspicious)]
+    [InlineData("SequenceGate", GateSeverity.Suspicious)]
+    [InlineData("QuarantineLeaseGate", GateSeverity.Suspicious)]
+    [InlineData("CanaryToolGate", GateSeverity.Incident)]
+    public void Severity_ClassifiesByPolicyName(string policy, GateSeverity expected)
+        => Assert.Equal(expected, GateSeverityClassifier.Classify(policy));
+
+    [Fact]
+    public void Severity_FailedClosedOnThrow_IsAlwaysIncident()
+        => Assert.Equal(GateSeverity.Incident, GateSeverityClassifier.Classify("RunBudgetGate", failedClosedOnThrow: true));
+
+    // ── Run identity ──
+
+    [Fact]
+    public void AgentRunScope_RunId_IsStableWithinScope_AndUniquePerScope()
+    {
+        using var outer = AgentRunScope.Begin(null, "a", null);
+        var outerId = outer.RunId;
+        Assert.Equal(outerId, AgentRunScope.Current!.RunId);   // stable while the scope is current
+
+        using (var inner = AgentRunScope.Begin(null, "b", null))
+        {
+            Assert.NotEqual(outerId, inner.RunId);             // each run gets its own id
+        }
+    }
+
+    // ── GateEvidence.ToMetadata projection ──
+
+    [Fact]
+    public void ToMetadata_KeepsReaderFields_AddsEnrichment_OmitsNulls()
+    {
+        var evidence = new GateEvidence
+        {
+            ReferenceId = "ref-1",
+            TimestampUtc = DateTimeOffset.UnixEpoch,
+            Stage = "tool",
+            Policy = "SomeGate",
+            Action = "Block",
+            Severity = GateSeverity.Incident,
+            RunId = "run-1",
+            AgentName = "Agatha",
+            ToolName = "delete_account",
+            Iteration = 3,
+            Reason = "nope",
+            ConfigFingerprint = "fp-abc",
+        };
+
+        Assert.Equal("gate.tool.7.SomeGate", evidence.TraceKey(7));
+
+        var value = evidence.ToMetadata();
+        Assert.Equal("Block", value["action"]);          // the field every reader keys on
+        Assert.Equal("nope", value["reason"]);
+        Assert.Equal("ref-1", value["referenceId"]);
+        Assert.Equal("Incident", value["severity"]);
+        Assert.Equal("run-1", value["runId"]);
+        Assert.Equal("Agatha", value["agentName"]);
+        Assert.Equal("delete_account", value["toolName"]);
+        Assert.Equal(3, value["iteration"]);
+        Assert.Equal("fp-abc", value["configFingerprint"]);
+        Assert.False(string.IsNullOrEmpty((string?)value["tsUtc"]));
+        Assert.DoesNotContain("correlationId", value.Keys);   // null optional field omitted
+    }
+
+    // ── Integration: a real tool-gate block carries complete evidence AND still counts as a block ──
+
+    [Fact]
+    public async Task ToolGateBlock_CarriesCompleteEnrichedEvidence_AndReaderStillCountsIt()
+    {
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "Agatha", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate()   // establishes the run scope so RunId is populated
+            .UseAgentEvalToolGate([new ForbiddenToolGate("delete_account")], ToolGatePolicy.Terminate, trace)
+            .Build();
+
+        await gated.RunAsync("go");
+
+        // Reader compatibility: GlassBoxEvidence (via GateMetadataReader.IsBlock) still recognizes & counts the block.
+        Assert.Equal(1, GlassBoxEvidence.FromTrace(trace).GateBlockCount);
+
+        var key = trace.Metadata!.Keys.Single(k => k.StartsWith("gate.tool.", StringComparison.Ordinal) && k.Contains("ForbiddenToolGate", StringComparison.Ordinal));
+        var value = (IDictionary<string, object?>)trace.Metadata![key];
+        Assert.Equal("Block", value["action"]);
+        Assert.Equal("Agatha", value["agentName"]);
+        Assert.Equal("delete_account", value["toolName"]);
+        Assert.False(string.IsNullOrEmpty((string?)value["runId"]));
+        Assert.False(string.IsNullOrEmpty((string?)value["configFingerprint"]));
+        Assert.False(string.IsNullOrEmpty((string?)value["tsUtc"]));
+        Assert.False(string.IsNullOrEmpty((string?)value["referenceId"]));
+        Assert.Equal("Routine", value["severity"]);   // ForbiddenToolGate is an ordinary policy block
+    }
+
+    // ── Integration: P3-3 — a run-gate block persists the verdict's GateProvenance ──
+
+    [Fact]
+    public async Task RunGateBlock_PersistsGateProvenance()
+    {
+        var scripted = new ScriptedChatClient().AddText("some output");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "J" });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate(post: [new ProvenanceGate()], policy: EvalGatePolicy.WarnOnly, trace: trace)
+            .Build();
+
+        await gated.RunAsync("go");
+
+        var key = trace.Metadata!.Keys.Single(k => k.Contains("ProvenanceGate", StringComparison.Ordinal));
+        var value = (IDictionary<string, object?>)trace.Metadata![key];
+        var provenance = (IDictionary<string, object?>)value["provenance"]!;
+        Assert.Equal("indirect-injection", provenance["ruleName"]);
+        Assert.Equal(0.9, provenance["threshold"]);
+        Assert.Equal(0.95, provenance["actualValue"]);
+    }
+
+    // A run gate whose Block verdict carries GateProvenance (like a CompositeJudgeGate does).
+    private sealed class ProvenanceGate : IChatGate
+    {
+        public string PolicyName => "ProvenanceGate";
+        public ValueTask<GateVerdict> InspectAsync(string text, CancellationToken cancellationToken = default)
+            => new(GateVerdict.Block(PolicyName, "flagged") with
+            {
+                Provenance = new GateProvenance("indirect-injection", ["span-a"], Threshold: 0.9, ActualValue: 0.95),
+            });
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceIndexAggregatorTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceIndexAggregatorTests.cs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text;
+using AgentEval.MAF.Gatekeeper;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using AgentEval.Testing;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>Phase 3, P3-8 — cross-run aggregation over the durable JSONL refusal index a GateReferenceLedger writes.</summary>
+public class GateReferenceIndexAggregatorTests
+{
+    private static GateReferenceLedger.GateReferenceIndexEntry Entry(string policy, string? tool, string config, string severity, DateTimeOffset ts) =>
+        new("ref-" + Guid.Empty, ts, "run-x", policy, tool is null ? "run-pre" : "tool", tool, "A", severity, config);
+
+    [Fact]
+    public void Aggregate_BreaksDownByPolicyToolConfigSeverityAndDay()
+    {
+        var d1 = new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero);
+        var d2 = new DateTimeOffset(2026, 1, 2, 10, 0, 0, TimeSpan.Zero);
+        var entries = new[]
+        {
+            Entry("ForbiddenToolGate", "delete_account", "fp-1", "Routine", d1),
+            Entry("ForbiddenToolGate", "delete_account", "fp-1", "Routine", d1),
+            Entry("TaintTrackingGate", "http_post", "fp-1", "Suspicious", d1),
+            Entry("CanaryToolGate", "canary", "fp-2", "Incident", d2),
+        };
+
+        var agg = GateReferenceIndexAggregator.Aggregate(entries);
+
+        Assert.Equal(4, agg.Total);
+        Assert.Equal(2, agg.ByPolicy["ForbiddenToolGate"]);
+        Assert.Equal(2, agg.ByTool["delete_account"]);
+        Assert.Equal(3, agg.ByConfigFingerprint["fp-1"]);
+        Assert.Equal(1, agg.ByConfigFingerprint["fp-2"]);
+        Assert.Equal(1, agg.BySeverity["Incident"]);
+        Assert.Equal(3, agg.ByDay["2026-01-01"]);
+        Assert.Equal(1, agg.ByDay["2026-01-02"]);
+    }
+
+    [Fact]
+    public void Read_ParsesJsonl_SkipsBlankAndMalformedLines()
+    {
+        var jsonl = new StringBuilder()
+            .AppendLine("""{"referenceId":"a","tsUtc":"2026-01-01T00:00:00+00:00","policy":"P","stage":"tool","severity":"Routine","toolName":"t","configFingerprint":"fp-1"}""")
+            .AppendLine("")                       // blank → skipped
+            .AppendLine("not json at all {")      // malformed → skipped, not fatal
+            .AppendLine("""{"referenceId":"b","tsUtc":"2026-01-01T00:00:00+00:00","policy":"P","stage":"tool","severity":"Routine","toolName":"t","configFingerprint":"fp-1"}""")
+            .ToString();
+
+        var entries = GateReferenceIndexAggregator.Read(new StringReader(jsonl));
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(2, GateReferenceIndexAggregator.Aggregate(entries).ByConfigFingerprint["fp-1"]);
+    }
+
+    [Fact]
+    public async Task Integration_RealRunWritesIndex_ThenAggregatesAcrossRuns()
+    {
+        // Two runs (two blocks) append to ONE durable index; aggregation reads it back offline.
+        var index = new StringBuilder();
+        var ledger = new GateReferenceLedger(new GateVerdictResolver(), new StringWriter(index));
+
+        for (var i = 0; i < 2; i++)
+        {
+            var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+            var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+            var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+            await agent.AsBuilder()
+                .UseAgentEvalGate(evidenceSink: ledger)
+                .UseAgentEvalToolGate([new ForbiddenToolGate("delete_account")], ToolGatePolicy.Terminate, trace: null, evidenceSink: ledger)
+                .Build()
+                .RunAsync("go");
+        }
+
+        var agg = GateReferenceIndexAggregator.ReadAndAggregate(new StringReader(index.ToString()));
+        Assert.Equal(2, agg.Total);
+        Assert.Equal(2, agg.ByPolicy["ForbiddenToolGate"]);
+        Assert.Equal(2, agg.ByTool["delete_account"]);
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceLedgerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceLedgerTests.cs
@@ -124,4 +124,35 @@ public class GateReferenceLedgerTests
         Assert.Equal("ForbiddenToolGate", evidence.Policy);
         Assert.False(string.IsNullOrEmpty(evidence.RunId));   // run scope stamped
     }
+
+    private sealed class NullRedactGate : IToolResultGate
+    {
+        public string PolicyName => "NullRedactGate";
+        public GateCost Cost => GateCost.PureCode;
+        public ToolGatePolicy MinimumPolicy => ToolGatePolicy.ReplaceResult;
+        public ValueTask<ToolResultVerdict> InspectAsync(GatedToolResult result, CancellationToken ct = default)
+            => new(new ToolResultVerdict(ToolResultAction.Redact, PolicyName, "no replacement supplied", RedactedResult: null));
+    }
+
+    [Fact]
+    public async Task NullRedactFallback_IsIndexedInDurableJsonl_AsARefusal()
+    {
+        // Phase 3 review #3: a null-redact fallback withholds the result and returns a model-facing refusal, so it
+        // must be persisted to the durable index (which only records refusals) — not just resolvable in memory.
+        var tool = AIFunctionFactory.Create((string x) => "the-secret", "fetch");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "fetch", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var index = new StringBuilder();
+        var ledger = new GateReferenceLedger(new GateVerdictResolver(), new StringWriter(index));
+
+        var gated = agent.AsBuilder()
+            .UseGatekeeper(GatekeeperEnforcement.ReplaceResult, g => { g.AddResultGate(new NullRedactGate()); g.EvidenceSink = ledger; })
+            .Build();
+
+        await gated.RunAsync("go");
+
+        var lines = index.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Single(lines);   // the withheld-result refusal IS in the durable index
+        Assert.Contains("NullRedactGate", lines[0]);
+    }
 }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceLedgerTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateReferenceLedgerTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>
+/// Phase 3, P3-1 — the referenceId ledger + resolver. A blocked call's opaque reference id resolves in O(1) to the
+/// full <see cref="GateEvidence"/>, WORKS WITH TRACING OFF (the resolver is fed directly, not from the trace), is
+/// bounded + TTL'd, and the JSONL index appends only enforced refusals.
+/// </summary>
+public class GateReferenceLedgerTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private sealed class TestClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+
+    private static GateEvidence Block(string referenceId) => new()
+    {
+        ReferenceId = referenceId,
+        TimestampUtc = T0,
+        Stage = "tool",
+        Policy = "ForbiddenToolGate",
+        Action = "Block",
+        ToolName = "delete_account",
+    };
+
+    [Fact]
+    public void Resolver_RecordThenResolve()
+    {
+        var resolver = new GateVerdictResolver(timeProvider: new TestClock(T0));
+        resolver.Record(Block("ref-1"));
+
+        Assert.True(resolver.TryResolve("ref-1", out var evidence));
+        Assert.Equal("ForbiddenToolGate", evidence.Policy);
+        Assert.False(resolver.TryResolve("nope", out _));
+    }
+
+    [Fact]
+    public void Resolver_ExpiredEntry_NoLongerResolves()
+    {
+        var clock = new TestClock(T0);
+        var resolver = new GateVerdictResolver(ttl: TimeSpan.FromMinutes(10), timeProvider: clock);
+        resolver.Record(Block("ref-1"));
+
+        Assert.True(resolver.TryResolve("ref-1", out _));
+        clock.Advance(TimeSpan.FromMinutes(11));
+        Assert.False(resolver.TryResolve("ref-1", out _));   // TTL expired
+    }
+
+    [Fact]
+    public void Resolver_EvictsOldest_PastCapacity()
+    {
+        var resolver = new GateVerdictResolver(maxEntries: 2, timeProvider: new TestClock(T0));
+        resolver.Record(Block("a"));
+        resolver.Record(Block("b"));
+        resolver.Record(Block("c"));   // evicts "a"
+
+        Assert.False(resolver.TryResolve("a", out _));
+        Assert.True(resolver.TryResolve("b", out _));
+        Assert.True(resolver.TryResolve("c", out _));
+        Assert.Equal(2, resolver.Count);
+    }
+
+    [Fact]
+    public void Ledger_JsonlIndex_AppendsOnlyBlocks()
+    {
+        var sb = new StringBuilder();
+        var ledger = new GateReferenceLedger(new GateVerdictResolver(timeProvider: new TestClock(T0)), new StringWriter(sb));
+
+        ledger.Record(Block("ref-block"), 1);
+        ledger.Record(new GateEvidence { ReferenceId = "ref-warn", TimestampUtc = T0, Stage = "tool", Policy = "P", Action = "Warn" }, 2);
+
+        var lines = sb.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Single(lines);   // only the Block was indexed to JSONL
+        using var doc = JsonDocument.Parse(lines[0]);
+        Assert.Equal("ref-block", doc.RootElement.GetProperty("referenceId").GetString());
+        Assert.Equal("delete_account", doc.RootElement.GetProperty("toolName").GetString());
+
+        // But BOTH are resolvable in memory (the resolver indexes every record).
+        Assert.True(ledger.Resolver.TryResolve("ref-block", out _));
+        Assert.True(ledger.Resolver.TryResolve("ref-warn", out _));
+    }
+
+    [Fact]
+    public async Task Integration_ToolBlock_ResolvesReferenceId_WithTracingOFF()
+    {
+        // The core P3-1 promise: a block's reference id resolves to the full record even when NO trace is attached.
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var index = new StringBuilder();
+        var ledger = new GateReferenceLedger(new GateVerdictResolver(), new StringWriter(index));
+
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate(evidenceSink: ledger)   // establishes the run scope; feeds the ledger
+            .UseAgentEvalToolGate([new ForbiddenToolGate("delete_account")], ToolGatePolicy.Terminate, trace: null, evidenceSink: ledger)
+            .Build();
+
+        await gated.RunAsync("go");
+
+        // The refusal was appended to the JSONL index; take its reference id and resolve the full record — with
+        // tracing entirely off (the resolver was fed directly by the sink, not reconstructed from a trace).
+        var line = index.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries).Single();
+        using var entry = JsonDocument.Parse(line);
+        var referenceId = entry.RootElement.GetProperty("referenceId").GetString()!;
+
+        Assert.True(ledger.Resolver.TryResolve(referenceId, out var evidence));
+        Assert.Equal("Block", evidence.Action);
+        Assert.Equal("delete_account", evidence.ToolName);
+        Assert.Equal("ForbiddenToolGate", evidence.Policy);
+        Assert.False(string.IsNullOrEmpty(evidence.RunId));   // run scope stamped
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateReplayRendererTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateReplayRendererTests.cs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>Phase 3, P3-9 — the fixture-capture → replayer bridge and the human-readable allow/block/mutate diff.</summary>
+public class GateReplayRendererTests
+{
+    private static GatedToolCall MakeCall(string name) =>
+        new(name, null, AgentName: "A", Iteration: 0, FunctionCallIndex: 0, FunctionCount: 1, IsStreaming: false, Messages: null);
+
+    private sealed class BlockByNameGate(string target) : IToolGate
+    {
+        public string PolicyName => $"block-{target}";
+        public GateCost Cost => GateCost.PureCode;
+        public ValueTask<ToolGateVerdict> InspectAsync(GatedToolCall call, CancellationToken ct = default)
+            => new(call.FunctionName == target ? ToolGateVerdict.Block(PolicyName, "forbidden") : ToolGateVerdict.Allow(PolicyName));
+    }
+
+    [Fact]
+    public async Task Render_ShowsPerCallDiff_DivergenceMarker_AndSummary()
+    {
+        var calls = new[] { MakeCall("read_file"), MakeCall("send_email") };
+        var comparison = await GateReplayer.CompareAsync(calls, baseline: [], candidate: [new BlockByNameGate("send_email")]);
+
+        var text = GateReplayRenderer.Render(comparison);
+
+        Assert.Contains("2 call(s), 1 diverged", text);
+        Assert.Contains("read_file: baseline=Allow  candidate=Allow", text);
+        Assert.Contains("DIVERGED", text);
+        Assert.Contains("candidate=Block(block-send_email)", text);
+    }
+
+    [Fact]
+    public void ExtractToolCalls_ReadsFunctionCallContent_InOrder()
+    {
+        var messages = new[]
+        {
+            new ChatMessage(ChatRole.Assistant, new List<AIContent>
+            {
+                new FunctionCallContent("c1", "read_file", new Dictionary<string, object?> { ["path"] = "a" }),
+                new FunctionCallContent("c2", "send_email", new Dictionary<string, object?> { ["to"] = "x" }),
+            }),
+            new ChatMessage(ChatRole.Assistant, "just text, no calls"),
+        };
+
+        var calls = GateReplayRenderer.ExtractToolCalls(messages, agentName: "A");
+
+        Assert.Equal(2, calls.Count);
+        Assert.Equal("read_file", calls[0].FunctionName);
+        Assert.Equal("send_email", calls[1].FunctionName);
+        Assert.Equal(2, calls[0].FunctionCount);
+        Assert.Equal("a", calls[0].Arguments!["path"]);
+    }
+
+    [Fact]
+    public async Task ExtractedCalls_FeedTheReplayer_EndToEnd()
+    {
+        var messages = new[]
+        {
+            new ChatMessage(ChatRole.Assistant, new List<AIContent>
+            {
+                new FunctionCallContent("c1", "send_email", new Dictionary<string, object?> { ["to"] = "x" }),
+            }),
+        };
+        var calls = GateReplayRenderer.ExtractToolCalls(messages);
+
+        var comparison = await GateReplayer.CompareAsync(calls, baseline: [], candidate: [new BlockByNameGate("send_email")]);
+        Assert.Single(comparison.Diverged);
+        Assert.Contains("send_email", GateReplayRenderer.Render(comparison));
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperObserverAndReceiptTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperObserverAndReceiptTests.cs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using AgentEval.Tracing;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Xunit;
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>Phase 3 — P3-4 (alerting observer) and P3-11 (end-of-run receipt), both riding the F-C evidence stream.</summary>
+public class GatekeeperObserverAndReceiptTests
+{
+    private sealed class RecordingObserver : IGatekeeperObserver
+    {
+        public List<GateEvidence> Findings { get; } = new();
+        public void OnFinding(GateEvidence evidence) => Findings.Add(evidence);
+    }
+
+    // ── P3-4 ──
+
+    [Fact]
+    public void Observer_NotifiedOnActionableFindings_NotOnRoutineWarn()
+    {
+        var observer = new RecordingObserver();
+        var sink = new ObserverEvidenceSink(observer);
+
+        sink.Record(new GateEvidence { ReferenceId = "1", TimestampUtc = default, Stage = "tool", Policy = "P", Action = "Block", Severity = GateSeverity.Routine }, 1);
+        sink.Record(new GateEvidence { ReferenceId = "2", TimestampUtc = default, Stage = "tool", Policy = "P", Action = "Redact", Severity = GateSeverity.Routine }, 2);
+        sink.Record(new GateEvidence { ReferenceId = "3", TimestampUtc = default, Stage = "warning", Policy = "P", Action = "Warn", Severity = GateSeverity.Incident }, 3);   // incident → notified despite Warn
+        sink.Record(new GateEvidence { ReferenceId = "4", TimestampUtc = default, Stage = "tool", Policy = "P", Action = "Warn", Severity = GateSeverity.Routine }, 4);   // routine warn → NOT notified
+
+        Assert.Equal(3, observer.Findings.Count);
+        Assert.DoesNotContain(observer.Findings, f => f.ReferenceId == "4");
+    }
+
+    [Fact]
+    public async Task Observer_FiresOnAToolBlock_ThroughUseGatekeeper()
+    {
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var observer = new RecordingObserver();
+        var trace = new AgentTrace();
+
+        var gated = agent.AsBuilder()
+            .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+            {
+                g.Add(new ForbiddenToolGate("delete_account"));
+                g.Trace = trace;
+                g.EvidenceSink = new ObserverEvidenceSink(observer);
+            })
+            .Build();
+
+        await gated.RunAsync("go");
+
+        Assert.Contains(observer.Findings, f => f.Action == "Block" && f.ToolName == "delete_account");
+    }
+
+    // ── P3-11 ──
+
+    [Fact]
+    public void RunLedger_Summarize_SnapshotsTotals()
+    {
+        var ledger = new RunLedger();
+        ledger.RecordToolCall("read");
+        ledger.RecordToolCall("read");
+        ledger.RecordToolCall("write");
+
+        var receipt = ledger.Summarize("run-1", "Agatha", "fp-x", new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Equal("run-1", receipt.RunId);
+        Assert.Equal(3, receipt.TotalToolCalls);
+        Assert.Equal(2, receipt.ToolCallCounts["read"]);
+        Assert.Equal(1, receipt.ToolCallCounts["write"]);
+    }
+
+    [Fact]
+    public async Task RunGate_EmitsReceipt_AtRunEnd()
+    {
+        var scripted = new ScriptedChatClient().AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "Agatha" });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder().UseAgentEvalGate(trace: trace).Build();
+
+        await gated.RunAsync("go");
+
+        var key = trace.Metadata!.Keys.Single(k => k.StartsWith("gate.receipt.", StringComparison.Ordinal));
+        var value = (IDictionary<string, object?>)trace.Metadata![key];
+        Assert.Equal("Receipt", value["action"]);
+        Assert.Equal("Agatha", value["agentName"]);
+        Assert.Equal(0, value["totalToolCalls"]);   // no tools called this run
+        Assert.False(string.IsNullOrEmpty((string?)value["runId"]));
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperObserverAndReceiptTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GatekeeperObserverAndReceiptTests.cs
@@ -96,4 +96,70 @@ public class GatekeeperObserverAndReceiptTests
         Assert.Equal(0, value["totalToolCalls"]);   // no tools called this run
         Assert.False(string.IsNullOrEmpty((string?)value["runId"]));
     }
+
+    [Fact]
+    public async Task RunGate_EmitsReceipt_OnStreamingRun_Too()
+    {
+        // Phase 3 review #4: a streamed run must emit the same end-of-run receipt as a non-streaming one.
+        var scripted = new ScriptedChatClient().AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "Agatha" });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder().UseAgentEvalGate(trace: trace).Build();
+
+        await foreach (var _ in gated.RunStreamingAsync("go")) { }
+
+        Assert.Contains(trace.Metadata!.Keys, k => k.StartsWith("gate.receipt.", StringComparison.Ordinal));
+    }
+
+    // ── Phase 3 review #1: a throwing evidence sink must never break enforcement ──
+
+    private sealed class ThrowingSink : IGateEvidenceSink
+    {
+        public void Record(GateEvidence evidence, int sequence) => throw new InvalidOperationException("sink boom");
+    }
+
+    [Fact]
+    public async Task ThrowingEvidenceSink_DoesNotBreakEnforcement_NorPropagate()
+    {
+        var executed = 0;
+        var tool = AIFunctionFactory.Create((string x) => { Interlocked.Increment(ref executed); return "ok"; }, "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+
+        var gated = agent.AsBuilder()
+            .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+            {
+                g.Add(new ForbiddenToolGate("delete_account"));
+                g.EvidenceSink = new ThrowingSink();   // every emission throws
+            })
+            .Build();
+
+        var ex = await Record.ExceptionAsync(() => gated.RunAsync("go"));
+
+        Assert.Null(ex);            // the throwing sink was isolated — no propagation out of the middleware
+        Assert.Equal(0, executed);  // and enforcement still held: the forbidden tool never ran (no fail-open)
+    }
+
+    [Fact]
+    public async Task ThrowingObserver_IsIsolated()
+    {
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "A", ChatOptions = new ChatOptions { Tools = [tool] } });
+
+        var gated = agent.AsBuilder()
+            .UseGatekeeper(GatekeeperEnforcement.Terminate, g =>
+            {
+                g.Add(new ForbiddenToolGate("delete_account"));
+                g.EvidenceSink = new ObserverEvidenceSink(new ThrowingObserver());
+            })
+            .Build();
+
+        Assert.Null(await Record.ExceptionAsync(() => gated.RunAsync("go")));
+    }
+
+    private sealed class ThrowingObserver : IGatekeeperObserver
+    {
+        public void OnFinding(GateEvidence evidence) => throw new InvalidOperationException("observer boom");
+    }
 }

--- a/tests/AgentEval.Tests/Trust/TrustScoreBreakdownTests.cs
+++ b/tests/AgentEval.Tests/Trust/TrustScoreBreakdownTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Trust;
+using Xunit;
+
+namespace AgentEval.Tests.Trust;
+
+/// <summary>Phase 3, P3-10 — the per-signal trust breakdown, band classification, and renderer.</summary>
+public class TrustScoreBreakdownTests
+{
+    [Theory]
+    [InlineData(95.0, TrustBand.High)]
+    [InlineData(85.0, TrustBand.High)]
+    [InlineData(70.0, TrustBand.Moderate)]
+    [InlineData(45.0, TrustBand.Low)]
+    [InlineData(10.0, TrustBand.Critical)]
+    public void ClassifyBand_MapsScoreToBand(double score, TrustBand expected)
+        => Assert.Equal(expected, TrustScoreBreakdownCalculator.ClassifyBand(score));
+
+    [Fact]
+    public void ClassifyBand_NullScore_IsUnknown()
+        => Assert.Equal(TrustBand.Unknown, TrustScoreBreakdownCalculator.ClassifyBand(null));
+
+    [Fact]
+    public void ComputeBreakdown_ContributionsSumToComposite_ExcludedMarked()
+    {
+        var signals = new[]
+        {
+            new TrustSignal("gate:a", 1.0, 1.0),
+            new TrustSignal("gate:b", 0.0, 1.0),
+            new TrustSignal("eval:c", 0.5, 1.0, Label: "skipped"),   // excluded — must not drag the score
+        };
+
+        var breakdown = TrustScoreBreakdownCalculator.ComputeBreakdown(signals);
+
+        Assert.Equal(50.0, breakdown.Result.Score);       // (1*1 + 0*1)/2 * 100
+        Assert.Equal(TrustBand.Low, breakdown.Band);
+
+        var included = breakdown.Contributions.Where(c => c.Included).ToList();
+        Assert.Equal(2, included.Count);
+        Assert.Equal(50.0, included.Sum(c => c.WeightedContribution), 3);   // included points reconstruct the composite
+
+        var skipped = breakdown.Contributions.Single(c => c.Name == "eval:c");
+        Assert.False(skipped.Included);
+        Assert.Equal("skipped", skipped.ExclusionReason);
+        Assert.Equal(0.0, skipped.WeightedContribution);
+    }
+
+    [Fact]
+    public void Render_ShowsBand_ScoreAndPerSignalLines()
+    {
+        var breakdown = TrustScoreBreakdownCalculator.ComputeBreakdown(new[]
+        {
+            new TrustSignal("gate:allow-all", 1.0, 2.0),
+            new TrustSignal("eval:c", 0.5, 1.0, Label: "error"),
+        });
+
+        var text = TrustScoreRenderer.Render(breakdown);
+
+        Assert.Contains("Trust: 100/100  [High]", text);
+        Assert.Contains("gate:allow-all", text);
+        Assert.Contains("+100.0 pts", text);
+        Assert.Contains("eval:c", text);
+        Assert.Contains("excluded: error", text);
+    }
+}


### PR DESCRIPTION
## Gatekeeper reporting to humans — Fable 5 review (Phase 3)

Phase 3 of the Fable 5 remediation plan makes the "reconstructable why / what now" story real, built on **F-C — one unified `GateEvidence` model** that replaces the divergent per-writer trace dictionaries. All non-breaking (additive).

### F-C foundation (P3-2, P3-3, P3-5, P3-6)
- **`GateEvidence`** — one canonical record `{referenceId, tsUtc, stage, policy, action, severity, runId, agentName, toolName, iteration, reason, provenance, configFingerprint, correlationId, extra}`. Every MAF Gatekeeper trace writer (tool / result / run / session) now projects it via `ToMetadata()`, a **superset that keeps the fields the existing readers parse** (`action` + the `gate.{stage}.{seq}.{policy}` key grammar) — so `GateMetadataReader` / `GlassBoxEvidence` are unaffected.
- **`IGateEvidenceSink`** (+ `TraceGateEvidenceSink`, `CompositeGateEvidenceSink`) — the DIP; sinks register instead of editing the pipeline. Wired through both seams; a sink that throws can't break enforcement.
- **P3-2** complete block evidence (agent/tool/iteration/timestamp/runId); **P3-3** persist `GateProvenance` for the first time + unify writer schemas; **P3-5** `GateSeverity` + classifier; **P3-6** `GateConfigFingerprint` (order-sensitive). New run identity on `AgentRunScope.RunId`.

### Reporting surfaces
- **P3-1** `GateVerdictResolver` (bounded/TTL) + `GateReferenceLedger` (JSONL index of refusals) — a block's opaque `referenceId` resolves in O(1) to the full record **with tracing off** (fed directly by the sink). Registered via `GatekeeperOptions.EvidenceSink`. *(CLI `agenteval trace find-reference` — a thin JSONL reader — deferred.)*
- **P3-4** `IGatekeeperObserver` + `ObserverEvidenceSink` — alerting fired only on actionable findings (Block/Mutate/Redact, or any Incident severity).
- **P3-7** cache-precedent evidence — `JudgeVerdictCache` tracks the original allow timestamp, hit/miss counters, and an `onLookup` hook.
- **P3-8** `GateReferenceIndexAggregator` — cross-run block-rate breakdown by policy / tool / config-fingerprint / severity / day over the durable JSONL index.
- **P3-9** `GateReplayRenderer` — fixture-capture → replayer bridge (`ExtractToolCalls`) + readable allow/block/mutate diff of a `GateReplayComparison`.
- **P3-10** `TrustScoreBreakdown` — trust bands + per-signal contribution breakdown (included points reconstruct the composite) + renderer.
- **P3-11** `RunReceipt` + `RunLedger.Summarize` — end-of-run summary emitted as a `gate.receipt.*` record.

### Verification
- **Full test project 8300+ pass, 2 skipped, 0 failed** (net10.0); **net8.0 builds clean** (multi-TFM).
- ~40 new tests across the phase. Adversarial phase audit run before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
