### PR TITLE
fix: upgrade Mission Control SPA to react-router 8.3.0

### DIFF
--- a/src/AgentEval.MissionControl.Spa/package-lock.json
+++ b/src/AgentEval.MissionControl.Spa/package-lock.json
@@ -14,7 +14,7 @@
         "lucide-react": "^0.469.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.18.0",
+        "react-router": "^8.3.0",
         "recharts": "^2.15.4"
       },
       "devDependencies": {
@@ -800,18 +800,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1427,22 +1419,22 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -1451,41 +1443,23 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-router": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
-      "license": "MIT",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-smooth": {
@@ -1584,12 +1558,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/src/AgentEval.MissionControl.Spa/package.json
+++ b/src/AgentEval.MissionControl.Spa/package.json
@@ -17,7 +17,7 @@
     "lucide-react": "^0.469.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.18.0",
+    "react-router": "^8.3.0",
     "recharts": "^2.15.4"
   },
   "devDependencies": {

--- a/src/AgentEval.MissionControl.Spa/src/App.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes } from "react-router";
 import { AppShell } from "@/components/AppShell";
 import { DashboardPage } from "@/pages/DashboardPage";
 import { SubjectDetailPage } from "@/pages/SubjectDetailPage";

--- a/src/AgentEval.MissionControl.Spa/src/components/AppShell.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { LayoutDashboard, ShieldCheck, ListChecks, Activity, History, Swords } from "lucide-react";
 import { ErrorBoundary } from "./ErrorBoundary";

--- a/src/AgentEval.MissionControl.Spa/src/components/SubjectCard.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/components/SubjectCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { VerdictBadge, type Verdict } from "./VerdictBadge";
 import { Sparkline } from "./charts/Sparkline";
 

--- a/src/AgentEval.MissionControl.Spa/src/main.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 import { App } from "./App";
 import "./index.css";
 

--- a/src/AgentEval.MissionControl.Spa/src/pages/ComplianceListPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/ComplianceListPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ShieldCheck } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/ComplianceMatrixPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/ComplianceMatrixPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ShieldAlert, ShieldCheck } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/EvaluatorDetailPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/EvaluatorDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink, FileCode } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/EvaluatorsPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/EvaluatorsPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { gqlRequest } from "@/lib/graphql-client";
 import { queryKeys } from "@/lib/keys";

--- a/src/AgentEval.MissionControl.Spa/src/pages/EvidenceDetailPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/EvidenceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink, ShieldAlert, ShieldCheck } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/NotFoundPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/NotFoundPage.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router";
 import { Compass, Home, ListChecks, ShieldCheck } from "lucide-react";
 
 // Plan-08 portal-review A23 (T2.2, 2026-05-25): when a user lands on a bad

--- a/src/AgentEval.MissionControl.Spa/src/pages/RunDetailPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/RunDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/RunsListPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/RunsListPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { gqlRequest } from "@/lib/graphql-client";
 import { queryKeys } from "@/lib/keys";

--- a/src/AgentEval.MissionControl.Spa/src/pages/ScenarioTreePage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/ScenarioTreePage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/SubjectDetailPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/SubjectDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { gqlRequest } from "@/lib/graphql-client";

--- a/src/AgentEval.MissionControl.Spa/src/pages/TraceWaterfallPage.tsx
+++ b/src/AgentEval.MissionControl.Spa/src/pages/TraceWaterfallPage.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 AgentEval Contributors
 // Licensed under the MIT License.
 
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import {


### PR DESCRIPTION
Resolves **Dependabot alert #9** (high severity: RSC-Mode CSRF bypass, vulnerable range `>= 7.12.0, < 8.3.0`).

react-router v8 absorbed `react-router-dom`, so the dependency moves to `react-router@^8.3.0` and the 15 SPA files import from `react-router` directly. Every API the SPA uses (`BrowserRouter`, `Link`, `NavLink`, `Outlet`, `Route`, `Routes`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams`) is unchanged in v8 — the diff is import paths + the dependency swap + lockfile.

**Exploitability note:** the SPA is a client-side Vite app and does not use RSC mode, so the vulnerable path was not reachable here; this clears the advisory properly rather than dismissing it.

**Validated:** `npm install` reports 0 vulnerabilities; `tsc -b && vite build` passes; `react-router-dom` has zero remaining references in the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)