### PR TITLE
Gatekeeper Phase 6: Meta-gates, presets & long tail (final phase)

### DIFF
--- a/src/AgentEval.Core/Guardrails/GateRegexTimeouts.cs
+++ b/src/AgentEval.Core/Guardrails/GateRegexTimeouts.cs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.Guardrails;
+
+/// <summary>
+/// The single source of truth for the ReDoS match-timeouts every gate's compiled <see cref="System.Text.RegularExpressions.Regex"/>
+/// runs under (Phase 6, P6-3 — "centralized tuning"). Before this, the same three values (50 / 100 / 300 ms) were
+/// scattered as inline <c>TimeSpan.FromMilliseconds(…)</c> literals across a dozen-plus gates, so tuning the ReDoS
+/// budget — or auditing that every gate even has one — meant hunting each call site. Tiered by how much text a gate's
+/// pattern scans, deliberately kept BELOW the <see cref="GateCost"/> ceilings a cost watchdog enforces (a
+/// <see cref="GateCost.Bounded"/> gate's 500 ms ceiling sits above <see cref="Extended"/> with headroom).
+/// </summary>
+public static class GateRegexTimeouts
+{
+    /// <summary>
+    /// 50 ms — a trivial, tightly-bounded pattern over a small slice (e.g. a <c>"{3,}</c> triple-quote prefilter).
+    /// </summary>
+    public static readonly TimeSpan Trivial = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
+    /// 100 ms — the default for a standard gate scan (PII, taint tokens, domain extraction, argument patterns):
+    /// linear/anchored patterns over a single argument or message.
+    /// </summary>
+    public static readonly TimeSpan Standard = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// 300 ms — an extended budget for a gate that scans a larger surface with several patterns (e.g. the secret
+    /// gate sweeping a whole tool result against many credential shapes). The upper bound; still under a
+    /// <see cref="GateCost.Bounded"/> gate's 500 ms cost ceiling.
+    /// </summary>
+    public static readonly TimeSpan Extended = TimeSpan.FromMilliseconds(300);
+}

--- a/src/AgentEval.Core/Guardrails/Gates/RegexPiiGate.cs
+++ b/src/AgentEval.Core/Guardrails/Gates/RegexPiiGate.cs
@@ -15,7 +15,7 @@ namespace AgentEval.Guardrails.Gates;
 /// </summary>
 public sealed class RegexPiiGate : IChatGate
 {
-    private static readonly TimeSpan PiiTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan PiiTimeout = GateRegexTimeouts.Standard;
 
     private static readonly (string Name, Regex Pattern)[] Patterns =
     {

--- a/src/AgentEval.Core/Guardrails/Gates/RenderedOutputExfilGate.cs
+++ b/src/AgentEval.Core/Guardrails/Gates/RenderedOutputExfilGate.cs
@@ -22,7 +22,7 @@ namespace AgentEval.Guardrails.Gates;
 /// </summary>
 public sealed class RenderedOutputExfilGate : IChatGate
 {
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan MatchTimeout = GateRegexTimeouts.Standard;
 
     private static readonly (string Name, Regex Pattern, string Replacement)[] Channels =
     {

--- a/src/AgentEval.Core/Tracing/GlassBoxEvidence.cs
+++ b/src/AgentEval.Core/Tracing/GlassBoxEvidence.cs
@@ -30,6 +30,23 @@ public sealed record GlassBoxEvidence
     [JsonPropertyName("gateBlockPolicies")]
     public IReadOnlyList<string> GateBlockPolicies { get; init; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Number of gate verdicts that WOULD have blocked but did not, because the gate ran under a non-enforcing policy
+    /// (Observe / WarnOnly) — Phase 6, P6-2. Counted separately from <see cref="GateBlockCount"/> (which stays
+    /// enforced-only), this is the counterfactual that turns an Observe-mode dry run into a data-driven
+    /// Observe→Enforce decision: "flipping to Enforce would have blocked this many calls."
+    /// </summary>
+    [JsonPropertyName("wouldBlockCount")]
+    public int WouldBlockCount { get; init; }
+
+    /// <summary>Number of gate verdicts that WOULD have mutated a call's arguments but did not (non-enforcing policy) — P6-2.</summary>
+    [JsonPropertyName("wouldMutateCount")]
+    public int WouldMutateCount { get; init; }
+
+    /// <summary>Number of gate verdicts that WOULD have redacted a tool result but did not (non-enforcing policy) — P6-2.</summary>
+    [JsonPropertyName("wouldRedactCount")]
+    public int WouldRedactCount { get; init; }
+
     /// <summary>Number of chat turns whose finish reason was content_filter or length (provider-side intervention).</summary>
     [JsonPropertyName("suppressedFinishTurns")]
     public int SuppressedFinishTurns { get; init; }
@@ -64,6 +81,7 @@ public sealed record GlassBoxEvidence
         }
 
         var (gateBlocks, policies) = CountGateBlocks(trace);
+        var (wouldBlock, wouldMutate, wouldRedact) = CountCounterfactuals(trace);
 
         return new GlassBoxEvidence
         {
@@ -71,6 +89,9 @@ public sealed record GlassBoxEvidence
             ToolExecutionCount = toolExecutions,
             GateBlockCount = gateBlocks,
             GateBlockPolicies = policies,
+            WouldBlockCount = wouldBlock,
+            WouldMutateCount = wouldMutate,
+            WouldRedactCount = wouldRedact,
             SuppressedFinishTurns = chatResponses.Count(r =>
                 string.Equals(r.FinishReason, "content_filter", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(r.FinishReason, "length", StringComparison.OrdinalIgnoreCase)),
@@ -104,5 +125,52 @@ public sealed record GlassBoxEvidence
         }
 
         return (count, policies.OrderBy(p => p, StringComparer.Ordinal).ToList());
+    }
+
+    // P6-2: count the Observe/WarnOnly counterfactuals recorded alongside real verdicts. A would-block carries the
+    // explicit "wouldAction":"Block" marker (a non-enforced block records action="Warn", which alone can't be told
+    // from a genuine warning); a would-mutate/would-redact is an action="Mutate"/"Redact" record with applied=false
+    // (the P2-2 recorded-not-applied flag). None of these are enforced, so none inflate GateBlockCount.
+    private static (int WouldBlock, int WouldMutate, int WouldRedact) CountCounterfactuals(AgentTrace trace)
+    {
+        if (trace.Metadata is null)
+        {
+            return (0, 0, 0);
+        }
+
+        int wouldBlock = 0, wouldMutate = 0, wouldRedact = 0;
+        foreach (var kv in trace.Metadata)
+        {
+            if (!GateMetadataReader.IsGateKey(kv.Key))
+            {
+                continue;
+            }
+
+            if (string.Equals(GateMetadataReader.ReadField(kv.Value, "wouldAction"), "Block", StringComparison.Ordinal))
+            {
+                wouldBlock++;
+                continue;
+            }
+
+            // applied is a bool: the in-memory dict renders "False", a reloaded JsonElement renders "false" — compare
+            // case-insensitively so the counterfactual survives serialization.
+            var notApplied = string.Equals(GateMetadataReader.ReadField(kv.Value, "applied"), "false", StringComparison.OrdinalIgnoreCase);
+            if (!notApplied)
+            {
+                continue;
+            }
+
+            switch (GateMetadataReader.ReadField(kv.Value, "action"))
+            {
+                case "Mutate":
+                    wouldMutate++;
+                    break;
+                case "Redact":
+                    wouldRedact++;
+                    break;
+            }
+        }
+
+        return (wouldBlock, wouldMutate, wouldRedact);
     }
 }

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -582,6 +582,14 @@ public static class AgentEvalToolGateExtensions
             extra["terminate"] = true;
         }
 
+        // P6-2: a non-enforced (WarnOnly/Observe) block records action="Warn"; capture what it WOULD have done so an
+        // Observe→Enforce dry-run diff can count would-have-blocks (GlassBoxEvidence.WouldBlockCount) without
+        // inflating the enforced GateBlockCount.
+        if (action != "Block")
+        {
+            extra["wouldAction"] = "Block";
+        }
+
         // F-C: one canonical record, projected to the same superset trace value the readers parse.
         var record = evidence.Build(
             stage: "tool", policy: verdict.PolicyName, action: action, referenceId: referenceId, reason: verdict.Reason,
@@ -606,6 +614,12 @@ public static class AgentEvalToolGateExtensions
         if (terminating)
         {
             extra["terminate"] = true;
+        }
+
+        // P6-2: same counterfactual marker as RecordBlock (see there) — a non-enforced result-gate block is a would-block.
+        if (action != "Block")
+        {
+            extra["wouldAction"] = "Block";
         }
 
         var record = evidence.Build(

--- a/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
+++ b/src/AgentEval.MAF/Gatekeeper/AgentEvalToolGateExtensions.cs
@@ -320,7 +320,13 @@ public static class AgentEvalToolGateExtensions
                             // so a good agent sees it's looping — without leaking why. Review #2: only tally when a
                             // run scope is established — a scopeless caller would otherwise accumulate denials in the
                             // process-wide fallback ledger, bleeding the count across runs/sessions; omit attempts then.
-                            int? attempts = AgentRunScope.Current is null ? null : RunLedger.ForCurrentRun().RecordDenial(DenialKey(call));
+                            int? attempts = null;
+                            if (AgentRunScope.Current is not null)
+                            {
+                                attempts = RunLedger.ForCurrentRun().RecordDenial(DenialKey(call));   // P4-3 per-(tool+arg-shape) retry tally
+                                RunLedger.ForRootRun().RecordTreeDenial();   // P6-1 block-storm total, aggregated at the run-tree root
+                            }
+
                             return GateReferenceId.RefusalBody(referenceId, RefusalDispositionClassifier.Classify(verdict.PolicyName), attempts);
                         }
                     }

--- a/src/AgentEval.MAF/Gatekeeper/ArgumentCanonicalizer.cs
+++ b/src/AgentEval.MAF/Gatekeeper/ArgumentCanonicalizer.cs
@@ -5,6 +5,7 @@
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using AgentEval.Guardrails;
 
 namespace AgentEval.MAF.Gatekeeper;
 
@@ -32,8 +33,8 @@ public static class ArgumentCanonicalizer
     /// <summary>Hard cap on the number of projections returned (raw included), bounding fan-out.</summary>
     public const int DefaultMaxProjections = 24;
 
-    private static readonly Regex UnicodeEscape = new(@"\\u([0-9A-Fa-f]{4})", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
-    private static readonly Regex Base64Candidate = new(@"[A-Za-z0-9+/]{16,}={0,2}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
+    private static readonly Regex UnicodeEscape = new(@"\\u([0-9A-Fa-f]{4})", RegexOptions.Compiled, GateRegexTimeouts.Standard);
+    private static readonly Regex Base64Candidate = new(@"[A-Za-z0-9+/]{16,}={0,2}", RegexOptions.Compiled, GateRegexTimeouts.Standard);
 
     /// <summary>
     /// Returns <paramref name="raw"/> and its decoded projections. The first element is always <paramref name="raw"/>.

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternApprovalGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternApprovalGate.cs
@@ -6,6 +6,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using AgentEval.Assertions;
+using AgentEval.Guardrails;
 using Microsoft.Extensions.AI;
 
 namespace AgentEval.MAF.Gatekeeper;
@@ -34,7 +35,7 @@ public sealed class ArgumentPatternApprovalGate : IToolApprovalGate
 
     /// <summary>Creates the gate from a pattern, compiled with a bounded (100 ms) match timeout (ReDoS-safe).</summary>
     public ArgumentPatternApprovalGate(string escalateWhenArgumentsMatch, string? policyName = null)
-        : this(new Regex(escalateWhenArgumentsMatch, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100)), policyName)
+        : this(new Regex(escalateWhenArgumentsMatch, RegexOptions.CultureInvariant, GateRegexTimeouts.Standard), policyName)
     {
     }
 

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ArgumentPatternGate.cs
@@ -6,6 +6,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using AgentEval.Assertions;
+using AgentEval.Guardrails;
 
 namespace AgentEval.MAF.Gatekeeper;
 
@@ -32,7 +33,7 @@ public sealed class ArgumentPatternGate : IToolGate
 
     /// <summary>Creates the gate from a pattern, compiled with a bounded (100 ms) match timeout (ReDoS-safe).</summary>
     public ArgumentPatternGate(string forbiddenPattern, string? policyName = null, bool canonicalize = false)
-        : this(new Regex(forbiddenPattern, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100)), policyName, canonicalize)
+        : this(new Regex(forbiddenPattern, RegexOptions.CultureInvariant, GateRegexTimeouts.Standard), policyName, canonicalize)
     {
     }
 

--- a/src/AgentEval.MAF/Gatekeeper/Gates/BlockStormSentinelGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/BlockStormSentinelGate.cs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+namespace AgentEval.MAF.Gatekeeper;
+
+/// <summary>
+/// One block-storm incident (Phase 6, P6-1): a run has accumulated enough ENFORCED policy blocks that the pattern
+/// itself is the signal — an agent (or an attacker steering it) repeatedly trying denied actions is probing.
+/// </summary>
+/// <param name="RunId">The run this fired on (<see cref="AgentRunScope.RunId"/>).</param>
+/// <param name="EnforcedBlockCount">Enforced blocks recorded this run when the sentinel tripped.</param>
+/// <param name="Threshold">The configured trip threshold.</param>
+/// <param name="Severity">Triage severity — <see cref="GateSeverity.Incident"/> (a block-storm demands attention).</param>
+public sealed record BlockStormIncident(string? RunId, int EnforcedBlockCount, int Threshold, GateSeverity Severity);
+
+/// <summary>
+/// A meta-gate (Phase 6, P6-1) that watches the run's ENFORCED-block volume — <see cref="RunLedger.TotalDenials"/>
+/// (the F-B block-storm dimension) — rather than any single call. Once <c>threshold</c> enforced blocks have been
+/// recorded this run, it blocks every subsequent call: repeated denials across a run are how probing looks (an agent
+/// hammering many <c>ACTION_NOT_AUTHORIZED</c>s). It reads no arguments, so it is <see cref="GateCost.PureCode"/>.
+/// <para><b>Escalate to Terminate.</b> A gate can't override the registration's <see cref="ToolGatePolicy"/>, so to
+/// turn a block-storm into a run <i>halt</i> register this sentinel in its OWN <see cref="ToolGatePolicy.Terminate"/>
+/// layer (a second <c>UseAgentEvalToolGate</c> call), leaving your ordinary gates on their own policy. Under a
+/// non-terminating policy it still blocks each further probe.</para>
+/// <para><b>Scope.</b> The tally is per-run (it reads <see cref="RunLedger.ForCurrentRun"/>, where enforced blocks are
+/// recorded); a block-storm spread across separate nested sub-agent runs is each counted on its own run. With no run
+/// scope the sentinel is a no-op (there is no per-run tally to read) — register the run gate for it to work.</para>
+/// <para>The optional <paramref name="onBlockStorm"/> callback fires once, on the call the threshold is first crossed,
+/// with an <see cref="BlockStormIncident"/> for alerting/incident routing; it is exception-isolated (an alert sink
+/// must never break the gate).</para>
+/// </summary>
+public sealed class BlockStormSentinelGate : IToolGate
+{
+    private readonly int _threshold;
+    private readonly Action<BlockStormIncident>? _onBlockStorm;
+
+    /// <inheritdoc/>
+    public string PolicyName => "BlockStormSentinel";
+
+    /// <inheritdoc/>
+    public GateCost Cost => GateCost.PureCode;
+
+    /// <summary>Creates the sentinel.</summary>
+    /// <param name="threshold">Enforced blocks this run before the sentinel starts blocking. Default 5.</param>
+    /// <param name="onBlockStorm">Optional incident callback, fired once on the trip (exception-isolated).</param>
+    public BlockStormSentinelGate(int threshold = 5, Action<BlockStormIncident>? onBlockStorm = null)
+    {
+        if (threshold < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(threshold), "must be at least 1.");
+        }
+
+        _threshold = threshold;
+        _onBlockStorm = onBlockStorm;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<ToolGateVerdict> InspectAsync(GatedToolCall call, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(call);
+
+        var scope = AgentRunScope.Current;
+        if (scope is null)
+        {
+            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));   // no per-run tally to read
+        }
+
+        var enforcedBlocks = RunLedger.ForCurrentRun().TotalDenials;
+        if (enforcedBlocks < _threshold)
+        {
+            return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
+        }
+
+        // Alert once, on the transition (TotalDenials is monotonic and increments by at most one between the
+        // sentinel's per-call checks, so it equals the threshold on exactly the call that first crosses it).
+        if (enforcedBlocks == _threshold && _onBlockStorm is not null)
+        {
+            try
+            {
+                _onBlockStorm(new BlockStormIncident(scope.RunId, enforcedBlocks, _threshold, GateSeverity.Incident));
+            }
+            catch
+            {
+                // An alert sink must never break the gate (Phase 3 exception-isolation discipline).
+            }
+        }
+
+        // Reason is audit-only (trace evidence); the model sees only the non-revealing {referenceId} refusal body (#12).
+        return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Block(PolicyName,
+            $"block-storm: {enforcedBlocks} enforced policy blocks this run (threshold {_threshold}) — repeated denials indicate probing"));
+    }
+}

--- a/src/AgentEval.MAF/Gatekeeper/Gates/BlockStormSentinelGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/BlockStormSentinelGate.cs
@@ -15,20 +15,27 @@ namespace AgentEval.MAF.Gatekeeper;
 public sealed record BlockStormIncident(string? RunId, int EnforcedBlockCount, int Threshold, GateSeverity Severity);
 
 /// <summary>
-/// A meta-gate (Phase 6, P6-1) that watches the run's ENFORCED-block volume — <see cref="RunLedger.TotalDenials"/>
-/// (the F-B block-storm dimension) — rather than any single call. Once <c>threshold</c> enforced blocks have been
-/// recorded this run, it blocks every subsequent call: repeated denials across a run are how probing looks (an agent
-/// hammering many <c>ACTION_NOT_AUTHORIZED</c>s). It reads no arguments, so it is <see cref="GateCost.PureCode"/>.
-/// <para><b>Escalate to Terminate.</b> A gate can't override the registration's <see cref="ToolGatePolicy"/>, so to
-/// turn a block-storm into a run <i>halt</i> register this sentinel in its OWN <see cref="ToolGatePolicy.Terminate"/>
-/// layer (a second <c>UseAgentEvalToolGate</c> call), leaving your ordinary gates on their own policy. Under a
-/// non-terminating policy it still blocks each further probe.</para>
-/// <para><b>Scope.</b> The tally is per-run (it reads <see cref="RunLedger.ForCurrentRun"/>, where enforced blocks are
-/// recorded); a block-storm spread across separate nested sub-agent runs is each counted on its own run. With no run
-/// scope the sentinel is a no-op (there is no per-run tally to read) — register the run gate for it to work.</para>
-/// <para>The optional <paramref name="onBlockStorm"/> callback fires once, on the call the threshold is first crossed,
-/// with an <see cref="BlockStormIncident"/> for alerting/incident routing; it is exception-isolated (an alert sink
-/// must never break the gate).</para>
+/// A meta-gate (Phase 6, P6-1) that watches the run tree's ENFORCED-block volume —
+/// <see cref="RunLedger.TreeDenialCount"/> (the F-B block-storm dimension) — rather than any single call. Once
+/// <c>threshold</c> enforced blocks have been recorded, it blocks every subsequent call: repeated denials are how
+/// probing looks (an agent hammering many <c>ACTION_NOT_AUTHORIZED</c>s). It reads no arguments, so it is
+/// <see cref="GateCost.PureCode"/>.
+/// <para><b>Escalate to Terminate.</b> A gate can't override the registration's <see cref="ToolGatePolicy"/>, so a
+/// block-storm becomes a run <i>halt</i> only when the sentinel is registered under
+/// <see cref="ToolGatePolicy.Terminate"/> — add it to the SAME <c>UseAgentEvalToolGate</c> list as your other gates
+/// (do NOT add a second, separate <c>UseAgentEvalToolGate</c> call: a later registration becomes OUTERMOST and can
+/// silently starve the earlier one — see the warning on <c>UseAgentEvalToolGate</c>). Under a non-terminating policy
+/// (Observe / ReplaceResult) the sentinel still BLOCKS each further probe but cannot itself force termination; put the
+/// whole gate list on Terminate if you want a probing run stopped.</para>
+/// <para><b>Scope.</b> The tally is aggregated at the run-tree ROOT (via <see cref="RunLedger.ForRootRun"/>), so a
+/// block-storm spread across nested sub-agent runs still accumulates into one total and cannot be laundered under the
+/// threshold — matching the P2-8 nested-run hardening the budget gates use. Separate <i>top-level</i> runs each have
+/// their own tree and do not share. With no run scope the sentinel is a no-op (there is no tally to read) — register
+/// the run gate for it to work.</para>
+/// <para>The optional <paramref name="onBlockStorm"/> callback fires <b>exactly once per run tree</b>, the first time
+/// the threshold is crossed (via an atomic latch, so it is race-free under concurrent tool calls), with an
+/// <see cref="BlockStormIncident"/> for alerting/incident routing; it is exception-isolated (an alert sink must never
+/// break the gate).</para>
 /// </summary>
 public sealed class BlockStormSentinelGate : IToolGate
 {
@@ -66,15 +73,17 @@ public sealed class BlockStormSentinelGate : IToolGate
             return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));   // no per-run tally to read
         }
 
-        var enforcedBlocks = RunLedger.ForCurrentRun().TotalDenials;
+        // Tree-wide total (ForRootRun) so a storm can't be laundered across nested sub-runs. Blocking is monotonic
+        // (>= threshold), so it never fails open even if the tally jumps past the exact threshold value.
+        var enforcedBlocks = RunLedger.ForRootRun().TreeDenialCount;
         if (enforcedBlocks < _threshold)
         {
             return new ValueTask<ToolGateVerdict>(ToolGateVerdict.Allow(PolicyName));
         }
 
-        // Alert once, on the transition (TotalDenials is monotonic and increments by at most one between the
-        // sentinel's per-call checks, so it equals the threshold on exactly the call that first crosses it).
-        if (enforcedBlocks == _threshold && _onBlockStorm is not null)
+        // Alert exactly once per run tree via an atomic latch — race-free under concurrent tool calls and correct
+        // even when the tally jumps past the threshold (a naive "== threshold" check would miss or double-fire).
+        if (_onBlockStorm is not null && RunLedger.ForRootRun().TryLatchBlockStorm())
         {
             try
             {

--- a/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/DomainAllowListGate.cs
@@ -5,6 +5,7 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using AgentEval.Guardrails;
 
 namespace AgentEval.MAF.Gatekeeper;
 
@@ -33,14 +34,14 @@ public sealed class DomainAllowListGate : IToolGate
     // AND scheme-relative "//attacker.example" are all caught, not just http(s). Stops at the next delimiter
     // (including ? and #, so a query/fragment isn't folded into the host). Bounded (ReDoS-safe).
     private static readonly Regex UrlAuthority = new(
-        @"(?:[a-z][a-z0-9+.\-]*:)?//([^/\s""'<>\\)}?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+        @"(?:[a-z][a-z0-9+.\-]*:)?//([^/\s""'<>\\)}?#]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase, GateRegexTimeouts.Standard);
 
     // A data: URI (data:[<mediatype>][;base64],<data>) has no host and so can never be host-allow-listed — in an
     // egress-controlled context it is un-vettable inline/exfil content. Conservative: requires the trailing comma
     // of a real data URI, so the literal word "data:" in prose does not false-positive. Bounded (ReDoS-safe).
     private static readonly Regex DataUri = new(
         @"\bdata:(?:[a-z][a-z0-9.+\-]*/[a-z0-9.+\-]+)?(?:;[a-z0-9\-]+(?:=[a-z0-9.\-]+)?)*,",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+        RegexOptions.Compiled | RegexOptions.IgnoreCase, GateRegexTimeouts.Standard);
 
     private readonly HashSet<string> _allowed;
     private readonly string[] _hostArguments;

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ReferentialIntegrityGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ReferentialIntegrityGate.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Text.RegularExpressions;
+using AgentEval.Guardrails;
 using Microsoft.Extensions.AI;
 
 namespace AgentEval.MAF.Gatekeeper;
@@ -36,7 +37,7 @@ namespace AgentEval.MAF.Gatekeeper;
 /// </summary>
 public sealed class ReferentialIntegrityGate : IToolGate
 {
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan MatchTimeout = GateRegexTimeouts.Standard;
 
     // Maximal runs of identifier characters. The "is this an id" decision (length + contains-a-digit) is done in
     // code, so the regex stays a simple linear character-class scan — no backtracking, ReDoS-safe.

--- a/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/TaintTrackingGate.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using AgentEval.Guardrails;
 using Microsoft.Extensions.AI;
 
 namespace AgentEval.MAF.Gatekeeper;
@@ -32,7 +33,7 @@ namespace AgentEval.MAF.Gatekeeper;
 /// </summary>
 public sealed class TaintTrackingGate : IToolGate
 {
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan MatchTimeout = GateRegexTimeouts.Standard;
 
     // Value-like tokens (secrets, keys, emails, ids, SSNs): runs of value characters, incl. '_' (env-style
     // SECRET_TOKEN / base64url). Linear ⇒ ReDoS-safe.

--- a/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
+++ b/src/AgentEval.MAF/Gatekeeper/Gates/ToolResultSecretGate.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 using System.Text.RegularExpressions;
+using AgentEval.Guardrails;
 
 namespace AgentEval.MAF.Gatekeeper;
 
@@ -31,7 +32,7 @@ namespace AgentEval.MAF.Gatekeeper;
 /// </summary>
 public sealed class ToolResultSecretGate : IToolResultGate
 {
-    private static readonly TimeSpan DefaultSecretTimeout = TimeSpan.FromMilliseconds(300);
+    private static readonly TimeSpan DefaultSecretTimeout = GateRegexTimeouts.Extended;
 
     private static readonly (string Name, Regex Pattern)[] DefaultPatterns = BuildPatterns(DefaultSecretTimeout);
 

--- a/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
+++ b/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
@@ -78,6 +78,7 @@ public sealed class RunLedger
     private readonly Dictionary<string, int> _perToolCallBudgetCounts = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, (int Count, long Sum, long Max)> _toolResultSizes = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, int> _denials = new(StringComparer.Ordinal);   // P4-3: per-(tool+arg-shape) denial tally (F-B dimension)
+    private int _totalDenials;   // P6-1: whole-run enforced-block volume (block-storm dimension)
 
     /// <summary>The ledger for the current run (keyed by <see cref="AgentRunScope.Current"/>).</summary>
     public static RunLedger ForCurrentRun()
@@ -335,8 +336,19 @@ public sealed class RunLedger
         {
             var count = (_denials.TryGetValue(denialKey, out var n) ? n : 0) + 1;
             _denials[denialKey] = count;
+            _totalDenials++;
             return count;
         }
+    }
+
+    /// <summary>
+    /// Total ENFORCED blocks recorded across every denial key this run (Phase 6, P6-1 / F-B) — the block-storm
+    /// dimension. Unlike <see cref="DenialCount"/> (which counts retries of one specific action), this is the whole
+    /// run's enforced-block volume, so a sentinel can spot an agent probing MANY different denied actions.
+    /// </summary>
+    public int TotalDenials
+    {
+        get { lock (_lock) { return _totalDenials; } }
     }
 
     /// <summary>The number of denials recorded so far for <paramref name="denialKey"/> this run (0 if none).</summary>

--- a/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
+++ b/src/AgentEval.MAF/Gatekeeper/RunLedger.cs
@@ -78,7 +78,8 @@ public sealed class RunLedger
     private readonly Dictionary<string, int> _perToolCallBudgetCounts = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, (int Count, long Sum, long Max)> _toolResultSizes = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, int> _denials = new(StringComparer.Ordinal);   // P4-3: per-(tool+arg-shape) denial tally (F-B dimension)
-    private int _totalDenials;   // P6-1: whole-run enforced-block volume (block-storm dimension)
+    private int _treeDenials;          // P6-1: enforced-block volume, aggregated at the run-tree ROOT (see RecordTreeDenial)
+    private bool _blockStormAlerted;   // P6-1: one-shot latch so a block-storm incident alert fires once per run tree
 
     /// <summary>The ledger for the current run (keyed by <see cref="AgentRunScope.Current"/>).</summary>
     public static RunLedger ForCurrentRun()
@@ -336,19 +337,50 @@ public sealed class RunLedger
         {
             var count = (_denials.TryGetValue(denialKey, out var n) ? n : 0) + 1;
             _denials[denialKey] = count;
-            _totalDenials++;
             return count;
         }
     }
 
     /// <summary>
-    /// Total ENFORCED blocks recorded across every denial key this run (Phase 6, P6-1 / F-B) — the block-storm
-    /// dimension. Unlike <see cref="DenialCount"/> (which counts retries of one specific action), this is the whole
-    /// run's enforced-block volume, so a sentinel can spot an agent probing MANY different denied actions.
+    /// Records one ENFORCED block toward the run-TREE's block-storm total (Phase 6, P6-1 / F-B), returning the new
+    /// total. Unlike <see cref="DenialCount"/> (retries of one specific action), this is the whole run's
+    /// enforced-block volume, so a sentinel can spot an agent probing MANY different denied actions. <b>Call on
+    /// <see cref="ForRootRun"/></b> so every nested sub-agent run accumulates into ONE total at the tree root —
+    /// otherwise a block-storm could be laundered across nested runs, each staying under the sentinel's threshold
+    /// (the same nested-run vector P2-8 closed for budget gates).
     /// </summary>
-    public int TotalDenials
+    public int RecordTreeDenial()
     {
-        get { lock (_lock) { return _totalDenials; } }
+        lock (_lock)
+        {
+            return ++_treeDenials;
+        }
+    }
+
+    /// <summary>The run-tree's ENFORCED-block total (P6-1). Read on <see cref="ForRootRun"/> to see the whole tree.</summary>
+    public int TreeDenialCount
+    {
+        get { lock (_lock) { return _treeDenials; } }
+    }
+
+    /// <summary>
+    /// Atomically claims the one-shot block-storm alert for this run tree (P6-1): returns <see langword="true"/>
+    /// exactly once — to the first caller — and <see langword="false"/> forever after, so a sentinel fires its
+    /// incident alert once even under concurrent tool calls or a tally that jumps past the threshold between checks.
+    /// Call on <see cref="ForRootRun"/> so one alert covers the whole tree.
+    /// </summary>
+    public bool TryLatchBlockStorm()
+    {
+        lock (_lock)
+        {
+            if (_blockStormAlerted)
+            {
+                return false;
+            }
+
+            _blockStormAlerted = true;
+            return true;
+        }
     }
 
     /// <summary>The number of denials recorded so far for <paramref name="denialKey"/> this run (0 if none).</summary>

--- a/tests/AgentEval.Tests/Guardrails/GateRegexTimeoutsTests.cs
+++ b/tests/AgentEval.Tests/Guardrails/GateRegexTimeoutsTests.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.Guardrails;
+using Xunit;
+
+namespace AgentEval.Tests.Guardrails;
+
+/// <summary>P6-3: the single ReDoS-timeout surface — pins the three tiers so a change is a deliberate, reviewed edit.</summary>
+public class GateRegexTimeoutsTests
+{
+    [Fact]
+    public void Tiers_HaveTheExpectedMilliseconds()
+    {
+        Assert.Equal(50, GateRegexTimeouts.Trivial.TotalMilliseconds);
+        Assert.Equal(100, GateRegexTimeouts.Standard.TotalMilliseconds);
+        Assert.Equal(300, GateRegexTimeouts.Extended.TotalMilliseconds);
+    }
+
+    [Fact]
+    public void Tiers_AreOrdered_AndUnderTheBoundedCostCeiling()
+    {
+        Assert.True(GateRegexTimeouts.Trivial < GateRegexTimeouts.Standard);
+        Assert.True(GateRegexTimeouts.Standard < GateRegexTimeouts.Extended);
+        Assert.True(GateRegexTimeouts.Extended < TimeSpan.FromMilliseconds(500));   // stays under the GateCost.Bounded ceiling
+    }
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/BlockStormSentinelGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/BlockStormSentinelGateTests.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>
+/// P6-1 BlockStormSentinelGate — a meta-gate that trips once a run's ENFORCED-block volume (RunLedger.TotalDenials)
+/// crosses a threshold, turning repeated denials (probing) into a block/terminate + one incident alert.
+/// </summary>
+public class BlockStormSentinelGateTests
+{
+    private static GatedToolCall Call(string tool = "any_tool")
+        => new(tool, new Dictionary<string, object?>(), "T", 0, 0, 1, false, Array.Empty<ChatMessage>());
+
+    private static void RecordDenials(int n)
+    {
+        for (var i = 0; i < n; i++)
+        {
+            RunLedger.ForCurrentRun().RecordDenial($"key-{i}");   // distinct keys → whole-run volume, not one retry
+        }
+    }
+
+    [Fact]
+    public async Task BelowThreshold_Allows()
+    {
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        RecordDenials(3);
+        var gate = new BlockStormSentinelGate(threshold: 5);
+
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(Call())).Action);
+    }
+
+    [Fact]
+    public async Task AtThreshold_Blocks()
+    {
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        RecordDenials(5);
+        var gate = new BlockStormSentinelGate(threshold: 5);
+
+        var verdict = await gate.InspectAsync(Call());
+        Assert.Equal(ToolGateAction.Block, verdict.Action);
+        Assert.Equal("BlockStormSentinel", verdict.PolicyName);
+    }
+
+    [Fact]
+    public async Task AboveThreshold_Blocks()
+    {
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        RecordDenials(9);
+        var gate = new BlockStormSentinelGate(threshold: 5);
+
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(Call())).Action);
+    }
+
+    [Fact]
+    public async Task Alert_FiresOnce_OnTheTransition_WithIncidentSeverity()
+    {
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        var incidents = new List<BlockStormIncident>();
+        var gate = new BlockStormSentinelGate(threshold: 5, onBlockStorm: incidents.Add);
+
+        RecordDenials(4);
+        await gate.InspectAsync(Call());   // 4 < 5 → allow, no alert
+
+        RecordDenials(1);                  // now 5
+        await gate.InspectAsync(Call());   // == threshold → block + alert
+        RecordDenials(1);                  // now 6
+        await gate.InspectAsync(Call());   // > threshold → block, NO second alert
+
+        Assert.Single(incidents);
+        Assert.Equal(5, incidents[0].EnforcedBlockCount);
+        Assert.Equal(5, incidents[0].Threshold);
+        Assert.Equal(GateSeverity.Incident, incidents[0].Severity);
+        Assert.Equal(scope.RunId, incidents[0].RunId);
+    }
+
+    [Fact]
+    public async Task ThrowingAlertSink_DoesNotBreakTheGate()
+    {
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        RecordDenials(5);
+        var gate = new BlockStormSentinelGate(threshold: 5, onBlockStorm: _ => throw new InvalidOperationException("sink boom"));
+
+        var verdict = await gate.InspectAsync(Call());   // must still block, not propagate the sink's throw
+        Assert.Equal(ToolGateAction.Block, verdict.Action);
+    }
+
+    [Fact]
+    public async Task NoRunScope_IsNoOp_Allows()
+    {
+        // No AgentRunScope ⇒ no per-run tally to read ⇒ the sentinel can't observe a storm ⇒ allow.
+        var gate = new BlockStormSentinelGate(threshold: 1);
+        Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(Call())).Action);
+    }
+
+    [Fact]
+    public async Task Tally_IsPerRun_DoesNotBleedAcrossRuns()
+    {
+        using (var run1 = AgentRunScope.Begin(null, "T", null))
+        {
+            RecordDenials(9);
+        }
+
+        using (var run2 = AgentRunScope.Begin(null, "T", null))
+        {
+            var gate = new BlockStormSentinelGate(threshold: 5);
+            Assert.Equal(ToolGateAction.Allow, (await gate.InspectAsync(Call())).Action);   // run1's storm stays in run1
+        }
+    }
+
+    [Fact]
+    public void Threshold_MustBePositive()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new BlockStormSentinelGate(threshold: 0));
+
+    [Fact]
+    public void PureCode_Cost()
+        => Assert.Equal(GateCost.PureCode, new BlockStormSentinelGate().Cost);
+}

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/BlockStormSentinelGateTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/BlockStormSentinelGateTests.cs
@@ -9,8 +9,9 @@ using Xunit;
 namespace AgentEval.Tests.MAF.Gatekeeper;
 
 /// <summary>
-/// P6-1 BlockStormSentinelGate — a meta-gate that trips once a run's ENFORCED-block volume (RunLedger.TotalDenials)
-/// crosses a threshold, turning repeated denials (probing) into a block/terminate + one incident alert.
+/// P6-1 BlockStormSentinelGate — a meta-gate that trips once a run tree's ENFORCED-block volume
+/// (RunLedger.TreeDenialCount, aggregated at the root) crosses a threshold, turning repeated denials (probing) into a
+/// block/terminate + one atomically-latched incident alert.
 /// </summary>
 public class BlockStormSentinelGateTests
 {
@@ -19,9 +20,12 @@ public class BlockStormSentinelGateTests
 
     private static void RecordDenials(int n)
     {
+        // Mirrors the enforced-block site (AgentEvalToolGateExtensions): a per-key attempts tally on the current run
+        // PLUS the tree-wide block-storm total on the root — the latter is what the sentinel reads.
         for (var i = 0; i < n; i++)
         {
-            RunLedger.ForCurrentRun().RecordDenial($"key-{i}");   // distinct keys → whole-run volume, not one retry
+            RunLedger.ForCurrentRun().RecordDenial($"key-{i}");
+            RunLedger.ForRootRun().RecordTreeDenial();
         }
     }
 
@@ -77,6 +81,43 @@ public class BlockStormSentinelGateTests
         Assert.Equal(5, incidents[0].Threshold);
         Assert.Equal(GateSeverity.Incident, incidents[0].Severity);
         Assert.Equal(scope.RunId, incidents[0].RunId);
+    }
+
+    [Fact]
+    public async Task Alert_FiresOnce_EvenWhenTallyJumpsPastThreshold()
+    {
+        // Audit-MEDIUM regression: the old "== threshold" check would MISS the alert when the tally jumped past the
+        // exact threshold (concurrency, or the sentinel not seeing every denial). The atomic latch fires once on the
+        // first crossing regardless of the jump.
+        using var scope = AgentRunScope.Begin(null, "T", null);
+        var incidents = new List<BlockStormIncident>();
+        var gate = new BlockStormSentinelGate(threshold: 5, onBlockStorm: incidents.Add);
+
+        RecordDenials(4);
+        await gate.InspectAsync(Call());   // 4 < 5 → allow
+
+        RecordDenials(2);                  // jumps 4 → 6, never landing exactly on 5
+        await gate.InspectAsync(Call());   // 6 ≥ 5 → block + alert (the old check would have missed this)
+        await gate.InspectAsync(Call());   // still latched → no second alert
+
+        Assert.Single(incidents);
+        Assert.Equal(6, incidents[0].EnforcedBlockCount);
+    }
+
+    [Fact]
+    public async Task NestedRuns_AggregateAtRoot_StormCannotBeLaunderedAcrossSubRuns()
+    {
+        // Audit-MEDIUM regression: a per-current-run tally would let an attacker spread denials across nested
+        // sub-agent runs, each under threshold. The tree-root aggregation (ForRootRun) catches the total.
+        var gate = new BlockStormSentinelGate(threshold: 5);
+        using var parent = AgentRunScope.Begin(null, "parent", null);
+        RecordDenials(3);   // 3 in the parent (tree root)
+
+        using var child = AgentRunScope.Begin(null, "child", null);   // nested: child.Root == parent
+        RecordDenials(2);   // 2 more, accumulated at the same tree root → total 5
+
+        // The sentinel in the CHILD run sees the whole tree's 5, not just the child's 2.
+        Assert.Equal(ToolGateAction.Block, (await gate.InspectAsync(Call())).Action);
     }
 
     [Fact]

--- a/tests/AgentEval.Tests/MAF/Gatekeeper/WouldEnforceEvidenceTests.cs
+++ b/tests/AgentEval.Tests/MAF/Gatekeeper/WouldEnforceEvidenceTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+// Licensed under the MIT License.
+
+using AgentEval.MAF.Gatekeeper;
+using AgentEval.Testing;
+using AgentEval.Tracing;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Xunit;
+using AgentTrace = AgentEval.Tracing.AgentTrace;
+
+namespace AgentEval.Tests.MAF.Gatekeeper;
+
+/// <summary>
+/// P6-2 Would-Have-Enforced evidence mode: under a non-enforcing policy (Observe / WarnOnly) the gate records what it
+/// WOULD have done, and GlassBoxEvidence surfaces WouldBlock/WouldMutate/WouldRedact counts — an Observe→Enforce diff
+/// that never inflates the enforced GateBlockCount.
+/// </summary>
+public class WouldEnforceEvidenceTests
+{
+    // ── Integration: a real WarnOnly tool-gate block records a would-block, not an enforced block ──
+
+    [Fact]
+    public async Task WarnOnly_BlockingToolGate_RecordsWouldBlock_NotEnforcedBlock()
+    {
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "T", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate()
+            .UseAgentEvalToolGate([new ForbiddenToolGate("delete_account")], ToolGatePolicy.WarnOnly, trace)
+            .Build();
+
+        await gated.RunAsync("go");
+
+        var evidence = GlassBoxEvidence.FromTrace(trace)!;
+        Assert.Equal(1, evidence.WouldBlockCount);   // WarnOnly ⇒ would have blocked
+        Assert.Equal(0, evidence.GateBlockCount);     // but did NOT enforce — the tool ran
+    }
+
+    [Fact]
+    public async Task Enforced_BlockingToolGate_RecordsBlock_NotWouldBlock()
+    {
+        var tool = AIFunctionFactory.Create((string x) => "ok", "delete_account");
+        var scripted = new ScriptedChatClient().AddToolCall("c1", "delete_account", new Dictionary<string, object?> { ["x"] = "1" }).AddText("done");
+        var agent = new ChatClientAgent(scripted, new ChatClientAgentOptions { Name = "T", ChatOptions = new ChatOptions { Tools = [tool] } });
+        var trace = new AgentTrace();
+        var gated = agent.AsBuilder()
+            .UseAgentEvalGate()
+            .UseAgentEvalToolGate([new ForbiddenToolGate("delete_account")], ToolGatePolicy.Terminate, trace)
+            .Build();
+
+        await gated.RunAsync("go");
+
+        var evidence = GlassBoxEvidence.FromTrace(trace)!;
+        Assert.Equal(1, evidence.GateBlockCount);     // enforced
+        Assert.Equal(0, evidence.WouldBlockCount);    // no counterfactual — it really blocked
+    }
+
+    // ── Unit: counting logic across all three counterfactuals, plus the serialized (JsonElement) path ──
+
+    private static AgentTrace TraceWithMixedEvidence()
+    {
+        var trace = new AgentTrace();
+        trace.SetMetadata("gate.tool.1.PolA", new Dictionary<string, object?> { ["action"] = "Warn", ["wouldAction"] = "Block" });   // would-block
+        trace.SetMetadata("gate.tool.2.PolB", new Dictionary<string, object?> { ["action"] = "Mutate", ["applied"] = false });        // would-mutate
+        trace.SetMetadata("gate.tool-result.3.PolC", new Dictionary<string, object?> { ["action"] = "Redact", ["applied"] = false }); // would-redact
+        trace.SetMetadata("gate.tool.4.PolD", new Dictionary<string, object?> { ["action"] = "Block" });                              // enforced block
+        trace.SetMetadata("gate.tool.5.PolE", new Dictionary<string, object?> { ["action"] = "Mutate", ["applied"] = true });         // APPLIED mutate — not a counterfactual
+        return trace;
+    }
+
+    [Fact]
+    public void CountsEachCounterfactual_Once_AndKeepsEnforcedBlockSeparate()
+    {
+        var evidence = GlassBoxEvidence.FromTrace(TraceWithMixedEvidence())!;
+
+        Assert.Equal(1, evidence.WouldBlockCount);
+        Assert.Equal(1, evidence.WouldMutateCount);
+        Assert.Equal(1, evidence.WouldRedactCount);
+        Assert.Equal(1, evidence.GateBlockCount);   // only the real enforced block (PolD)
+    }
+
+    [Fact]
+    public async Task Counterfactuals_SurviveSerializationRoundTrip()
+    {
+        // The reloaded trace's metadata values are JsonElement (and a bool renders "false", not "False") — the reader
+        // must still count the counterfactuals, or an Observe dry run persisted to disk would silently report zero.
+        var json = await TraceSerializer.SerializeToStringAsync(TraceWithMixedEvidence());
+        var reloaded = await TraceSerializer.DeserializeFromStringAsync(json);
+
+        var evidence = GlassBoxEvidence.FromTrace(reloaded)!;
+        Assert.Equal(1, evidence.WouldBlockCount);
+        Assert.Equal(1, evidence.WouldMutateCount);
+        Assert.Equal(1, evidence.WouldRedactCount);
+        Assert.Equal(1, evidence.GateBlockCount);
+    }
+}


### PR DESCRIPTION
**Phase 6 — the FINAL phase of the Fable-5 Gatekeeper remediation.** Non-breaking; additive. Full net10 suite: 8474 pass / 0 fail / 2 skip; net8 builds clean.

## Tasks

- **P6-1 · Block-storm sentinel** (`BlockStormSentinelGate`) — a PureCode `IToolGate` that watches the run **tree's** enforced-block volume (new `RunLedger.TreeDenialCount`, aggregated at the root) rather than any single call. Once `threshold` enforced blocks are recorded, it blocks every subsequent call — repeated denials across a run are how probing looks. A once-per-tree incident alert (atomic latch) routes to an optional callback. Register it in a Terminate-policy gate list to turn a storm into a run halt.
- **P6-2 · Would-Have-Enforced evidence** — under a non-enforcing policy (Observe/WarnOnly) the tool/result block writers stamp a `wouldAction="Block"` counterfactual (Mutate/Redact already carry `applied=false`); `GlassBoxEvidence` gains `WouldBlockCount`/`WouldMutateCount`/`WouldRedactCount`, counted separately from the enforced-only `GateBlockCount`. An Observe dry run now yields a **data-driven Observe→Enforce diff** instead of a guess.
- **P6-3 (part) · Centralized ReDoS-timeout surface** — `GateRegexTimeouts` (Trivial=50/Standard=100/Extended=300 ms) replaces a dozen-plus scattered inline `TimeSpan.FromMilliseconds` literals across every Gatekeeper + Core guardrail gate (values unchanged). The `GatekeeperPresets` factory half is **deferred per D7** (needs product-design judgment the plan chose to postpone).
- **P6-4 · Long-tail closure** — verified: all five fold-in items are owned by already-merged tasks (P1-6/P1-8/P5-4/P2-4b/F-C); P4-4 the only standing deferral. No code.

## Adversarial audit (Opus subagent) — no HIGH; 3 MED on P6-1, all fixed before this PR

P6-2 and P6-3 verified clean. The three MEDIUMs were all about the sentinel's observability/scope (enforcement itself was sound and thread-safe):
- The "fire-once" alert was a non-atomic `== threshold` check → missed on a tally jump, double-fired under concurrency. Replaced with an **atomic one-shot latch** (`RunLedger.TryLatchBlockStorm`).
- The tally read `ForCurrentRun` → a storm could be **laundered across nested sub-runs**. Now aggregated at the run-tree **root** (`ForRootRun`), matching the P2-8 nested-run hardening.
- The doc recommended a second `UseAgentEvalToolGate` call, contradicting that method's own no-chain warning (could starve the sentinel). Corrected to same-list + Terminate-registration guidance.

Regression tests added for the alert-once-under-jump and nested-run-no-laundering cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)