### PR TITLE
Gatekeeper Phase 5: Performance & cost (8 tasks + audit fixes)

### DIFF
--- a/src/AgentEval.Core/Guardrails/EvalGatingChatClient.cs
+++ b/src/AgentEval.Core/Guardrails/EvalGatingChatClient.cs
@@ -126,9 +126,10 @@ public sealed class EvalGatingChatClient : DelegatingChatClient
         if (_policy == EvalGatePolicy.WarnOnly && _pre.Count > 1)
         {
             // P5-6: WarnOnly pre-gates are independent — no Redact text-chaining, no ThrowOnFail short-circuit —
-            // so their (often LLM-backed) inspections overlap. Record/Observe afterward IN LIST ORDER, so
-            // evidence and correlation are byte-identical to the sequential path; only wall-clock shrinks
-            // (sum of judge latencies → slowest judge).
+            // so their (often LLM-backed) inspections overlap. Record/Observe afterward IN LIST ORDER, so on the
+            // normal (no gate throws) path evidence and correlation are byte-identical to the sequential path; only
+            // wall-clock shrinks (sum of judge latencies → slowest judge). If a gate throws, the turn faults (as an
+            // uncaught throw on the sequential path also would) before this Record/Observe loop — see the helper.
             var verdicts = await InspectConcurrentlyAsync(_pre, text, cancellationToken).ConfigureAwait(false);
             foreach (var verdict in verdicts)
             {
@@ -347,6 +348,9 @@ public sealed class EvalGatingChatClient : DelegatingChatClient
     // Used ONLY under WarnOnly, where gates neither chain redacted text nor short-circuit — so overlapping them
     // changes nothing but wall-clock. (Gates are already required to be thread-safe: this client is itself invoked
     // concurrently across in-flight requests, sharing the same gate instances.)
+    // Exception behavior: if a gate throws, Task.WhenAll faults and this rethrows BEFORE the caller records any
+    // verdict — so a faulting WarnOnly gate yields no evidence for that turn (vs. the sequential path, whose uncaught
+    // throw records verdicts up to the thrower). Either way the turn faults; only the partial-evidence trail differs.
     private static async Task<GateVerdict[]> InspectConcurrentlyAsync(
         IReadOnlyList<IChatGate> gates, string text, CancellationToken cancellationToken)
     {

--- a/src/AgentEval.Core/Guardrails/EvalGatingChatClient.cs
+++ b/src/AgentEval.Core/Guardrails/EvalGatingChatClient.cs
@@ -123,27 +123,44 @@ public sealed class EvalGatingChatClient : DelegatingChatClient
         var targetIdx = userIdx >= 0 ? userIdx : msgs.Count - 1;
         var text = targetIdx >= 0 ? msgs[targetIdx].Text ?? string.Empty : string.Empty;
 
-        foreach (var gate in _pre)
+        if (_policy == EvalGatePolicy.WarnOnly && _pre.Count > 1)
         {
-            var verdict = await gate.InspectAsync(text, cancellationToken).ConfigureAwait(false);
-            Record(verdict, "pre");
-            _correlator?.Observe(verdict, "pre");
-            if (verdict.Action == GateAction.Allow)
+            // P5-6: WarnOnly pre-gates are independent — no Redact text-chaining, no ThrowOnFail short-circuit —
+            // so their (often LLM-backed) inspections overlap. Record/Observe afterward IN LIST ORDER, so
+            // evidence and correlation are byte-identical to the sequential path; only wall-clock shrinks
+            // (sum of judge latencies → slowest judge).
+            var verdicts = await InspectConcurrentlyAsync(_pre, text, cancellationToken).ConfigureAwait(false);
+            foreach (var verdict in verdicts)
             {
-                continue;
+                Record(verdict, "pre");
+                _correlator?.Observe(verdict, "pre");
+                // WarnOnly: recorded, proceed (no throw, no redact).
             }
-
-            if (_policy == EvalGatePolicy.ThrowOnFail)
+        }
+        else
+        {
+            foreach (var gate in _pre)
             {
-                throw new EvalGateRefusalException(verdict, "pre");
-            }
+                var verdict = await gate.InspectAsync(text, cancellationToken).ConfigureAwait(false);
+                Record(verdict, "pre");
+                _correlator?.Observe(verdict, "pre");
+                if (verdict.Action == GateAction.Allow)
+                {
+                    continue;
+                }
 
-            if (_policy == EvalGatePolicy.Redact && targetIdx >= 0)
-            {
-                text = RedactRequestMessageInPlace(msgs, targetIdx, verdict);   // chain over redacted text
-            }
+                if (_policy == EvalGatePolicy.ThrowOnFail)
+                {
+                    throw new EvalGateRefusalException(verdict, "pre");
+                }
 
-            // WarnOnly: recorded, proceed.
+                if (_policy == EvalGatePolicy.Redact && targetIdx >= 0)
+                {
+                    text = RedactRequestMessageInPlace(msgs, targetIdx, verdict);   // chain over redacted text
+                }
+
+                // WarnOnly with a single gate: recorded, proceed.
+            }
         }
 
         // Fleet Correlation: folded into the SAME EvalGatePolicy enforcement path every gate above already
@@ -181,24 +198,38 @@ public sealed class EvalGatingChatClient : DelegatingChatClient
         }
 
         var text = response.Text ?? string.Empty;
-        foreach (var gate in _post)
+        if (_policy == EvalGatePolicy.WarnOnly && _post.Count > 1)
         {
-            var verdict = await gate.InspectAsync(text, cancellationToken).ConfigureAwait(false);
-            Record(verdict, "post");
-            _correlator?.Observe(verdict, "post");
-            if (verdict.Action == GateAction.Allow)
+            // P5-6: WarnOnly post-gates are independent (see ApplyPreAsync's matching note) — overlap them,
+            // then Record/Observe in list order for byte-identical evidence.
+            var verdicts = await InspectConcurrentlyAsync(_post, text, cancellationToken).ConfigureAwait(false);
+            foreach (var verdict in verdicts)
             {
-                continue;
+                Record(verdict, "post");
+                _correlator?.Observe(verdict, "post");
             }
-
-            if (_policy == EvalGatePolicy.ThrowOnFail)
+        }
+        else
+        {
+            foreach (var gate in _post)
             {
-                throw new EvalGateRefusalException(verdict, "post");
-            }
+                var verdict = await gate.InspectAsync(text, cancellationToken).ConfigureAwait(false);
+                Record(verdict, "post");
+                _correlator?.Observe(verdict, "post");
+                if (verdict.Action == GateAction.Allow)
+                {
+                    continue;
+                }
 
-            if (_policy == EvalGatePolicy.Redact)
-            {
-                text = RedactResponseInPlace(response, verdict);
+                if (_policy == EvalGatePolicy.ThrowOnFail)
+                {
+                    throw new EvalGateRefusalException(verdict, "post");
+                }
+
+                if (_policy == EvalGatePolicy.Redact)
+                {
+                    text = RedactResponseInPlace(response, verdict);
+                }
             }
         }
 
@@ -308,6 +339,24 @@ public sealed class EvalGatingChatClient : DelegatingChatClient
             ["confidence"] = verdict.Confidence,
             ["correlationId"] = ToolCorrelationScope.Current,
         });
+    }
+
+    // P5-6: run an independent (WarnOnly) gate panel's inspections concurrently. Each InspectAsync is started
+    // before any is awaited, so the (typically LLM-bound) calls overlap; Task.WhenAll preserves input order, so
+    // the returned verdicts align 1:1 with the gate list and the caller can Record/Observe them deterministically.
+    // Used ONLY under WarnOnly, where gates neither chain redacted text nor short-circuit — so overlapping them
+    // changes nothing but wall-clock. (Gates are already required to be thread-safe: this client is itself invoked
+    // concurrently across in-flight requests, sharing the same gate instances.)
+    private static async Task<GateVerdict[]> InspectConcurrentlyAsync(
+        IReadOnlyList<IChatGate> gates, string text, CancellationToken cancellationToken)
+    {
+        var tasks = new Task<GateVerdict>[gates.Count];
+        for (var i = 0; i < gates.Count; i++)
+        {
+            tasks[i] = gates[i].InspectAsync(text, cancellationToken).AsTask();
+        }
+
+        return await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
     private static int LastIndexOfRole(IList<ChatMessage> messages, ChatRole role)

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -55,6 +55,11 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
             throw new ArgumentOutOfRangeException(nameof(options), "JudgeGateOptions.BlockThreshold must be in [0, 1].");
         }
 
+        if (_options.MaxInputChars < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "JudgeGateOptions.MaxInputChars must be non-negative (0 = unbounded).");
+        }
+
         PolicyName = $"judge:{rubric.Axis}";
     }
 
@@ -115,10 +120,35 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
         };
     }
 
+    // P5-3: bound the text the model sees to a head + tail sandwich when it exceeds MaxInputChars, so a
+    // pathologically large turn can't blow up cost/latency/context — while an injection payload at EITHER
+    // boundary is still visible. The prefilter has already run on the full text; only the prompt is bounded.
+    private string BoundInput(string text)
+    {
+        var max = _options.MaxInputChars;
+        if (max <= 0 || text.Length <= max)
+        {
+            return text;   // unbounded, or already within the cap
+        }
+
+        var half = max / 2;
+        var droppedCount = text.Length - (half * 2);
+        return string.Concat(
+            text.AsSpan(0, half),
+            $"\n…[judge input truncated: {droppedCount} chars omitted]…\n",
+            text.AsSpan(text.Length - half));
+    }
+
     // P5-2: a deliberately cheap, dependency-free token estimate for the spend reservation — input chars/4 (the
     // usual rough chars-per-token ratio) plus the output-token cap. It only needs to bound spend, not be exact;
-    // the reservation is a ceiling, so over-estimating is the safe direction.
-    private long EstimateTokens(string text) => ((long)text.Length / 4) + _options.MaxOutputTokens;
+    // the reservation is a ceiling, so over-estimating is the safe direction. The input length is capped at
+    // MaxInputChars (P5-3) because that is all the model actually sees — otherwise a huge benign turn would
+    // over-reserve on chars that BoundInput will drop, and could falsely exhaust the wallet.
+    private long EstimateTokens(string text)
+    {
+        var chars = _options.MaxInputChars > 0 ? Math.Min(text.Length, _options.MaxInputChars) : text.Length;
+        return ((long)chars / 4) + _options.MaxOutputTokens;
+    }
 
     private bool SafePrefilter(string text)
     {
@@ -139,7 +169,7 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
         try
         {
             cts.CancelAfter(_options.Timeout);   // inside the try so a bad value degrades to Inconclusive, never escapes
-            var messages = new List<ChatMessage> { new(ChatRole.User, _rubric.BuildPrompt(text)) };
+            var messages = new List<ChatMessage> { new(ChatRole.User, _rubric.BuildPrompt(BoundInput(text))) };
             var options = new ChatOptions { MaxOutputTokens = _options.MaxOutputTokens, Temperature = 0f };
             var response = await _fastModel.GetResponseAsync(messages, options, cts.Token).ConfigureAwait(false);
             return _rubric.Parse(response.Text ?? string.Empty) ?? JudgeVerdict.Inconclusive($"{_rubric.Axis} rubric returned null");

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -66,8 +66,20 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
             return GateVerdict.Allow(PolicyName);   // cheap short-circuit — most turns never reach the model
         }
 
-        var verdict = await JudgeAsync(text, cancellationToken).ConfigureAwait(false);
         var ruleName = $"judge:{_rubric.Axis}";
+
+        // P5-2: reserve against the shared token+call wallet BEFORE the model call. On exhaustion, skip the model
+        // and degrade to a recorded "unjudged — budget exhausted" verdict (fail-open advisory by default).
+        if (_options.SpendGovernor is { } governor && !governor.TryReserve(EstimateTokens(text)))
+        {
+            var exhaustedReason = $"{_rubric.Axis} judge unjudged — spend budget exhausted";
+            var exhaustedProvenance = new GateProvenance($"{ruleName}:budget-exhausted", Array.Empty<string>());
+            return _options.FailClosedOnBudgetExhausted
+                ? GateVerdict.Block(PolicyName, $"{exhaustedReason} (fail-closed)") with { Provenance = exhaustedProvenance }
+                : GateVerdict.Allow(PolicyName) with { Provenance = exhaustedProvenance };
+        }
+
+        var verdict = await JudgeAsync(text, cancellationToken).ConfigureAwait(false);
         var evidence = verdict.Spans ?? Array.Empty<string>();
 
         return verdict.Decision switch
@@ -102,6 +114,11 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
             },
         };
     }
+
+    // P5-2: a deliberately cheap, dependency-free token estimate for the spend reservation — input chars/4 (the
+    // usual rough chars-per-token ratio) plus the output-token cap. It only needs to bound spend, not be exact;
+    // the reservation is a ceiling, so over-estimating is the safe direction.
+    private long EstimateTokens(string text) => ((long)text.Length / 4) + _options.MaxOutputTokens;
 
     private bool SafePrefilter(string text)
     {

--- a/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/CompositeJudgeGate.cs
@@ -22,6 +22,10 @@ namespace AgentEval.Guardrails.Judges;
 public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibration
     where TRubric : IJudgeRubric
 {
+    // Floor for a bounded (non-zero) MaxInputChars — below this the head+tail sandwich carries too little signal to
+    // judge with. 256 chars ≈ 64 tokens of head + 64 of tail.
+    private const int MinBoundedInputChars = 256;
+
     private readonly TRubric _rubric;
     private readonly IChatClient _fastModel;
     private readonly JudgeGateOptions _options;
@@ -55,9 +59,12 @@ public sealed class CompositeJudgeGate<TRubric> : IChatGate, IRequiresCalibratio
             throw new ArgumentOutOfRangeException(nameof(options), "JudgeGateOptions.BlockThreshold must be in [0, 1].");
         }
 
-        if (_options.MaxInputChars < 0)
+        // 0 = unbounded; otherwise a floor so a fat-fingered tiny cap can't collapse the head+tail sandwich to just
+        // the truncation marker and blind the judge (audit LOW).
+        if (_options.MaxInputChars < 0 || (_options.MaxInputChars > 0 && _options.MaxInputChars < MinBoundedInputChars))
         {
-            throw new ArgumentOutOfRangeException(nameof(options), "JudgeGateOptions.MaxInputChars must be non-negative (0 = unbounded).");
+            throw new ArgumentOutOfRangeException(nameof(options),
+                $"JudgeGateOptions.MaxInputChars must be 0 (unbounded) or at least {MinBoundedInputChars}.");
         }
 
         PolicyName = $"judge:{rubric.Axis}";

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
@@ -25,6 +25,15 @@ public sealed class JudgeGateOptions
     public int MaxOutputTokens { get; init; } = 256;
 
     /// <summary>
+    /// Cap on the number of input characters the judge sends to the model (Phase 5, P5-3 — bounds cost, latency,
+    /// and context-overflow risk on a pathologically large turn). Over the cap, the text is reduced to a
+    /// head + tail sandwich with a truncation marker so an injection payload at <i>either</i> boundary is still
+    /// seen. The <see cref="IJudgeRubric.Prefilter"/> always runs on the FULL text — only the model prompt is
+    /// bounded. Default 16000 (≈4k tokens). <c>0</c> means unbounded (the pre-P5-3 behavior).
+    /// </summary>
+    public int MaxInputChars { get; init; } = 16_000;
+
+    /// <summary>
     /// When the judge is <see cref="JudgeDecision.Inconclusive"/> (timeout / model error / unparseable reply),
     /// whether to block (fail-closed) or allow (fail-open, observe-only). Default <c>true</c> (fail-closed) — a
     /// gate that cannot prove a turn safe should not pass it under a blocking policy. Enforcement is still gated

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
@@ -31,4 +31,22 @@ public sealed class JudgeGateOptions
     /// by the run gate's <see cref="EvalGatePolicy"/> (a block only stops the run under a blocking policy).
     /// </summary>
     public bool FailClosedOnInconclusive { get; init; } = true;
+
+    /// <summary>
+    /// Optional shared token + call budget across judges (Phase 5, P5-2 — a denial-of-wallet / runaway-cost bound).
+    /// When set, the gate reserves against it before calling the model; if the budget for the current window is
+    /// exhausted the model call is SKIPPED and the turn degrades per <see cref="FailClosedOnBudgetExhausted"/>.
+    /// Share one instance across every <see cref="CompositeJudgeGate{TRubric}"/> that draws on the same wallet.
+    /// Default <c>null</c> (no budget cap — the pre-P5-2 behavior).
+    /// </summary>
+    public JudgeSpendGovernor? SpendGovernor { get; init; }
+
+    /// <summary>
+    /// When <see cref="SpendGovernor"/> refuses a reservation (budget exhausted), whether the un-run judge blocks
+    /// (fail-closed) or allows (fail-open, recorded as "unjudged — budget exhausted"). Default <c>false</c>
+    /// (fail-open): a spent <i>cost</i> budget must not turn into a full traffic outage — exhaustion is a resource
+    /// limit, not a detection failure, so the judge degrades to advisory rather than blocking everything. Set
+    /// <c>true</c> only where an unjudged turn is unacceptable and a judge outage blocking all traffic is preferred.
+    /// </summary>
+    public bool FailClosedOnBudgetExhausted { get; init; }
 }

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeGateOptions.cs
@@ -29,7 +29,9 @@ public sealed class JudgeGateOptions
     /// and context-overflow risk on a pathologically large turn). Over the cap, the text is reduced to a
     /// head + tail sandwich with a truncation marker so an injection payload at <i>either</i> boundary is still
     /// seen. The <see cref="IJudgeRubric.Prefilter"/> always runs on the FULL text — only the model prompt is
-    /// bounded. Default 16000 (≈4k tokens). <c>0</c> means unbounded (the pre-P5-3 behavior).
+    /// bounded. Default 16000 (≈4k tokens). <c>0</c> means unbounded (the pre-P5-3 behavior); any other value must
+    /// be at least 256 (a floor, so a fat-fingered tiny cap can't collapse the head+tail sandwich and blind the
+    /// judge) — the gate constructor throws otherwise.
     /// </summary>
     public int MaxInputChars { get; init; } = 16_000;
 
@@ -56,6 +58,11 @@ public sealed class JudgeGateOptions
     /// (fail-open): a spent <i>cost</i> budget must not turn into a full traffic outage — exhaustion is a resource
     /// limit, not a detection failure, so the judge degrades to advisory rather than blocking everything. Set
     /// <c>true</c> only where an unjudged turn is unacceptable and a judge outage blocking all traffic is preferred.
+    /// <para><b>Attack note:</b> with the default (fail-open) and a <i>shared</i> <see cref="SpendGovernor"/>, an
+    /// adversary who first floods the window's budget with junk turns can then push a payload turn past this judge
+    /// un-inspected. This judge is one layer — deterministic gates still run — but if the semantic judge is
+    /// load-bearing for your threat model, either give it an isolated (not shared) governor, size the budget above
+    /// plausible adversarial volume, or set this <c>true</c> and accept the self-DoS tradeoff.</para>
     /// </summary>
     public bool FailClosedOnBudgetExhausted { get; init; }
 }

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeSpendGovernor.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeSpendGovernor.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails.Judges;
+
+/// <summary>
+/// A shared token + call budget across inline LLM judges (Phase 5, P5-2) — a denial-of-wallet / runaway-cost
+/// bound that a single <see cref="CompositeJudgeGate{TRubric}"/> can't enforce alone. Judges call
+/// <see cref="TryReserve"/> before hitting the model; when the budget for the current window is exhausted the
+/// reservation is refused and the judge degrades to a recorded "unjudged — budget exhausted" verdict (fail-open or
+/// fail-closed per <see cref="JudgeGateOptions.FailClosedOnBudgetExhausted"/>). The budget refills each window.
+/// Thread-safe; a <see cref="TimeProvider"/> makes the window testable.
+/// </summary>
+public sealed class JudgeSpendGovernor
+{
+    private readonly int _maxCalls;
+    private readonly long _maxTokens;
+    private readonly TimeSpan _window;
+    private readonly TimeProvider _timeProvider;
+    private readonly object _lock = new();
+    private DateTimeOffset _windowStart;
+    private int _calls;
+    private long _tokens;
+
+    /// <summary>Creates the governor.</summary>
+    /// <param name="maxCalls">Max judge model calls per window.</param>
+    /// <param name="maxTokens">Max estimated tokens per window.</param>
+    /// <param name="window">The refill window (default 1 minute).</param>
+    /// <param name="timeProvider">Clock (testability); defaults to <see cref="TimeProvider.System"/>.</param>
+    public JudgeSpendGovernor(int maxCalls, long maxTokens, TimeSpan? window = null, TimeProvider? timeProvider = null)
+    {
+        if (maxCalls < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCalls), "must be at least 1.");
+        }
+
+        if (maxTokens < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxTokens), "must be at least 1.");
+        }
+
+        _maxCalls = maxCalls;
+        _maxTokens = maxTokens;
+        _window = window ?? TimeSpan.FromMinutes(1);
+        if (_window <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(window), "must be positive.");
+        }
+
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _windowStart = _timeProvider.GetUtcNow();
+    }
+
+    /// <summary>
+    /// Atomically tries to reserve one call plus <paramref name="estimatedTokens"/> against the current window.
+    /// Returns true (and records the spend) if it fits; false if either the call or token budget is exhausted.
+    /// The window auto-refills once <see cref="_window"/> has elapsed.
+    /// </summary>
+    public bool TryReserve(long estimatedTokens)
+    {
+        if (estimatedTokens < 0)
+        {
+            estimatedTokens = 0;   // defensive: a negative estimate must never manufacture headroom
+        }
+
+        lock (_lock)
+        {
+            var now = _timeProvider.GetUtcNow();
+            if (now - _windowStart >= _window)
+            {
+                _windowStart = now;   // refill
+                _calls = 0;
+                _tokens = 0;
+            }
+
+            if (_calls >= _maxCalls || _tokens + estimatedTokens > _maxTokens)
+            {
+                return false;
+            }
+
+            _calls++;
+            _tokens += estimatedTokens;
+            return true;
+        }
+    }
+}

--- a/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
+++ b/src/AgentEval.Core/Guardrails/Judges/JudgeVerdictCache.cs
@@ -2,7 +2,6 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -15,20 +14,30 @@ namespace AgentEval.Guardrails.Judges;
 /// <para><b>Only <see cref="GateAction.Allow"/> verdicts are cached.</b> A block is re-evaluated every time — so a
 /// transient fail-closed block (a judge timeout / model error) can never be cached into a permanent block, and a
 /// real detection is always re-confirmed.</para>
-/// <para><b>Tradeoffs (by design).</b> There is no TTL: an allow is memoized for the process lifetime, so if the
-/// judge is nondeterministic a first-time allow sticks and a later-improved judge won't re-block that exact
-/// content — clear/rebuild the cache on a judge change. The bound is a <i>soft</i> cap (check-then-add), so under
-/// heavy concurrency it may overshoot slightly. Both are acceptable for a same-content dedup cache.</para>
+/// <para><b>Bounded LRU + TTL (Phase 5, P5-4).</b> The cache holds at most <c>maxEntries</c> allows, evicting the
+/// LEAST-RECENTLY-USED when full (a full cache still admits hot new content — evicting only forces a cheap
+/// re-judge, never a wrong verdict). An optional <c>ttl</c> expires a memoized allow after a fixed lifetime so a
+/// later-improved judge is not shadowed forever by an old allow; with no TTL an allow is memoized for the process
+/// lifetime. An optional <c>invalidationKey</c> (a hash of the judge / prompt / model) is folded into the cache key
+/// so a config change never serves a stale precedent. The bound is a <i>hard</i> cap under a lock, so it cannot
+/// overshoot.</para>
 /// </summary>
 public sealed class JudgeVerdictCache : IChatGate
 {
     private readonly IChatGate _inner;
     private readonly int _maxEntries;
+    private readonly TimeSpan? _ttl;
+    private readonly string _invalidationKey;
     private readonly TimeProvider _timeProvider;
     private readonly Action<JudgeCacheEvent>? _onLookup;
-    private readonly ConcurrentDictionary<string, (GateVerdict Verdict, DateTimeOffset FirstSeenUtc)> _allowed = new(StringComparer.Ordinal);
+
+    private readonly object _lock = new();
+    private readonly Dictionary<string, LinkedListNode<Entry>> _map = new(StringComparer.Ordinal);
+    private readonly LinkedList<Entry> _lru = new();   // First = most-recently-used, Last = least-recently-used
     private long _hits;
     private long _misses;
+
+    private sealed record Entry(string Key, GateVerdict Verdict, DateTimeOffset FirstSeenUtc);
 
     /// <inheritdoc/>
     public string PolicyName => _inner.PolicyName;
@@ -39,13 +48,26 @@ public sealed class JudgeVerdictCache : IChatGate
     /// <summary>Lookups that missed and re-litigated the inner judge (P3-7).</summary>
     public long Misses => Interlocked.Read(ref _misses);
 
+    /// <summary>Entries currently cached.</summary>
+    public int Count
+    {
+        get { lock (_lock) { return _map.Count; } }
+    }
+
     /// <summary>Wraps <paramref name="inner"/> with an allow-verdict cache.</summary>
     /// <param name="inner">The judge whose Allow verdicts are memoized.</param>
-    /// <param name="maxEntries">Soft cap on cached entries (default 4096).</param>
-    /// <param name="onLookup">Optional cache-precedent hook (P3-7) invoked on every lookup — a caller wires it to
-    /// emit <c>gate.cache.*</c> evidence (AllowCached, the original timestamp, hit/miss).</param>
-    /// <param name="timeProvider">Clock stamped onto a first-seen allow (testability); defaults to <see cref="TimeProvider.System"/>.</param>
-    public JudgeVerdictCache(IChatGate inner, int maxEntries = 4096, Action<JudgeCacheEvent>? onLookup = null, TimeProvider? timeProvider = null)
+    /// <param name="maxEntries">Hard cap on cached entries; the least-recently-used is evicted past this (default 4096).</param>
+    /// <param name="onLookup">Optional cache-precedent hook (P3-7) invoked on every lookup — a caller wires it to emit <c>gate.cache.*</c> evidence.</param>
+    /// <param name="timeProvider">Clock (testability); defaults to <see cref="TimeProvider.System"/>.</param>
+    /// <param name="ttl">Optional lifetime for a memoized allow (P5-4); null keeps it for the process lifetime.</param>
+    /// <param name="invalidationKey">Optional judge/prompt/model version folded into the cache key (P5-4) so a config change never serves a stale precedent.</param>
+    public JudgeVerdictCache(
+        IChatGate inner,
+        int maxEntries = 4096,
+        Action<JudgeCacheEvent>? onLookup = null,
+        TimeProvider? timeProvider = null,
+        TimeSpan? ttl = null,
+        string? invalidationKey = null)
     {
         ArgumentNullException.ThrowIfNull(inner);
         if (maxEntries < 1)
@@ -53,10 +75,17 @@ public sealed class JudgeVerdictCache : IChatGate
             throw new ArgumentOutOfRangeException(nameof(maxEntries), "must be at least 1.");
         }
 
+        if (ttl is { } t && t <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ttl), "must be positive when set.");
+        }
+
         _inner = inner;
         _maxEntries = maxEntries;
         _onLookup = onLookup;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _ttl = ttl;
+        _invalidationKey = invalidationKey ?? string.Empty;
     }
 
     /// <inheritdoc/>
@@ -64,24 +93,73 @@ public sealed class JudgeVerdictCache : IChatGate
     {
         var safe = text ?? string.Empty;
         var key = HashOf(safe);
-        if (_allowed.TryGetValue(key, out var cached))
+
+        if (TryGetCached(key, out var cachedVerdict, out var firstSeen))
         {
             Interlocked.Increment(ref _hits);
-            NotifyLookup(new JudgeCacheEvent(PolicyName, Hit: true, cached.FirstSeenUtc));   // precedent: served the original allow
-            return cached.Verdict;
+            NotifyLookup(new JudgeCacheEvent(PolicyName, Hit: true, firstSeen));   // precedent: served the original allow
+            return cachedVerdict;
         }
 
         Interlocked.Increment(ref _misses);
         var verdict = await _inner.InspectAsync(safe, cancellationToken).ConfigureAwait(false);
 
-        // Cache only Allow (see class remarks). Stop admitting once full — never evict a proven-safe entry.
-        if (verdict.Action == GateAction.Allow && _allowed.Count < _maxEntries)
+        // Cache only Allow (see class remarks).
+        if (verdict.Action == GateAction.Allow)
         {
-            _allowed.TryAdd(key, (verdict, _timeProvider.GetUtcNow()));
+            Admit(key, verdict);
         }
 
         NotifyLookup(new JudgeCacheEvent(PolicyName, Hit: false, OriginalTimestampUtc: null));
         return verdict;
+    }
+
+    private bool TryGetCached(string key, out GateVerdict verdict, out DateTimeOffset firstSeenUtc)
+    {
+        lock (_lock)
+        {
+            if (_map.TryGetValue(key, out var node))
+            {
+                if (_ttl is { } ttl && _timeProvider.GetUtcNow() - node.Value.FirstSeenUtc >= ttl)
+                {
+                    _lru.Remove(node);   // expired — drop it (a later-improved judge gets to re-judge)
+                    _map.Remove(key);
+                }
+                else
+                {
+                    _lru.Remove(node);   // touch: promote to most-recently-used
+                    _lru.AddFirst(node);
+                    verdict = node.Value.Verdict;
+                    firstSeenUtc = node.Value.FirstSeenUtc;
+                    return true;
+                }
+            }
+
+            verdict = null!;
+            firstSeenUtc = default;
+            return false;
+        }
+    }
+
+    private void Admit(string key, GateVerdict verdict)
+    {
+        lock (_lock)
+        {
+            if (_map.ContainsKey(key))
+            {
+                return;   // already cached (a concurrent miss admitted it first) — leave its recency/first-seen intact
+            }
+
+            var node = _lru.AddFirst(new Entry(key, verdict, _timeProvider.GetUtcNow()));
+            _map[key] = node;
+
+            while (_map.Count > _maxEntries)
+            {
+                var lru = _lru.Last!;   // least-recently-used
+                _lru.RemoveLast();
+                _map.Remove(lru.Value.Key);
+            }
+        }
     }
 
     // The precedent hook is pure observability — a throw from it must never propagate out of InspectAsync, where
@@ -103,9 +181,10 @@ public sealed class JudgeVerdictCache : IChatGate
         }
     }
 
-    private static string HashOf(string text)
+    private string HashOf(string text)
     {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text));
+        // Fold the invalidation key in so a judge/prompt/model change never collides with a stale precedent (P5-4).
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(_invalidationKey + "\n" + text));
         return Convert.ToHexString(bytes);
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -363,20 +363,19 @@ public static class AgentEvalToolGateExtensions
 
             // P0-3: the tool has now ACTUALLY executed — result gates only ever decide what the model gets to
             // see of a result that already happened, never whether the call itself was allowed.
+            // P5-5: ONE shared view whose ResultText is serialized lazily and reused across result gates while the
+            // result is unchanged (serialize once, not once per gate); re-created only when a Redact rewrites the
+            // result (a genuinely new value to serialize).
+            GatedToolResult MakeResultView() => new(
+                context.Function.Name, context.Arguments as IReadOnlyDictionary<string, object?>, toolResult,
+                agent.Name, context.Iteration, context.FunctionCallIndex, context.FunctionCount, context.IsStreaming,
+                context.Messages as IReadOnlyList<ChatMessage>);
+            var resultView = MakeResultView();
+
             foreach (var resultGate in frozenResultGates)
             {
                 ToolResultVerdict resultVerdict;
                 var resultStopwatch = telemetry is null ? null : Stopwatch.StartNew();
-                var resultView = new GatedToolResult(
-                    FunctionName: context.Function.Name,
-                    Arguments: context.Arguments as IReadOnlyDictionary<string, object?>,
-                    Result: toolResult,
-                    AgentName: agent.Name,
-                    Iteration: context.Iteration,
-                    FunctionCallIndex: context.FunctionCallIndex,
-                    FunctionCount: context.FunctionCount,
-                    IsStreaming: context.IsStreaming,
-                    Messages: context.Messages as IReadOnlyList<ChatMessage>);
 
                 try
                 {
@@ -446,6 +445,7 @@ public static class AgentEvalToolGateExtensions
                             RecordResultRedact(trace, Interlocked.Increment(ref gateSeq), resultVerdict, applied: true, evidence);
                         }
 
+                        resultView = MakeResultView();   // P5-5: the result changed — the next gate needs a fresh view + serialization
                         continue;
 
                     case ToolResultAction.Block:

--- a/src/AgentEval.MAF/Gatekeeper/Coverage/GateCostWatchdog.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Coverage/GateCostWatchdog.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>One gate whose measured hot-path latency persistently exceeds the ceiling for its declared <see cref="GateCost"/> class (Phase 5, P5-8).</summary>
+/// <param name="PolicyName">The offending gate's policy name.</param>
+/// <param name="DeclaredCost">The <see cref="GateCost"/> class it declared.</param>
+/// <param name="MeasuredAverage">Its measured mean per-invocation latency (from <see cref="GateTelemetry"/>).</param>
+/// <param name="Ceiling">The ceiling for its declared class.</param>
+/// <param name="Invocations">How many invocations the measurement is over.</param>
+public sealed record GateCostViolation(
+    string PolicyName,
+    GateCost DeclaredCost,
+    TimeSpan MeasuredAverage,
+    TimeSpan Ceiling,
+    long Invocations);
+
+/// <summary>
+/// Compares each gate's measured latency (from <see cref="GateTelemetry"/>) to the ceiling for its declared
+/// <see cref="GateCost"/> class (Phase 5, P5-8) — a gate that declares <see cref="GateCost.PureCode"/> but
+/// persistently runs like a network call is a mis-declared cost contract that silently adds latency to the
+/// tool-invocation hot path. Offline / periodic (it reads accumulated telemetry, never the hot path itself), so a
+/// caller runs it after enough traffic and emits a <c>gate.warning.*.CostContractViolation</c> for each finding.
+/// </summary>
+public static class GateCostWatchdog
+{
+    /// <summary>The mean-latency ceiling for a cost class. Network/Llm have none (they never run inline).</summary>
+    public static TimeSpan CeilingFor(GateCost cost) => cost switch
+    {
+        GateCost.PureCode => TimeSpan.FromMilliseconds(10),
+        GateCost.Bounded => TimeSpan.FromMilliseconds(500),   // above the 300ms ReDoS-timeout ceiling, with headroom
+        _ => TimeSpan.MaxValue,   // Network / Llm are rejected inline anyway — no inline latency contract to check
+    };
+
+    /// <summary>
+    /// Returns the gates whose mean latency exceeds their class ceiling, considering only gates with at least
+    /// <paramref name="minInvocations"/> samples (so a single slow cold-start can't trip the "persistent" check).
+    /// </summary>
+    public static IReadOnlyList<GateCostViolation> CheckViolations(
+        IEnumerable<IToolGate> gates, GateTelemetry telemetry, int minInvocations = 20)
+    {
+        ArgumentNullException.ThrowIfNull(gates);
+        ArgumentNullException.ThrowIfNull(telemetry);
+        if (minInvocations < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minInvocations), "must be at least 1.");
+        }
+
+        var snapshots = telemetry.Snapshot().ToDictionary(s => s.PolicyName, StringComparer.Ordinal);
+        var violations = new List<GateCostViolation>();
+
+        foreach (var gate in gates)
+        {
+            if (!snapshots.TryGetValue(gate.PolicyName, out var snapshot) || snapshot.InvocationCount < minInvocations)
+            {
+                continue;   // not enough samples to call it a persistent violation
+            }
+
+            var ceiling = CeilingFor(gate.Cost);
+            if (snapshot.AverageElapsed > ceiling)
+            {
+                violations.Add(new GateCostViolation(gate.PolicyName, gate.Cost, snapshot.AverageElapsed, ceiling, snapshot.InvocationCount));
+            }
+        }
+
+        return violations;
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/GatedToolResult.cs
+++ b/src/AgentEval.MAF/Gatekeeper/GatedToolResult.cs
@@ -32,4 +32,15 @@ public sealed record GatedToolResult(
     int FunctionCallIndex,
     int FunctionCount,
     bool IsStreaming,
-    IReadOnlyList<ChatMessage>? Messages);
+    IReadOnlyList<ChatMessage>? Messages)
+{
+    private string? _resultText;
+
+    /// <summary>
+    /// The <see cref="Result"/> serialized to text ONCE and cached (Phase 5, P5-5). Result gates read THIS instead
+    /// of each calling <c>GateText.Stringify(Result)</c> — the tool-gate loop reuses one <see cref="GatedToolResult"/>
+    /// across gates while the result is unchanged, so a large result is serialized once, not once per gate. (The
+    /// cache field is excluded from record equality, which is over the ctor members only.)
+    /// </summary>
+    public string ResultText => _resultText ??= GateText.Stringify(Result);
+}

--- a/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
@@ -46,6 +47,25 @@ public sealed class TaintTrackingGate : IToolGate
     private readonly int _minTaintLength;
     private readonly bool _canonicalize;
 
+    // P5-1: per-run incremental taint state, keyed by the run scope. Weak keys, so a run's ledger is collected with
+    // its scope (no manual cleanup / leak). Owned by THIS gate instance, so two differently-configured taint gates in
+    // one run never cross-contaminate. Populated only when a run scope is in effect; otherwise the stateless
+    // CollectTaintedTokens fallback runs (see InspectAsync).
+    private readonly ConditionalWeakTable<AgentRunScope, RunTaintState> _perRun = new();
+
+    // The accumulating taint ledger for one run: the tainted-token set, the source CallIds seen, a monotonic cursor
+    // into the run's history (how many messages have been folded in), the nearest-preceding-call name for the
+    // CallId-less fallback, and a sticky cap flag. All access is under Lock.
+    private sealed class RunTaintState
+    {
+        public readonly object Lock = new();
+        public readonly HashSet<string> Tainted = new(StringComparer.Ordinal);
+        public readonly HashSet<string> SourceCallIds = new(StringComparer.Ordinal);
+        public int ProcessedCount;
+        public string? LastCallName;
+        public bool CapHit;
+    }
+
     /// <inheritdoc/>
     public string PolicyName => "TaintTrackingGate";
 
@@ -89,38 +109,93 @@ public sealed class TaintTrackingGate : IToolGate
     {
         ArgumentNullException.ThrowIfNull(call);
 
-        // Only sink tools with arguments can leak — everything else is an immediate allow (skip the taint scan).
-        if (!_sinks.Contains(call.FunctionName) || call.Arguments is null || call.Arguments.Count == 0)
-        {
-            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
-        }
+        // Only sink tools WITH arguments can leak; everything else is an immediate allow — but under a run scope we
+        // still fold this call's history first (below), so taint from an earlier non-sink call is visible to a later sink.
+        var isSink = _sinks.Contains(call.FunctionName) && call.Arguments is { Count: > 0 };
+        var scope = AgentRunScope.Current;
 
         HashSet<string> tainted;
-        try
+        if (scope is not null)
         {
-            tainted = CollectTaintedTokens(call.Messages);
+            // P5-1 fast path: fold only this call's newly-appeared history into the run ledger ONCE (incremental),
+            // then scan against the accumulated token set — O(total history) across the run, not O(n²).
+            var state = _perRun.GetValue(scope, static _ => new RunTaintState());
+            lock (state.Lock)
+            {
+                try
+                {
+                    IngestIncremental(state, call.Messages);
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    return TimedOut(call.FunctionName);   // fail closed WITHIN the policy (WarnOnly still only warns)
+                }
+
+                if (!isSink)
+                {
+                    return Allow();   // history folded; a non-sink (or arg-less) call has nothing to scan
+                }
+
+                if (state.CapHit)
+                {
+                    return CapExceeded(call.FunctionName);
+                }
+
+                if (state.Tainted.Count == 0)
+                {
+                    return Allow();
+                }
+
+                tainted = new HashSet<string>(state.Tainted, StringComparer.Ordinal);   // snapshot; scan outside the lock
+            }
         }
-        catch (RegexMatchTimeoutException)
+        else
         {
-            // A pathological history can time out the bounded token scan. Fail closed WITHIN the policy (a WarnOnly
-            // registration still only warns) rather than let the exception become an unconditional block upstream.
-            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(PolicyName,
-                $"taint scan timed out for sink '{call.FunctionName}' — cannot verify, failing closed"));
+            // No run scope ⇒ no stable per-run key (the shared fallback key would bleed taint across runs). Fall back
+            // to the original stateless per-call computation: identical behavior to pre-P5-1, at the pre-P5-1 cost.
+            if (!isSink)
+            {
+                return Allow();
+            }
+
+            try
+            {
+                tainted = CollectTaintedTokens(call.Messages);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return TimedOut(call.FunctionName);
+            }
+
+            if (tainted.Count >= MaxTaintedTokens)
+            {
+                return CapExceeded(call.FunctionName);
+            }
+
+            if (tainted.Count == 0)
+            {
+                return Allow();
+            }
         }
 
-        if (tainted.Count >= MaxTaintedTokens)
-        {
-            // A source flooded the taint set past the cost bound — fail closed within the policy (WarnOnly warns).
-            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(PolicyName,
-                $"too many tainted tokens to scan for sink '{call.FunctionName}' — cannot verify, failing closed"));
-        }
+        return ScanArguments(call, tainted);
+    }
 
-        if (tainted.Count == 0)
-        {
-            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
-        }
+    private ValueTask<ToolGateVerdict> Allow()
+        => new(ToolGateVerdict.Allow(PolicyName));
 
-        foreach (var kv in call.Arguments)
+    // A pathological history can time out the bounded token scan. Fail closed within the policy rather than let the
+    // exception become an unconditional block upstream.
+    private ValueTask<ToolGateVerdict> TimedOut(string sink)
+        => new(ToolGateVerdict.Block(PolicyName, $"taint scan timed out for sink '{sink}' — cannot verify, failing closed"));
+
+    // A source flooded the taint set past the cost bound — fail closed within the policy.
+    private ValueTask<ToolGateVerdict> CapExceeded(string sink)
+        => new(ToolGateVerdict.Block(PolicyName, $"too many tainted tokens to scan for sink '{sink}' — cannot verify, failing closed"));
+
+    private ValueTask<ToolGateVerdict> ScanArguments(GatedToolCall call, HashSet<string> tainted)
+    {
+        foreach (var kv in call.Arguments!)   // non-null: only reached on the isSink path (Arguments has ≥1 entry)
         {
             var argText = GateText.Stringify(kv.Value);
             if (argText.Length == 0)
@@ -150,6 +225,65 @@ public sealed class TaintTrackingGate : IToolGate
         }
 
         return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
+    }
+
+    // P5-1: fold the messages the run has produced since the last call into the ledger, in a single forward pass (a
+    // source CALL always precedes its RESULT, so one pass suffices where the stateless path used two). Tokens and
+    // source CallIds only accumulate. If the history shrank (a reducer rewrote the prefix), the cursor is stale, so
+    // reprocess from the top — re-adds are idempotent and previously-tainted tokens are retained.
+    private void IngestIncremental(RunTaintState state, IReadOnlyList<ChatMessage>? messages)
+    {
+        if (messages is null || state.CapHit)
+        {
+            return;
+        }
+
+        var start = state.ProcessedCount;
+        if (messages.Count < start)
+        {
+            start = 0;
+            state.LastCallName = null;   // prefix changed — rebuild the nearest-preceding-call name from scratch
+        }
+
+        for (var i = start; i < messages.Count; i++)
+        {
+            foreach (var content in messages[i].Contents)
+            {
+                switch (content)
+                {
+                    case FunctionCallContent fcCall:
+                        state.LastCallName = fcCall.Name;
+                        if (!string.IsNullOrEmpty(fcCall.CallId) && _sources.Contains(fcCall.Name))
+                        {
+                            state.SourceCallIds.Add(fcCall.CallId);
+                        }
+
+                        break;
+
+                    case FunctionResultContent fr when IsSourceResult(fr, state.SourceCallIds, state.LastCallName):
+                        foreach (var text in TaintTexts(fr.Result))
+                        {
+                            foreach (Match match in Token.Matches(text))
+                            {
+                                if (match.Value.Length >= _minTaintLength)
+                                {
+                                    state.Tainted.Add(match.Value);
+                                    if (state.Tainted.Count >= MaxTaintedTokens)
+                                    {
+                                        state.CapHit = true;      // saturated — the caller fails closed
+                                        state.ProcessedCount = messages.Count;
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        state.ProcessedCount = messages.Count;
     }
 
     private HashSet<string> CollectTaintedTokens(IReadOnlyList<ChatMessage>? messages)

--- a/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
@@ -53,16 +53,17 @@ public sealed class TaintTrackingGate : IToolGate
     // CollectTaintedTokens fallback runs (see InspectAsync).
     private readonly ConditionalWeakTable<AgentRunScope, RunTaintState> _perRun = new();
 
-    // The accumulating taint ledger for one run: the tainted-token set, the source CallIds seen, a monotonic cursor
-    // into the run's history (how many messages have been folded in), the nearest-preceding-call name for the
-    // CallId-less fallback, and a sticky cap flag. All access is under Lock.
+    // The accumulating taint ledger for one run: the tainted-token set, every source CallId seen so far, and the
+    // CallIds of source results already tokenized (so re-walking the current history each call does not re-tokenize
+    // an already-seen result — the expensive part). A sticky cap flag. All access is under Lock. Deliberately has NO
+    // positional cursor: a positional cursor is unsafe against a sliding-window / keep-last-N history reducer, which
+    // keeps the message count constant while rotating a NEW source result into an already-passed index (audit HIGH).
     private sealed class RunTaintState
     {
         public readonly object Lock = new();
         public readonly HashSet<string> Tainted = new(StringComparer.Ordinal);
         public readonly HashSet<string> SourceCallIds = new(StringComparer.Ordinal);
-        public int ProcessedCount;
-        public string? LastCallName;
+        public readonly HashSet<string> TokenizedResultCallIds = new(StringComparer.Ordinal);
         public bool CapHit;
     }
 
@@ -124,7 +125,7 @@ public sealed class TaintTrackingGate : IToolGate
             {
                 try
                 {
-                    IngestIncremental(state, call.Messages);
+                    FoldHistory(state, call.Messages);
                 }
                 catch (RegexMatchTimeoutException)
                 {
@@ -227,40 +228,56 @@ public sealed class TaintTrackingGate : IToolGate
         return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
     }
 
-    // P5-1: fold the messages the run has produced since the last call into the ledger, in a single forward pass (a
-    // source CALL always precedes its RESULT, so one pass suffices where the stateless path used two). Tokens and
-    // source CallIds only accumulate. If the history shrank (a reducer rewrote the prefix), the cursor is stale, so
-    // reprocess from the top — re-adds are idempotent and previously-tainted tokens are retained.
-    private void IngestIncremental(RunTaintState state, IReadOnlyList<ChatMessage>? messages)
+    // P5-1: fold the run's CURRENT history into the ledger. The message walk is redone each call (so a sliding-window
+    // reducer that rotates a new source result into an already-passed index can never hide it — the audit-HIGH
+    // fail-open a positional cursor had), but the EXPENSIVE work — tokenizing each source result (regex + JSON parse)
+    // — is done at most ONCE per result via the TokenizedResultCallIds dedup. That is what kills the quadratic cost:
+    // the old code re-tokenized every result on every sink call; here each result is tokenized once across the run.
+    // Two passes (like the stateless original): collect ALL source CallIds first, then taint — so a result that
+    // appears before its own source call (a reordering reducer) is still attributed (audit-MEDIUM). The ledger only
+    // accumulates, so a result later rotated OUT of the window keeps the taint it already contributed.
+    private void FoldHistory(RunTaintState state, IReadOnlyList<ChatMessage>? messages)
     {
         if (messages is null || state.CapHit)
         {
             return;
         }
 
-        var start = state.ProcessedCount;
-        if (messages.Count < start)
+        // Pass 1: every source CALL's id in the current history (accumulates across calls; conservative under reuse).
+        foreach (var message in messages)
         {
-            start = 0;
-            state.LastCallName = null;   // prefix changed — rebuild the nearest-preceding-call name from scratch
+            foreach (var content in message.Contents)
+            {
+                if (content is FunctionCallContent fc && !string.IsNullOrEmpty(fc.CallId) && _sources.Contains(fc.Name))
+                {
+                    state.SourceCallIds.Add(fc.CallId);
+                }
+            }
         }
 
-        for (var i = start; i < messages.Count; i++)
+        // Pass 2: taint each source RESULT once. lastCallName drives the CallId-less fallback (§16), recomputed each
+        // walk since we no longer carry a positional cursor.
+        string? lastCallName = null;
+        foreach (var message in messages)
         {
-            foreach (var content in messages[i].Contents)
+            foreach (var content in message.Contents)
             {
                 switch (content)
                 {
                     case FunctionCallContent fcCall:
-                        state.LastCallName = fcCall.Name;
-                        if (!string.IsNullOrEmpty(fcCall.CallId) && _sources.Contains(fcCall.Name))
-                        {
-                            state.SourceCallIds.Add(fcCall.CallId);
-                        }
-
+                        lastCallName = fcCall.Name;
                         break;
 
-                    case FunctionResultContent fr when IsSourceResult(fr, state.SourceCallIds, state.LastCallName):
+                    case FunctionResultContent fr when IsSourceResult(fr, state.SourceCallIds, lastCallName):
+                        // Dedup on the CallId (cheap, stable across reducer re-clones): a source result already
+                        // tokenized this run is skipped, so re-walking never re-tokenizes it. A CallId-less result
+                        // (the §16 reducer-stripped case) has no stable id, so it is re-tokenized each call — rare,
+                        // and its tokens dedup in the Tainted set anyway.
+                        if (!string.IsNullOrEmpty(fr.CallId) && !state.TokenizedResultCallIds.Add(fr.CallId))
+                        {
+                            break;   // already tokenized this exact result — skip the expensive re-tokenization
+                        }
+
                         foreach (var text in TaintTexts(fr.Result))
                         {
                             foreach (Match match in Token.Matches(text))
@@ -270,8 +287,7 @@ public sealed class TaintTrackingGate : IToolGate
                                     state.Tainted.Add(match.Value);
                                     if (state.Tainted.Count >= MaxTaintedTokens)
                                     {
-                                        state.CapHit = true;      // saturated — the caller fails closed
-                                        state.ProcessedCount = messages.Count;
+                                        state.CapHit = true;   // saturated — the caller fails closed
                                         return;
                                     }
                                 }
@@ -282,8 +298,6 @@ public sealed class TaintTrackingGate : IToolGate
                 }
             }
         }
-
-        state.ProcessedCount = messages.Count;
     }
 
     private HashSet<string> CollectTaintedTokens(IReadOnlyList<ChatMessage>? messages)

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultInjectionGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultInjectionGate.cs
@@ -39,7 +39,7 @@ public sealed class ToolResultInjectionGate : IToolResultGate
     public ValueTask<ToolResultVerdict> InspectAsync(GatedToolResult result, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(result);
-        var text = GateText.Stringify(result.Result);
+        var text = result.ResultText;
         if (string.IsNullOrEmpty(text))
         {
             return new ValueTask<ToolResultVerdict>(ToolResultVerdict.Allow(PolicyName));

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
@@ -81,7 +81,7 @@ public sealed class ToolResultSecretGate : IToolResultGate
     public ValueTask<ToolResultVerdict> InspectAsync(GatedToolResult result, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(result);
-        var text = GateText.Stringify(result.Result);
+        var text = result.ResultText;
         if (string.IsNullOrEmpty(text))
         {
             return new ValueTask<ToolResultVerdict>(ToolResultVerdict.Allow(PolicyName));

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeAnomalyGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeAnomalyGate.cs
@@ -74,7 +74,7 @@ public sealed class ToolResultSizeAnomalyGate : IToolResultGate
     public ValueTask<ToolResultVerdict> InspectAsync(GatedToolResult result, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(result);
-        var text = GateText.Stringify(result.Result);
+        var text = result.ResultText;
         var size = text.Length;
 
         // Atomically reads the baseline as it stood BEFORE this call AND records this call's size into that

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSizeGate.cs
@@ -44,7 +44,7 @@ public sealed class ToolResultSizeGate : IToolResultGate
     public ValueTask<ToolResultVerdict> InspectAsync(GatedToolResult result, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(result);
-        var text = GateText.Stringify(result.Result);
+        var text = result.ResultText;
         if (text.Length <= _maxLength)
         {
             return new ValueTask<ToolResultVerdict>(ToolResultVerdict.Allow(PolicyName));

--- a/src/AgentEval.MAF/Gatekeeper/Shadow/ShadowJudgePump.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Shadow/ShadowJudgePump.cs
@@ -35,6 +35,14 @@ public sealed class ShadowJudgePump : IAsyncDisposable
     private readonly TimeSpan _drainTimeout;
     private volatile bool _completed;   // writer completed (drained/disposed) — distinguishes "full" from "closed"
     private bool _disposed;
+    private long _accepted;   // P5-7: visible backpressure counters
+    private long _dropped;
+
+    /// <summary>Runs accepted into the shadow queue so far (P5-7).</summary>
+    public long AcceptedCount => Interlocked.Read(ref _accepted);
+
+    /// <summary>Runs DROPPED because the bounded queue was full (or the pump was completed) — a visible backpressure signal (P5-7). The single-consumer ordering guarantee is unchanged; this only counts what a full queue already discarded.</summary>
+    public long DroppedCount => Interlocked.Read(ref _dropped);
 
     /// <summary>Creates the pump and starts its background consumer.</summary>
     /// <param name="judge">The (possibly expensive) judge to run off the hot path.</param>
@@ -71,15 +79,20 @@ public sealed class ShadowJudgePump : IAsyncDisposable
     public void Enqueue(ShadowJudgeContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        if (!_channel.Writer.TryWrite(context))
+        if (_channel.Writer.TryWrite(context))
         {
-            // Distinguish a legitimately-full queue from a race with completion/dispose, so the reported cause
-            // (and the operator's remedy) is accurate.
-            SafeReport(_completed
-                ? new InvalidOperationException("Shadow-judge pump is completed/disposed — dropped a run's verdict.")
-                : new InvalidOperationException(
-                    "Shadow-judge queue is full — dropped a run's verdict. Increase queueCapacity or speed up the judge."));
+            Interlocked.Increment(ref _accepted);
+            return;
         }
+
+        Interlocked.Increment(ref _dropped);   // P5-7: count the drop before reporting it
+
+        // Distinguish a legitimately-full queue from a race with completion/dispose, so the reported cause
+        // (and the operator's remedy) is accurate.
+        SafeReport(_completed
+            ? new InvalidOperationException("Shadow-judge pump is completed/disposed — dropped a run's verdict.")
+            : new InvalidOperationException(
+                "Shadow-judge queue is full — dropped a run's verdict. Increase queueCapacity or speed up the judge."));
     }
 
     /// <summary>Completes the queue and awaits the consumer draining all pending items (deterministic for tests).</summary>

--- a/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
@@ -322,7 +322,7 @@ public class CompositeJudgeGateTests
         var rubric = new CapturingRubric();
         var text = "HEADSTART " + new string('x', 5000) + " TAILEND";
         var gate = new CompositeJudgeGate<CapturingRubric>(rubric, new ScriptedChatClient().AddText("ALLOW"),
-            new JudgeGateOptions { MaxInputChars = 200 });
+            new JudgeGateOptions { MaxInputChars = 400 });
 
         await gate.InspectAsync(text);
 
@@ -335,8 +335,8 @@ public class CompositeJudgeGateTests
         Assert.EndsWith("TAILEND", rubric.PromptSaw);
         Assert.Contains("truncated", rubric.PromptSaw, StringComparison.Ordinal);
         Assert.True(rubric.PromptSaw!.Length < text.Length);
-        // Head + tail ≈ MaxInputChars (200) plus the short marker — nowhere near the 5000-char original.
-        Assert.True(rubric.PromptSaw.Length < 300);
+        // Head + tail ≈ MaxInputChars (400) plus the short marker — nowhere near the 5000-char original.
+        Assert.True(rubric.PromptSaw.Length < 600);
     }
 
     [Fact]
@@ -352,9 +352,12 @@ public class CompositeJudgeGateTests
         Assert.Equal(text, rubric.PromptSaw);   // 0 = unbounded ⇒ full text through
     }
 
-    [Fact]
-    public void NegativeMaxInputChars_Throws()
-        => Assert.Throws<ArgumentOutOfRangeException>(() => Gate(new ScriptedChatClient(), new JudgeGateOptions { MaxInputChars = -1 }));
+    [Theory]
+    [InlineData(-1)]     // negative
+    [InlineData(1)]      // positive but below the floor — would collapse the head+tail sandwich (audit LOW)
+    [InlineData(255)]    // just under the 256 floor
+    public void InvalidMaxInputChars_Throws(int maxInputChars)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Gate(new ScriptedChatClient(), new JudgeGateOptions { MaxInputChars = maxInputChars }));
 
     // A fast model that respects cancellation but otherwise never returns in time (for the timeout path).
     private sealed class DelayingChatClient : IChatClient

--- a/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
@@ -229,6 +229,66 @@ public class CompositeJudgeGateTests
     public void NullModel_Throws()
         => Assert.Throws<ArgumentNullException>(() => new CompositeJudgeGate<KeywordRubric>(new KeywordRubric(), null!));
 
+    // ── P5-2: shared spend governor ──
+
+    [Fact]
+    public async Task SpendGovernor_BudgetExhausted_FailOpen_Allows_AndSkipsModel()
+    {
+        // maxTokens=1 is smaller than any real estimate (chars/4 + 256 output cap), so the first reservation is
+        // already refused — the model must be skipped and the turn allowed (fail-open default), with provenance.
+        var model = new ScriptedChatClient().AddText("BLOCK");   // would block IF called
+        var gov = new JudgeSpendGovernor(maxCalls: 100, maxTokens: 1);
+        var v = await Gate(model, new JudgeGateOptions { SpendGovernor = gov }).InspectAsync("please scan this");
+
+        Assert.Equal(GateAction.Allow, v.Action);
+        Assert.Empty(model.ReceivedMessages);   // proves the model was never called — spend was refused
+        Assert.NotNull(v.Provenance);
+        Assert.Contains("budget-exhausted", v.Provenance!.RuleName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SpendGovernor_BudgetExhausted_FailClosed_Blocks_AndSkipsModel()
+    {
+        var model = new ScriptedChatClient().AddText("ALLOW");   // would allow IF called
+        var gov = new JudgeSpendGovernor(maxCalls: 100, maxTokens: 1);
+        var opts = new JudgeGateOptions { SpendGovernor = gov, FailClosedOnBudgetExhausted = true };
+
+        var v = await Gate(model, opts).InspectAsync("please scan this");
+
+        Assert.Equal(GateAction.Block, v.Action);
+        Assert.Contains("budget", v.Reason!, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(model.ReceivedMessages);   // fail-closed still skips the (unaffordable) model call
+    }
+
+    [Fact]
+    public async Task SpendGovernor_WithinBudget_JudgeRunsNormally()
+    {
+        var model = new ScriptedChatClient().AddText("BLOCK");
+        var gov = new JudgeSpendGovernor(maxCalls: 100, maxTokens: 1_000_000);
+
+        var v = await Gate(model, new JudgeGateOptions { SpendGovernor = gov }).InspectAsync("please scan this");
+
+        Assert.Equal(GateAction.Block, v.Action);      // budget ok ⇒ the judge actually ran
+        Assert.NotEmpty(model.ReceivedMessages);
+    }
+
+    [Fact]
+    public async Task SpendGovernor_PrefilterSkip_DoesNotConsumeBudget()
+    {
+        // A turn that never reaches the model (prefilter false) must not spend the wallet — otherwise benign
+        // traffic would starve the budget before any judge-worthy turn arrives.
+        var gov = new JudgeSpendGovernor(maxCalls: 1, maxTokens: 1_000_000);
+        var opts = new JudgeGateOptions { SpendGovernor = gov };
+
+        _ = await Gate(new ScriptedChatClient().AddText("BLOCK"), opts).InspectAsync("nothing interesting");   // no "scan"
+
+        // The single call in the budget is still available — a real (scanned) turn now runs the model.
+        var model = new ScriptedChatClient().AddText("BLOCK");
+        var v = await Gate(model, opts).InspectAsync("please scan this");
+        Assert.Equal(GateAction.Block, v.Action);
+        Assert.NotEmpty(model.ReceivedMessages);
+    }
+
     // A fast model that respects cancellation but otherwise never returns in time (for the timeout path).
     private sealed class DelayingChatClient : IChatClient
     {

--- a/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/CompositeJudgeGateTests.cs
@@ -43,6 +43,18 @@ public class CompositeJudgeGateTests
         public JudgeVerdict Parse(string reply) => reply.Contains("BLOCK") ? JudgeVerdict.Blocked("x", null, 0.9) : JudgeVerdict.Allowed();
     }
 
+    // Captures exactly what text Prefilter and BuildPrompt each receive — used to prove P5-3 bounds only the
+    // model prompt, never the prefilter.
+    private sealed class CapturingRubric : IJudgeRubric
+    {
+        public string? PrefilterSaw { get; private set; }
+        public string? PromptSaw { get; private set; }
+        public string Axis => "capture-axis";
+        public bool Prefilter(string text) { PrefilterSaw = text; return true; }
+        public string BuildPrompt(string text) { PromptSaw = text; return text; }
+        public JudgeVerdict Parse(string reply) => JudgeVerdict.Allowed();
+    }
+
     private static CompositeJudgeGate<KeywordRubric> Gate(IChatClient model, JudgeGateOptions? opts = null)
         => new(new KeywordRubric(), model, opts);
 
@@ -288,6 +300,61 @@ public class CompositeJudgeGateTests
         Assert.Equal(GateAction.Block, v.Action);
         Assert.NotEmpty(model.ReceivedMessages);
     }
+
+    // ── P5-3: bound judge input ──
+
+    [Fact]
+    public async Task InputBound_UnderCap_PassesFullTextToModel()
+    {
+        var rubric = new CapturingRubric();
+        var text = "please scan this " + new string('x', 100);
+        var gate = new CompositeJudgeGate<CapturingRubric>(rubric, new ScriptedChatClient().AddText("ALLOW"),
+            new JudgeGateOptions { MaxInputChars = 16_000 });
+
+        await gate.InspectAsync(text);
+
+        Assert.Equal(text, rubric.PromptSaw);   // well under the cap ⇒ untouched
+    }
+
+    [Fact]
+    public async Task InputBound_OverCap_TruncatesToHeadTailSandwich_ButPrefilterSeesFullText()
+    {
+        var rubric = new CapturingRubric();
+        var text = "HEADSTART " + new string('x', 5000) + " TAILEND";
+        var gate = new CompositeJudgeGate<CapturingRubric>(rubric, new ScriptedChatClient().AddText("ALLOW"),
+            new JudgeGateOptions { MaxInputChars = 200 });
+
+        await gate.InspectAsync(text);
+
+        // Prefilter saw the FULL text (it decides whether to invoke the judge at all).
+        Assert.Equal(text, rubric.PrefilterSaw);
+
+        // The MODEL saw a bounded head+tail sandwich: both boundaries survive, the middle is dropped + marked.
+        Assert.NotNull(rubric.PromptSaw);
+        Assert.StartsWith("HEADSTART", rubric.PromptSaw);
+        Assert.EndsWith("TAILEND", rubric.PromptSaw);
+        Assert.Contains("truncated", rubric.PromptSaw, StringComparison.Ordinal);
+        Assert.True(rubric.PromptSaw!.Length < text.Length);
+        // Head + tail ≈ MaxInputChars (200) plus the short marker — nowhere near the 5000-char original.
+        Assert.True(rubric.PromptSaw.Length < 300);
+    }
+
+    [Fact]
+    public async Task InputBound_Zero_MeansUnbounded()
+    {
+        var rubric = new CapturingRubric();
+        var text = "please scan this " + new string('y', 5000);
+        var gate = new CompositeJudgeGate<CapturingRubric>(rubric, new ScriptedChatClient().AddText("ALLOW"),
+            new JudgeGateOptions { MaxInputChars = 0 });
+
+        await gate.InspectAsync(text);
+
+        Assert.Equal(text, rubric.PromptSaw);   // 0 = unbounded ⇒ full text through
+    }
+
+    [Fact]
+    public void NegativeMaxInputChars_Throws()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Gate(new ScriptedChatClient(), new JudgeGateOptions { MaxInputChars = -1 }));
 
     // A fast model that respects cancellation but otherwise never returns in time (for the timeout path).
     private sealed class DelayingChatClient : IChatClient

--- a/tests/AgentEval.Tests/Guardrails/EvalGatingChatClientTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/EvalGatingChatClientTests.cs
@@ -391,6 +391,137 @@ public class EvalGatingChatClientTests
                 : MetricResult.Fail(Name, _explanation ?? "failed"));
     }
 
+    // ── P5-6: concurrent WarnOnly gate panel ──
+
+    [Fact]
+    public async Task WarnOnly_MultiPreGatePanel_RunsConcurrently()
+    {
+        // Three WarnOnly pre-gates each hold for a moment; if the panel overlaps them, at least two are inside
+        // InspectAsync at once. Sequential execution would only ever see one.
+        var tracker = new ConcurrencyTracker();
+        var scripted = new ScriptedChatClient().AddText("ok");
+        var gates = new IChatGate[]
+        {
+            new ConcurrencyProbeGate(tracker, "probe-a"),
+            new ConcurrencyProbeGate(tracker, "probe-b"),
+            new ConcurrencyProbeGate(tracker, "probe-c"),
+        };
+        var client = scripted.AsBuilder().UseEvalGate(pre: gates, policy: EvalGatePolicy.WarnOnly).Build();
+
+        await client.GetResponseAsync(UserSays("hi"));
+
+        Assert.True(tracker.MaxConcurrent >= 2, $"expected overlap, saw max {tracker.MaxConcurrent}");
+    }
+
+    [Fact]
+    public async Task ThrowOnFail_MultiPreGatePanel_StaysSequential()
+    {
+        // Contrast: ThrowOnFail short-circuits in list order, so its gates must NOT overlap (the sequential path).
+        // All probes Allow, so nothing throws — the point is only that they ran one at a time.
+        var tracker = new ConcurrencyTracker();
+        var scripted = new ScriptedChatClient().AddText("ok");
+        var gates = new IChatGate[]
+        {
+            new ConcurrencyProbeGate(tracker, "probe-a"),
+            new ConcurrencyProbeGate(tracker, "probe-b"),
+            new ConcurrencyProbeGate(tracker, "probe-c"),
+        };
+        var client = scripted.AsBuilder().UseEvalGate(pre: gates, policy: EvalGatePolicy.ThrowOnFail).Build();
+
+        await client.GetResponseAsync(UserSays("hi"));
+
+        Assert.Equal(1, tracker.MaxConcurrent);   // strictly one gate at a time
+    }
+
+    [Fact]
+    public async Task WarnOnly_ConcurrentPanel_RecordsEveryVerdict_IncludingABlock()
+    {
+        // Concurrency must not lose evidence: every gate's verdict is still recorded (in list order), and a
+        // WarnOnly Block is still observe-only — the run proceeds.
+        var trace = new AgentTrace();
+        var scripted = new ScriptedChatClient().AddText("proceeds anyway");
+        var gates = new IChatGate[]
+        {
+            new AllowNamedGate("gate-1"),
+            new AlwaysBlockGate(),          // blocks, but WarnOnly ⇒ recorded, not enforced
+            new AllowNamedGate("gate-3"),
+        };
+        var client = scripted.AsBuilder().UseEvalGate(pre: gates, policy: EvalGatePolicy.WarnOnly, trace: trace).Build();
+
+        var response = await client.GetResponseAsync(UserSays("hi"));
+
+        Assert.Equal("proceeds anyway", response.Text);   // WarnOnly never blocks
+        Assert.Equal(3, trace.Metadata!.Keys.Count(k => k.StartsWith("gate.pre.", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task WarnOnly_MultiPostGatePanel_RunsConcurrently()
+    {
+        var tracker = new ConcurrencyTracker();
+        var scripted = new ScriptedChatClient().AddText("some response text");
+        var gates = new IChatGate[]
+        {
+            new ConcurrencyProbeGate(tracker, "post-a"),
+            new ConcurrencyProbeGate(tracker, "post-b"),
+        };
+        var client = scripted.AsBuilder().UseEvalGate(post: gates, policy: EvalGatePolicy.WarnOnly).Build();
+
+        await client.GetResponseAsync(UserSays("hi"));
+
+        Assert.True(tracker.MaxConcurrent >= 2, $"expected overlap, saw max {tracker.MaxConcurrent}");
+    }
+
+    /// <summary>Tracks the peak number of gates concurrently inside <see cref="ConcurrencyProbeGate.InspectAsync"/>.</summary>
+    private sealed class ConcurrencyTracker
+    {
+        private int _current;
+        private int _max;
+        public int MaxConcurrent => Volatile.Read(ref _max);
+
+        public void Enter()
+        {
+            var now = Interlocked.Increment(ref _current);
+            int seen;
+            while (now > (seen = Volatile.Read(ref _max)))
+            {
+                Interlocked.CompareExchange(ref _max, now, seen);
+            }
+        }
+
+        public void Exit() => Interlocked.Decrement(ref _current);
+    }
+
+    /// <summary>Allows, but holds inside InspectAsync long enough for a concurrent panel to overlap.</summary>
+    private sealed class ConcurrencyProbeGate : IChatGate
+    {
+        private readonly ConcurrencyTracker _tracker;
+        public ConcurrencyProbeGate(ConcurrencyTracker tracker, string name) { _tracker = tracker; PolicyName = name; }
+        public string PolicyName { get; }
+
+        public async ValueTask<GateVerdict> InspectAsync(string text, CancellationToken cancellationToken = default)
+        {
+            _tracker.Enter();
+            try
+            {
+                await Task.Delay(60, cancellationToken).ConfigureAwait(false);
+                return GateVerdict.Allow(PolicyName);
+            }
+            finally
+            {
+                _tracker.Exit();
+            }
+        }
+    }
+
+    /// <summary>Allows under a caller-chosen policy name (so several distinct verdicts can be recorded).</summary>
+    private sealed class AllowNamedGate : IChatGate
+    {
+        public AllowNamedGate(string name) => PolicyName = name;
+        public string PolicyName { get; }
+        public ValueTask<GateVerdict> InspectAsync(string text, CancellationToken cancellationToken = default)
+            => new(GateVerdict.Allow(PolicyName));
+    }
+
     // ── Fleet Correlation Layer — wiring through EvalGatingChatClient/UseEvalGate (P1) ──
 
     [Fact]

--- a/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/JudgeCompositionTests.cs
@@ -166,6 +166,60 @@ public class JudgeCompositionTests
     }
 
     [Fact]
+    public async Task Cache_TtlExpiry_ReJudgesAfterLifetime()
+    {
+        // P5-4: a memoized allow expires after the TTL, so a later-improved judge gets to re-evaluate.
+        var clock = new FakeClock(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var inner = new StubGate(GateVerdict.Allow("j"));
+        var cache = new JudgeVerdictCache(inner, timeProvider: clock, ttl: TimeSpan.FromMinutes(10));
+
+        await cache.InspectAsync("x");   // miss → cached
+        await cache.InspectAsync("x");   // hit
+        Assert.Equal(1, inner.Calls);
+
+        clock.Advance(TimeSpan.FromMinutes(11));
+        await cache.InspectAsync("x");   // expired → re-judged
+        Assert.Equal(2, inner.Calls);
+    }
+
+    [Fact]
+    public async Task Cache_Lru_EvictsLeastRecentlyUsed_WhenFull()
+    {
+        // P5-4: a full cache evicts the LRU entry (not "stop admitting"). Touching "a" spares it; "b" is evicted.
+        var inner = new StubGate(GateVerdict.Allow("j"));
+        var cache = new JudgeVerdictCache(inner, maxEntries: 2);
+
+        await cache.InspectAsync("a");   // cache a       (inner calls: 1)
+        await cache.InspectAsync("b");   // cache b, full (2)
+        await cache.InspectAsync("a");   // hit → a is now MRU, b is LRU
+        await cache.InspectAsync("c");   // cache c → evicts LRU (b) (3)
+        Assert.Equal(2, cache.Count);
+
+        var calls = inner.Calls;
+        await cache.InspectAsync("a");   // still cached → hit
+        Assert.Equal(calls, inner.Calls);
+        await cache.InspectAsync("b");   // was evicted → miss (re-judged)
+        Assert.Equal(calls + 1, inner.Calls);
+    }
+
+    [Fact]
+    public async Task Cache_InvalidationKey_IsFoldedIntoTheCacheKey()
+    {
+        // P5-4: the same text under different invalidation keys hashes differently, so a judge/prompt/model change
+        // never serves a stale precedent. (Each cache still memoizes correctly under its own key.)
+        var innerV1 = new StubGate(GateVerdict.Allow("j"));
+        var innerV2 = new StubGate(GateVerdict.Allow("j"));
+        var v1 = new JudgeVerdictCache(innerV1, invalidationKey: "judge@v1");
+        var v2 = new JudgeVerdictCache(innerV2, invalidationKey: "judge@v2");
+
+        await v1.InspectAsync("same"); await v1.InspectAsync("same");   // v1: miss then hit
+        await v2.InspectAsync("same");                                   // v2: independent miss
+
+        Assert.Equal(1, innerV1.Calls);   // v1 memoized under its own key
+        Assert.Equal(1, innerV2.Calls);   // v2 did not see v1's precedent
+    }
+
+    [Fact]
     public async Task Cache_ThrowingOnLookup_DoesNotTurnAllowIntoBlock()
     {
         // Phase 3 review #2: the precedent hook is pure observability — a throw must not propagate out of

--- a/tests/AgentEval.Tests/Guardrails/JudgeSpendGovernorTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/JudgeSpendGovernorTests.cs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails.Judges;
+using Xunit;
+
+namespace AgentEval.Tests.Guardrails;
+
+/// <summary>P5-2: the shared token+call wallet judges reserve against — window refill, both caps, thread-safety.</summary>
+public class JudgeSpendGovernorTests
+{
+    // A hand-driven clock so the window is deterministic (no wall-clock flake, no Task.Delay).
+    private sealed class FakeClock : TimeProvider
+    {
+        public DateTimeOffset Now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => Now;
+    }
+
+    [Fact]
+    public void CallCap_ExhaustsAfterMaxCalls()
+    {
+        var gov = new JudgeSpendGovernor(maxCalls: 2, maxTokens: 1_000_000);
+        Assert.True(gov.TryReserve(1));
+        Assert.True(gov.TryReserve(1));
+        Assert.False(gov.TryReserve(1));   // third call over the 2-call cap
+    }
+
+    [Fact]
+    public void TokenCap_RefusesReservationThatWouldOverrun_ButNotOne_ThatExactlyFits()
+    {
+        var gov = new JudgeSpendGovernor(maxCalls: 1_000, maxTokens: 10);
+        Assert.True(gov.TryReserve(6));    // 6 ≤ 10
+        Assert.False(gov.TryReserve(6));   // 6 + 6 = 12 > 10 ⇒ refused, and does NOT consume
+        Assert.True(gov.TryReserve(4));    // 6 + 4 = 10, exactly at the cap ⇒ allowed
+        Assert.False(gov.TryReserve(1));   // now at 10 ⇒ nothing more fits
+    }
+
+    [Fact]
+    public void Window_Refills_AfterElapsed()
+    {
+        var clock = new FakeClock();
+        var gov = new JudgeSpendGovernor(maxCalls: 1, maxTokens: 1_000_000, window: TimeSpan.FromMinutes(1), timeProvider: clock);
+
+        Assert.True(gov.TryReserve(1));
+        Assert.False(gov.TryReserve(1));   // call cap hit within the window
+
+        clock.Now = clock.Now.AddSeconds(61);   // window elapsed
+        Assert.True(gov.TryReserve(1));    // refilled
+    }
+
+    [Fact]
+    public void Window_DoesNotRefill_BeforeElapsed()
+    {
+        var clock = new FakeClock();
+        var gov = new JudgeSpendGovernor(maxCalls: 1, maxTokens: 1_000_000, window: TimeSpan.FromMinutes(1), timeProvider: clock);
+
+        Assert.True(gov.TryReserve(1));
+        clock.Now = clock.Now.AddSeconds(59);   // still inside the window
+        Assert.False(gov.TryReserve(1));
+    }
+
+    [Fact]
+    public void NegativeEstimate_ClampedToZero_NeitherCreditsNorOverruns()
+    {
+        var gov = new JudgeSpendGovernor(maxCalls: 100, maxTokens: 10);
+        Assert.True(gov.TryReserve(-100));   // clamped to 0 — a negative estimate must not manufacture headroom
+        Assert.True(gov.TryReserve(10));     // 0 + 10 = 10 ⇒ still fits (the -100 added nothing)
+        Assert.False(gov.TryReserve(1));     // now full
+    }
+
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(-1, 10)]
+    [InlineData(10, 0)]
+    [InlineData(10, -1)]
+    public void Ctor_RejectsNonPositiveCaps(int maxCalls, long maxTokens)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new JudgeSpendGovernor(maxCalls, maxTokens));
+
+    [Fact]
+    public void Ctor_RejectsNonPositiveWindow()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new JudgeSpendGovernor(1, 1, window: TimeSpan.Zero));
+
+    [Fact]
+    public void TryReserve_IsThreadSafe_NeverOverGrantsUnderContention()
+    {
+        // 8 threads racing 1000 reservations each against a 500-call budget must grant EXACTLY 500 — no torn
+        // increment past the cap. (Token budget kept huge so only the call cap binds.)
+        const int budget = 500;
+        var gov = new JudgeSpendGovernor(maxCalls: budget, maxTokens: long.MaxValue);
+        int granted = 0;
+
+        var threads = new Thread[8];
+        for (int t = 0; t < threads.Length; t++)
+        {
+            threads[t] = new Thread(() =>
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    if (gov.TryReserve(1))
+                    {
+                        Interlocked.Increment(ref granted);
+                    }
+                }
+            });
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Join();
+        }
+
+        Assert.Equal(budget, granted);   // exactly the budget — never more
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/GateCostWatchdogTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/GateCostWatchdogTests.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>Phase 5, P5-8 — the GateCost runtime watchdog: flags a gate whose measured latency persistently exceeds its declared cost class.</summary>
+public class GateCostWatchdogTests
+{
+    private sealed class FakeGate(string name, GateCost cost) : IToolGate
+    {
+        public string PolicyName => name;
+        public GateCost Cost => cost;
+        public ValueTask<ToolGateVerdict> InspectAsync(GatedToolCall call, CancellationToken ct = default)
+            => new(ToolGateVerdict.Allow(PolicyName));
+    }
+
+    private static GateTelemetry TelemetryWith(string policy, TimeSpan each, int times)
+    {
+        var t = new GateTelemetry();
+        for (var i = 0; i < times; i++)
+        {
+            t.Record(policy, ToolGateAction.Allow, each);
+        }
+
+        return t;
+    }
+
+    [Fact]
+    public void Flags_PureCodeGate_PersistentlyOverCeiling()
+    {
+        var telemetry = TelemetryWith("SlowPure", TimeSpan.FromMilliseconds(50), times: 30);   // avg 50ms >> 10ms PureCode ceiling
+
+        var violations = GateCostWatchdog.CheckViolations(new[] { new FakeGate("SlowPure", GateCost.PureCode) }, telemetry);
+
+        Assert.Single(violations);
+        Assert.Equal("SlowPure", violations[0].PolicyName);
+        Assert.Equal(GateCost.PureCode, violations[0].DeclaredCost);
+        Assert.Equal(30, violations[0].Invocations);
+    }
+
+    [Fact]
+    public void NoViolation_ForFastGate()
+        => Assert.Empty(GateCostWatchdog.CheckViolations(
+            new[] { new FakeGate("FastPure", GateCost.PureCode) },
+            TelemetryWith("FastPure", TimeSpan.FromMilliseconds(1), times: 30)));
+
+    [Fact]
+    public void NoViolation_BelowMinInvocations_EvenWhenSlow()
+        => Assert.Empty(GateCostWatchdog.CheckViolations(
+            new[] { new FakeGate("SlowButRare", GateCost.PureCode) },
+            TelemetryWith("SlowButRare", TimeSpan.FromMilliseconds(500), times: 3)));   // only 3 samples < default 20
+
+    [Fact]
+    public void BoundedGate_UnderItsHigherCeiling_NoViolation()
+        => Assert.Empty(GateCostWatchdog.CheckViolations(
+            new[] { new FakeGate("RegexGate", GateCost.Bounded) },
+            TelemetryWith("RegexGate", TimeSpan.FromMilliseconds(100), times: 30)));   // 100ms < 500ms Bounded ceiling
+
+    [Fact]
+    public void NetworkAndLlm_HaveNoInlineCeiling()
+    {
+        Assert.Equal(TimeSpan.MaxValue, GateCostWatchdog.CeilingFor(GateCost.Network));
+        Assert.Equal(TimeSpan.MaxValue, GateCostWatchdog.CeilingFor(GateCost.Llm));
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/ShadowJudgeTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/ShadowJudgeTests.cs
@@ -92,6 +92,23 @@ public class ShadowJudgeTests
         Assert.NotNull(reported);   // the failure was reported, not thrown into the run
     }
 
+    [Fact]
+    public async Task ShadowJudge_FullQueue_CountsDropsVisibly()
+    {
+        // P5-7: a full bounded queue drops items VISIBLY — every enqueue is accounted for as Accepted or Dropped,
+        // and DroppedCount surfaces the backpressure. The single-consumer ordering guarantee is unchanged.
+        await using var pump = new ShadowJudgePump(new HangingShadowJudge(), queueCapacity: 1, drainTimeout: TimeSpan.FromMilliseconds(50));
+
+        const int total = 200;
+        for (var i = 0; i < total; i++)
+        {
+            pump.Enqueue(new ShadowJudgeContext($"r{i}", InputText: null, AgentName: null, Session: null));
+        }
+
+        Assert.Equal(total, pump.AcceptedCount + pump.DroppedCount);   // every enqueue is accounted for
+        Assert.True(pump.DroppedCount > 0);                            // backpressure was visible, not silent
+    }
+
     // ── streaming seam ──
 
     [Fact]

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
@@ -228,6 +228,107 @@ public class TaintTrackingGateTests
         Assert.Equal(1, GlassBoxEvidence.FromTrace(trace).GateBlockCount);
     }
 
+    // ── P5-1: incremental per-run taint ledger (kicks in under a run scope) ──
+
+    [Fact]
+    public async Task Incremental_WithinScope_BlocksReadThenPostInOneCall()
+    {
+        // Parity: with a run scope in effect, the incremental path must reach the same verdict as the stateless one.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        var call = Call("http_post", new Dictionary<string, object?> { ["body"] = "here you go: demo-9a8b7c6d5e4f" },
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=demo-9a8b7c6d5e4f"));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(call)).Action);
+    }
+
+    [Fact]
+    public async Task Incremental_TaintPersists_AfterSourceResultDroppedFromLaterHistory()
+    {
+        // The core reducer-can't-launder property: an earlier call folds the secret into the run ledger; a later
+        // sink call whose OWN history no longer contains the source is STILL blocked (taint only accumulates).
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+
+        var seed = Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },   // non-sink, folds the source result
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=demo-9a8b7c6d5e4f"));
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(seed)).Action);
+
+        var sink = Call("http_post", new Dictionary<string, object?> { ["body"] = "leak: demo-9a8b7c6d5e4f" });   // empty history
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(sink)).Action);
+    }
+
+    [Fact]
+    public async Task Incremental_FoldsMultipleSources_AcrossGrowingHistory()
+    {
+        // Append-only growth across calls: each call folds only the newly-appeared source; both end up tainted.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+
+        await gate.InspectAsync(Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=secretone-11112222")));
+
+        await gate.InspectAsync(Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=secretone-11112222"),
+            AssistantCall("c2", "read_secrets"),
+            ToolResult("c2", "API_KEY=secrettwo-33334444")));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(
+            Call("http_post", new Dictionary<string, object?> { ["body"] = "leak secretone-11112222" }))).Action);
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(
+            Call("http_post", new Dictionary<string, object?> { ["body"] = "leak secrettwo-33334444" }))).Action);
+    }
+
+    [Fact]
+    public async Task Incremental_TaintDoesNotBleedAcrossRuns()
+    {
+        // Per-run keying: a secret folded in run 1 must not taint run 2's sink (which never called the source).
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+
+        using (var run1 = AgentRunScope.Begin(null, "T", null))
+        {
+            await gate.InspectAsync(Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },
+                AssistantCall("c1", "read_secrets"),
+                ToolResult("c1", "API_KEY=demo-9a8b7c6d5e4f")));
+        }
+
+        using (var run2 = AgentRunScope.Begin(null, "T", null))
+        {
+            var sink = Call("http_post", new Dictionary<string, object?> { ["body"] = "value demo-9a8b7c6d5e4f" });
+            Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(sink)).Action);   // run1's taint stays in run1
+        }
+    }
+
+    [Fact]
+    public async Task Incremental_ShrunkHistory_RetainsPriorTaint_AndFoldsRemaining()
+    {
+        // A reducer summarizes the prefix, shrinking the list (Count drops below the cursor). The stale cursor
+        // triggers a from-top reprocess: prior taint is retained AND whatever remains is re-folded.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+
+        await gate.InspectAsync(Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },
+            AssistantCall("c1", "read_secrets"),
+            ToolResult("c1", "API_KEY=secretone-11112222"),
+            AssistantCall("c2", "read_secrets"),
+            ToolResult("c2", "API_KEY=secrettwo-33334444")));   // cursor advances to 4
+
+        // History shrank to a single summary message (Count 1 < cursor 4) that still contains secret #2.
+        await gate.InspectAsync(Call("log", new Dictionary<string, object?> { ["msg"] = "ok" },
+            AssistantCall("c9", "read_secrets"),
+            ToolResult("c9", "API_KEY=secrettwo-33334444")));
+
+        // Secret #1 (only ever seen pre-shrink) is retained; secret #2 (present post-shrink) is still tainted.
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(
+            Call("http_post", new Dictionary<string, object?> { ["body"] = "leak secretone-11112222" }))).Action);
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(
+            Call("http_post", new Dictionary<string, object?> { ["body"] = "leak secrettwo-33334444" }))).Action);
+    }
+
     private sealed class Cyclic
     {
         public Cyclic? Self { get; set; }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/TaintTrackingGateTests.cs
@@ -329,6 +329,46 @@ public class TaintTrackingGateTests
             Call("http_post", new Dictionary<string, object?> { ["body"] = "leak secrettwo-33334444" }))).Action);
     }
 
+    [Fact]
+    public async Task Incremental_SlidingWindowReducer_ConstantCount_StillTaints()
+    {
+        // Regression for the P5-1 audit HIGH: a keep-last-N reducer keeps the message Count constant while rotating a
+        // NEW source result into the window. A positional cursor would skip it (fail open); the full re-walk catches it.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+
+        // Call 1: a 4-message window with NO source — this is what advanced the old cursor to 4.
+        await gate.InspectAsync(Call("http_post", new Dictionary<string, object?> { ["body"] = "nothing to see" },
+            new ChatMessage(ChatRole.User, "hi"),
+            AssistantCall("a1", "get_weather"),
+            ToolResult("a1", "sunny"),
+            new ChatMessage(ChatRole.Assistant, "ok")));
+
+        // Call 2: SAME Count (4), but the window slid — read_secrets and its SECRET result rotated in at the tail.
+        var sink = Call("http_post", new Dictionary<string, object?> { ["body"] = "leak: demo-9a8b7c6d5e4f" },
+            ToolResult("a1", "sunny"),
+            new ChatMessage(ChatRole.Assistant, "ok"),
+            AssistantCall("c2", "read_secrets"),
+            ToolResult("c2", "API_KEY=demo-9a8b7c6d5e4f"));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(sink)).Action);   // must NOT fail open
+    }
+
+    [Fact]
+    public async Task Incremental_ResultBeforeItsSourceCall_StillTaints()
+    {
+        // Regression for the P5-1 audit MEDIUM: a reordered history where the source RESULT precedes its CALL. The
+        // two-pass fold collects all source CallIds first, so the result is still attributed and tainted.
+        var gate = new TaintTrackingGate(["read_secrets"], ["http_post"]);
+        using var scope = AgentRunScope.Begin(null, "T", null);
+
+        var sink = Call("http_post", new Dictionary<string, object?> { ["body"] = "leak: demo-9a8b7c6d5e4f" },
+            ToolResult("c1", "API_KEY=demo-9a8b7c6d5e4f"),   // result appears BEFORE its call
+            AssistantCall("c1", "read_secrets"));
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(sink)).Action);
+    }
+
     private sealed class Cyclic
     {
         public Cyclic? Self { get; set; }

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/ToolResultGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/ToolResultGateTests.cs
@@ -579,6 +579,35 @@ public class ToolResultGateTests
         IsStreaming: false,
         Messages: null);
 
+    // ── P5-5: dedup result serialization ──
+
+    private sealed class CountingResult : IFormattable
+    {
+        public int SerializeCount;
+        public string ToString(string? format, IFormatProvider? formatProvider)
+        {
+            SerializeCount++;
+            return "the-result";
+        }
+    }
+
+    [Fact]
+    public void ResultText_SerializesOnce_AndCachesAcrossAccesses()
+    {
+        // P5-5: multiple result gates reading result.ResultText serialize the result ONCE, not once per gate.
+        var counter = new CountingResult();
+        var view = new GatedToolResult("f", null, counter, "A", 0, 0, 1, false, null);
+
+        var a = view.ResultText;
+        var b = view.ResultText;
+        var c = view.ResultText;
+
+        Assert.Equal("the-result", a);
+        Assert.Same(a, b);
+        Assert.Same(b, c);
+        Assert.Equal(1, counter.SerializeCount);   // three reads, one serialization
+    }
+
     private sealed class AllowAllResultGate : IToolResultGate
     {
         public string PolicyName => "AllowAllResultGate";


### PR DESCRIPTION
**Phase 5 of the Fable-5 Gatekeeper remediation plan — Performance & cost (8/8).** Non-breaking; all changes additive with opt-in knobs. Full net10 suite: 8457 pass / 0 fail / 2 skip; net8 builds clean.

## Tasks

- **P5-1 · Incremental per-run taint ledger** (`TaintTrackingGate`) — kills the O(n²) re-tokenization: under a run scope, a per-run `ConditionalWeakTable` ledger tokenizes each source result **once** across the run instead of re-walking + re-tokenizing the full (growing) history on every sink call. No-scope callers keep the original stateless behavior. Realizes **F-B** (the per-run RunLedger dimension pattern) alongside P4-3.
- **P5-2 · Judge spend governor** (`JudgeSpendGovernor`) — a shared, windowed token+call wallet across inline judges (denial-of-wallet bound). On exhaustion the model call is skipped; fail-open advisory by default (a spent cost budget must not self-DoS), fail-closed opt-in.
- **P5-3 · Bound judge input** — caps the text sent to the model at a head+tail sandwich (`MaxInputChars`, default 16000, floor 256); the prefilter still runs on full text. (Prefilter tuning deferred — needs a gold set.)
- **P5-4 · JudgeVerdictCache eviction** — bounded LRU + TTL + invalidation key.
- **P5-5 · Dedup result-gate serialization** — a tool result is serialized once (`GatedToolResult.ResultText`) and one view is shared across result gates.
- **P5-6 · Concurrent WarnOnly gate panel** — independent (WarnOnly) pre/post gates overlap; Record/Observe stay in list order so evidence is unchanged. Redact/ThrowOnFail keep exact sequential semantics.
- **P5-7 · ShadowJudgePump drop visibility** — Accepted/DroppedCount counters.
- **P5-8 · GateCost runtime watchdog** — flags a gate whose measured average exceeds its declared `GateCost` ceiling.

## Adversarial audit (Opus subagent) — 1 HIGH + 4, all fixed before this PR

- **(HIGH, P5-1)** the first-cut incremental cursor only reset on a strict count shrink, so a keep-last-N **sliding-window reducer** (constant count, source result rotated into the already-passed prefix) could hide a secret from the ledger and let it reach a sink un-blocked. Fixed by replacing the cursor with a full re-walk that tokenizes each result at most once (dedup by CallId) — correct under any history mutation, still kills the quadratic tokenization.
- **(MED, P5-1)** result-before-its-source-call ordering was missed → restored the two-pass fold.
- **(MED, P5-6)** corrected the "byte-identical" comment (holds on the no-throw path).
- **(MED, P5-2)** documented the drain-then-bypass attack on a shared governor (kept fail-open default + mitigations).
- **(LOW, P5-3)** added a 256-char floor so a tiny cap can't blind the judge.

Regression tests added for the sliding-window fail-open, result-before-call, and the input-cap floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)