### PR TITLE
fix(release): stamp the release version into the assemblies, and gate on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Pack umbrella library
-      run: dotnet pack src/AgentEval/AgentEval.csproj --configuration Release --no-restore -p:PackageVersion=${{ steps.version.outputs.version }} --output ./nupkgs
+      run: dotnet pack src/AgentEval/AgentEval.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }} -p:PackageVersion=${{ steps.version.outputs.version }} --output ./nupkgs
 
     # T1.5 (v1.1): also pack the CLI as a dotnet-tool nupkg so users can
     # `dotnet tool install --global AgentEval.Cli --prerelease`. Multi-TFM
@@ -68,7 +68,39 @@ jobs:
     # AgentEval.Cli.csproj; the dotnet-tool installer picks the highest
     # compatible runtime, so net10 hosts get net10 + net8 hosts get net8).
     - name: Pack CLI as dotnet tool
-      run: dotnet pack src/AgentEval.Cli/AgentEval.Cli.csproj --configuration Release --no-restore -p:PackageVersion=${{ steps.version.outputs.version }} --output ./nupkgs
+      run: dotnet pack src/AgentEval.Cli/AgentEval.Cli.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }} -p:PackageVersion=${{ steps.version.outputs.version }} --output ./nupkgs
+
+    # Between the pack and the push, because a NuGet package cannot be recalled. 0.23.0-beta
+    # shipped assemblies stamped 0.16.0.0: the pack passed -p:PackageVersion, which moves the
+    # nupkg's version and nothing else, while AssemblyVersion / FileVersion /
+    # InformationalVersion all derive from -p:Version. `AgentEvalVersion` in result provenance
+    # reads Assembly.GetName().Version, so every result that release produced carried a version
+    # that had not been current since 0.16 — and nothing failed, because nothing looked.
+    - name: Verify the packed assemblies carry the release version
+      shell: pwsh
+      run: |
+        $expected = '${{ steps.version.outputs.version }}'
+        $numeric  = ($expected -split '-')[0]
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $bad = @()
+        foreach ($pkg in Get-ChildItem ./nupkgs/*.nupkg) {
+          $dir = Join-Path $env:RUNNER_TEMP ("x_" + $pkg.BaseName)
+          Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+          [IO.Compression.ZipFile]::ExtractToDirectory($pkg.FullName, $dir)
+          foreach ($dll in Get-ChildItem $dir -Recurse -Filter 'AgentEval*.dll') {
+            $info = [Diagnostics.FileVersionInfo]::GetVersionInfo($dll.FullName).ProductVersion
+            $asm  = [Reflection.AssemblyName]::GetAssemblyName($dll.FullName).Version.ToString()
+            if (-not $info.StartsWith($expected) -or -not $asm.StartsWith($numeric)) {
+              $bad += "$($pkg.Name)/$($dll.Name): AssemblyVersion=$asm Informational=$info"
+            }
+          }
+        }
+        if ($bad) {
+          Write-Host "::error::Packed assemblies do not carry $expected. Nothing was pushed."
+          $bad | Select-Object -Unique | ForEach-Object { Write-Host "  $_" }
+          exit 1
+        }
+        Write-Host "All packed AgentEval assemblies report $expected."
 
     - name: Push to NuGet
       run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Result provenance stamped `AgentEvalVersion: 0.16.0-beta` in every release since 0.16.**
+  The release workflow passed `-p:PackageVersion`, which sets the nupkg's version and nothing
+  else; `AssemblyVersion`, `FileVersion` and `InformationalVersion` all derive from `-p:Version`.
+  `AgentEvalVersion` reads `Assembly.GetName().Version`, so 0.23.0-beta shipped assemblies
+  reporting `0.16.0.0` and every result it produced carries a version that has not been current
+  since 0.16. Found by the consuming project's consumption pass, not by us.
+
+  The pack now sets both properties, and a **pre-push gate** unpacks each `.nupkg` and refuses to
+  publish if any `AgentEval*.dll` disagrees with the release version — placed between pack and
+  push, because a NuGet package cannot be recalled. Takes effect from the next release; packages
+  already published cannot be corrected in place.
+
 ## [0.23.0-beta] - 2026-08-15
 
 **TypedMemEval corpus revision v3, and V7 — adversarial separability.** The consuming project's

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,7 +31,14 @@
          AgentEval.Cli dotnet tool are built from one source tree and released together on one
          tag, so they version in lockstep. Keeping the number here (and nowhere else) makes that
          parity structural — there is no second number to drift. CI overrides this for releases
-         via `dotnet pack -p:PackageVersion=<tag>`. -->
+         via `dotnet pack -p:Version=<tag> -p:PackageVersion=<tag>`.
+
+         BOTH properties, and the first one is the one that was missing. `PackageVersion` sets the
+         nupkg's version and nothing else; AssemblyVersion, FileVersion and InformationalVersion all
+         derive from `Version`. Overriding only PackageVersion shipped 0.23.0-beta as a package
+         whose assemblies reported 0.16.0.0 — and `AgentEvalVersion` in result provenance reads
+         Assembly.GetName().Version, so every result that release produced was stamped with a
+         version that had not been current since 0.16. The consuming project caught it. -->
     <Version>0.16.0-beta</Version>
 
     <!-- Package icon for NuGet -->

--- a/docs/adr/026-typedmemeval-benchmark-family.md
+++ b/docs/adr/026-typedmemeval-benchmark-family.md
@@ -1006,14 +1006,27 @@ Two things V7 does **not** refuse, both stated rather than quietly excluded:
 position separates gold perfectly and is meant to — the construct is how far back the memory sits.
 Declared as an exemption with a reason rather than accommodated by raising a threshold.
 
-**Episodic attribution: a varied-template regeneration is planned for corpus revision v3**, not
-permanent by design. The shape currently emits its statements from a fixed frame, so a system
-storing no speaker label can recover the answer from the framing rather than from memory, and its
-numbers are a floor rather than speaker-attribution accuracy. That is a corpus fix of the same kind
-as the shape-parity pass above, and it ships with the next corpus revision (v3) — the same one that
-addresses phrase recurrence, since both need richer generated language and neither is worth a corpus
-regeneration on its own. The v2 revision in this release is what the separability finding forced;
-v3 is what the two remaining known limitations are queued behind.
+**Episodic attribution: a varied-template regeneration was planned for corpus revision v3, and v3
+shipped without it.** Recorded here as a slip rather than quietly restated, because a plan that
+moves each time the revision moves is indistinguishable from "later". What happened: v3 was forced
+by the separability finding and scoped to shape parity, the attribution framing was never touched,
+and nothing failed when it was not — the commitment lived only in this paragraph.
+
+**The decision, dated: it ships in corpus v4, and the mechanism is named so the scope cannot drift
+again.** Today all fifteen attribution questions share one frame, so a system storing no speaker
+label recovers the answer from the framing rather than from memory. The fix is to draw the frame
+per question from a bank, while keeping it byte-identical *within* a pair — which is what the
+shape's design actually requires, and is a much smaller change than it has been treated as. It does
+**not** depend on the by-construction redesign in §14; it is independent and can land first.
+
+Until then the shape's numbers are a floor and are published as one. Two things now hold the
+commitment rather than this paragraph: the getting-started guide states the limitation against the
+*shipped* revision rather than a future one, and V1/V3 shortfalls in this shape are called out by
+name in the release notes, so the floor is visible in the numbers a reader actually sees.
+
+Phrase recurrence, which §13 originally queued behind the same revision, no longer needs one: both
+directions are refused outright at the 0.75 bar as of v3 (§14), so it is a gate rather than a
+promise.
 
 ### 14. Corpus v3 — the separability check was measuring the wrong thing (round-3 review)
 


### PR DESCRIPTION
`AgentEvalVersion` in result provenance reads `Assembly.GetName().Version`. The release workflow passed only `-p:PackageVersion`, which sets the nupkg's version and nothing else — `AssemblyVersion`, `FileVersion` and `InformationalVersion` all derive from `-p:Version`.

**0.23.0-beta shipped assemblies reporting `0.16.0.0`.** Verified against the published package:

```
AgentEval.Core.dll    AssemblyVersion=0.16.0.0  Informational=0.16.0-beta+81e4b5b
AgentEval.Memory.dll  AssemblyVersion=0.16.0.0  Informational=0.16.0-beta+81e4b5b
```

Found by the consuming project's consumption pass. Nothing in our pipeline would have caught it — the package version was correct everywhere anyone was looking.

**Fix:** pack sets both properties (verified locally: `AssemblyVersion=0.23.1.0`), plus a pre-push gate that unpacks each `.nupkg` and fails the release if any `AgentEval*.dll` disagrees with the tag. Between pack and push, because a package cannot be recalled.

Also settles prompt 07 §1.6: ADR-026 §13 promised the Episodic attribution regeneration in v3, v3 shipped without it, and the slip is now recorded rather than quietly restated. Dated to v4 with the mechanism named.

Takes effect from the next release; 0.23.0-beta cannot be corrected in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ