### PR TITLE
TypedMemEval: the empty-rate gate understated every arm it measured (0.28.0-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attribution rather than reimplementing it, because two copies of that rule is how the first one
   drifted.
 
+- **A LongMemEval CLI test failed on a random temp path rather than on the thing it guards.**
+  `RunAsync_MixedOutcomes_UsesScoredDenominatorAndCorrectPercentRendering` asserted that `"5000"`
+  appears nowhere in the console transcript — a guard against a mis-scaled percent rendering `50.0%`
+  as `5000`. The transcript also prints the workspace path, which is a randomly named temp
+  directory, and a CI run that drew `...96f2e438390616129bc35000e...` failed on the hex coincidence.
+  The substring is now checked on the accuracy line, where the rendering actually happens.
+
 ## [0.27.0-beta] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0-beta] - 2026-08-22
+
+### Fixed
+
+- **The per-arm empty-rate instrument shipped in 0.27.0-beta was measuring itself wrong, and
+  understated the defect it exists to expose.** Two mistakes, one release apart in discovery but
+  both present at publication.
+
+  It parsed an arm token as `v` followed by digits, then **fell back to `"v1"` when that failed**.
+  `v9strip` is a real arm, not a malformed `v9`, so all 700 of its calls were filed under v1: v1's
+  denominator read **920 against a true 220**, v9strip's empties were counted in v1's numerator, and
+  **v9strip itself had no row and therefore no ceiling** — it cleared the gate by not being in it.
+  Second, **judge grades were pooled into each arm's denominator** alongside probe answers, which
+  are the population the ceiling is about.
+
+  Corrected, probe-answers only — every affected arm was **understated, never overstated**:
+
+  | arm | published 0.27.0-beta | corrected |
+  |---|---|---|
+  | v3 | 258/387 (66.7%) | **258/330 (78.2%)** |
+  | v6 | 182/861 (21.1%) | **182/675 (27.0%)** |
+  | v9 | 8/212 (3.8%) | **8/110 (7.3%)** |
+  | v1 | 4/920 (0.4%) | **0/110 (0.0%)** |
+  | v9strip | *not measured* | **4/352 (1.1%)** |
+
+  **V9's true rate breaches the 5% ceiling and always did** — pooling 102 judge grades into 110
+  probe calls is the only reason it read as passing. It is now recorded as a ratchet entry, visible
+  and able only to shrink, rather than silently clearing a bar it does not clear. Its direction is
+  conservative (silence scores as a failure on V9), so the published retrieval ceiling remains a
+  lower bound. Judge grades are healthy at **0 empty of 1246**, so the pooling diluted the rates
+  without changing any conclusion: **V3/V6 remain uncitable pending re-run**, by a slightly larger
+  margin than first stated.
+
+  The gate now asserts the recorded arm set **equals** a C# list rather than checking only that
+  present arms are under their ceilings — the same pass-by-absence defence the V7 separability test
+  uses, and the fix for an arm going unmonitored. An unattributable key becomes `unknown`, which the
+  gate fails on, instead of borrowing a real arm's identity. Six attribution cases were added to the
+  runner's CI self-test. Verified by falsification: removing an arm, introducing an `unknown`
+  bucket, and regressing a rate each fail the gate.
+
+  Corpus **bytes are untouched** — only the metadata stamp changed, so every `probed_corpus_sha256`
+  still matches and no probe re-run was required. Recomputed offline from the same call cache via
+  `run_typedmemeval_probes.py --restamp-empty-rates-from-cache`, which reuses the runner's own
+  attribution rather than reimplementing it, because two copies of that rule is how the first one
+  drifted.
+
 ## [0.27.0-beta] - 2026-08-22
 
 ### Added
@@ -4335,7 +4381,9 @@ This release marks the transition from alpha to beta. The framework is now featu
 - `AgentEval.Tracing` (OTel + run artifacts) - planned
 - `AgentEval.Studio` (workflow visualizer / time-travel UI) - future
 
-[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.26.0-beta...HEAD
+[Unreleased]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.28.0-beta...HEAD
+[0.28.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.27.0-beta...v0.28.0-beta
+[0.27.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.26.0-beta...v0.27.0-beta
 [0.26.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.25.0-beta...v0.26.0-beta
 [0.25.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.24.0-beta...v0.25.0-beta
 [0.24.0-beta]: https://github.com/AgentEvalHQ/AgentEval/compare/v0.23.0-beta...v0.24.0-beta

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
          whose assemblies reported 0.16.0.0 — and `AgentEvalVersion` in result provenance reads
          Assembly.GetName().Version, so every result that release produced was stamped with a
          version that had not been current since 0.16. The consuming project caught it. -->
-    <Version>0.27.0-beta</Version>
+    <Version>0.28.0-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>

--- a/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
@@ -1408,53 +1408,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
@@ -1435,53 +1435,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
@@ -1327,53 +1327,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
@@ -1317,53 +1317,88 @@
       "reading": "V1 is a perfect selector, V8 is unlimited context, V9 is a plain BM25 top-K selector. V1 - V9 is what better retrieval can buy. V1 - V8 is NOT a headroom number -- it only asks whether distractors confuse a reader who already has everything."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
@@ -1345,53 +1345,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
@@ -1312,53 +1312,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
@@ -1476,53 +1476,88 @@
       "reading": "A failure with no captured answer is not a wrong answer. These questions are counted as failures in the published pass counts, so the arm's figure is a LOWER BOUND on what the answer model achieves and the shortfall is partly silence rather than error. Whether an empty response is a refusal, a provider filter or a capture fault is not decidable from this record; it is disclosed rather than corrected because excluding it would substitute one unexamined assumption for another."
     },
     "empty_completion_disclosure": {
-      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm; not necessarily the full historical run",
+      "measured_over": "the 4033 cached reference-model calls present in this tree, attributed by cache-key arm and split into probe answers and judge grades; not necessarily the full historical run",
       "empty_completion_rate": {
-        "v1": "0/220",
-        "v2": "0/1436",
-        "v3": "258/387 (66.7%)",
-        "v6": "182/861 (21.1%)",
-        "v8": "3/217",
-        "v9": "8/212"
+        "v1": "0/110",
+        "v2": "0/1100",
+        "v3": "258/330 (78.2%)",
+        "v6": "182/675 (27.0%)",
+        "v8": "3/110 (2.7%)",
+        "v9": "8/110 (7.3%)",
+        "v9strip": "4/352 (1.1%)"
       },
       "direction": {
         "v8_v9": "CONSERVATIVE. An empty completion cannot match gold, so it scores as a failure and the published pass count is a lower bound.",
         "v3_v6": "ANTI-CONSERVATIVE, and this is the serious one. V3 passes when an ablated context FAILS to reproduce the answer, and an empty completion cannot reproduce anything, so silence scores as a PASS. V6 has the same shape. Two thirds of V3's calls are empty, so its 50/50 results certify less than they appear to."
       },
-      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer."
+      "reading": "An empty completion is not evidence of anything, but the probe arms treated it as evidence in both directions at once. The likely cause is a reasoning deployment spending the completion budget on reasoning tokens before emitting content -- V2, whose prompt carries no session context, has a zero rate, while V3 and V6, which ask the model to work hard over a context that no longer contains the answer, have the highest. V3 AND V6 MUST BE RE-RUN BEFORE THEY ARE CITED AGAIN. V1, V2, V7 are unaffected. The capture path now retries a length-truncated empty at a larger budget, records finish_reason, filter verdict and usage for any that remain, and no longer serves an empty cache entry as a purchased answer.",
+      "correction": "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 `v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and `v9strip` itself got no bucket and so no ceiling; judge grades were also pooled into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at 0/1246 empty, so the pooling diluted the rates without changing their direction. The V3/V6 re-run requirement is unchanged and slightly larger than first stated."
     },
     "empty_rate_by_arm": {
       "v1": {
-        "calls": 920,
-        "empty": 4,
-        "rate": 0.0043
+        "population": "probe_answers",
+        "calls": 110,
+        "empty": 0,
+        "rate": 0.0,
+        "judge_calls": 110,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v2": {
-        "calls": 1436,
+        "population": "probe_answers",
+        "calls": 1100,
         "empty": 0,
-        "rate": 0.0
+        "rate": 0.0,
+        "judge_calls": 336,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v3": {
-        "calls": 387,
+        "population": "probe_answers",
+        "calls": 330,
         "empty": 258,
-        "rate": 0.6667
+        "rate": 0.7818,
+        "judge_calls": 57,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v6": {
-        "calls": 861,
+        "population": "probe_answers",
+        "calls": 675,
         "empty": 182,
-        "rate": 0.2114
+        "rate": 0.2696,
+        "judge_calls": 186,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v8": {
-        "calls": 217,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 3,
-        "rate": 0.0138
+        "rate": 0.0273,
+        "judge_calls": 107,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       },
       "v9": {
-        "calls": 212,
+        "population": "probe_answers",
+        "calls": 110,
         "empty": 8,
-        "rate": 0.0377
+        "rate": 0.0727,
+        "judge_calls": 102,
+        "judge_empty": 0,
+        "judge_rate": 0.0
+      },
+      "v9strip": {
+        "population": "probe_answers",
+        "calls": 352,
+        "empty": 4,
+        "rate": 0.0114,
+        "judge_calls": 348,
+        "judge_empty": 0,
+        "judge_rate": 0.0
       }
     },
-    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache; per-corpus attribution arrives with the next full run"
+    "empty_rate_scope": "family-wide, derived from the shared reference-model call cache and split by population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried alongside rather than pooled into them. Per-corpus attribution arrives with the next full run."
   }
 }

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
@@ -521,9 +521,13 @@ public sealed class TypedMemEvalCorpusTests
     // A probe arm that returns nothing is not measuring the model, and both directions of that
     // mistake have already shipped. V8/V9 counted silence as a wrong answer, which understated a
     // ceiling. V3 and V6 pass when an ablated context FAILS to reproduce the answer, so silence
-    // scores as a PASS and certifies validity the evidence does not support -- 258 of V3's 387
-    // calls were empty. This gate exists so the class dies at authoring time rather than being
-    // rediscovered forensically, which is how both instances were found.
+    // scores as a PASS and certifies validity the evidence does not support -- 258 of V3's 330
+    // probe answers were empty. This gate exists so the class dies at authoring time rather than
+    // being rediscovered forensically, which is how both instances were found.
+    //
+    // The rate is measured over PROBE ANSWERS. Judge grades are a separate population -- 0 of 1246
+    // empty, i.e. healthy -- and pooling them into the denominator is what made this instrument
+    // understate itself on its own first release.
     [Theory]
     [MemberData(nameof(AllVerticals))]
     public void Metadata_KeepsEveryProbeArmBelowItsEmptyResponseCeiling(TypedMemEvalVertical vertical)
@@ -533,8 +537,29 @@ public sealed class TypedMemEvalCorpusTests
             probes.TryGetProperty("empty_rate_by_arm", out var byArm),
             $"{vertical} carries no empty-rate record. Re-run tools/run_typedmemeval_probes.py.");
 
+        // Equality against a C# list, not "every arm present is under its ceiling". The first cut
+        // of this gate checked only the latter, and v9strip -- a real arm -- produced no bucket at
+        // all because the tally parsed an arm token as `v` plus digits and quietly filed its 700
+        // calls under v1. An arm with no row cleared the ceiling by not being there, which is the
+        // pass-by-absence shape this suite has been bitten by before (see the V7 refused-features
+        // check, which is written this way for the same reason). Adding an arm to the runner now
+        // fails here until it is named and monitored.
+        var recorded = byArm.EnumerateObject().Select(a => a.Name).ToHashSet(StringComparer.Ordinal);
+        Assert.False(
+            recorded.Contains("unknown"),
+            $"{vertical} has probe calls that could not be attributed to a named arm. An arm " +
+            "nobody can name is an arm nobody is watching — fix _arm_and_kind, do not ignore it.");
+        Assert.Equal(
+            ExpectedProbeArms.OrderBy(n => n, StringComparer.Ordinal),
+            recorded.OrderBy(n => n, StringComparer.Ordinal));
+
         foreach (var arm in byArm.EnumerateObject())
         {
+            // `rate` is PROBE ANSWERS only. Judge grades ride alongside in judge_* and are
+            // deliberately not pooled in: doing so put 1246 healthy grades into the denominators
+            // and understated every affected arm (v3 78.2% read as 66.7%, v9 7.3% as 3.8%).
+            Assert.Equal("probe_answers", arm.Value.GetProperty("population").GetString());
+
             if (!arm.Value.TryGetProperty("rate", out var rateNode) ||
                 rateNode.ValueKind == JsonValueKind.Null)
             {
@@ -568,9 +593,28 @@ public sealed class TypedMemEvalCorpusTests
     /// </summary>
     private static readonly Dictionary<string, double> KnownEmptyRateRatchet = new(StringComparer.Ordinal)
     {
-        ["v3"] = 0.6667,
-        ["v6"] = 0.2114,
+        // Probe-answer rates. These are HIGHER than the 0.6667 / 0.2114 published in 0.27.0-beta,
+        // and nothing got worse between the two: that cut pooled judge grades into the denominator
+        // and mis-filed 700 v9strip calls under v1, so every affected arm was understated. The
+        // numbers moved because the instrument was corrected, and the ratchet firing on that move
+        // is the ratchet working.
+        ["v3"] = 0.7818,
+        ["v6"] = 0.2696,
+
+        // v9 is a ceiling BREACH, not a waiver. Its true probe-answer rate has always been above
+        // EmptyRateCeiling; pooling 102 judge grades into 110 probe calls is the only reason it
+        // ever read as passing. Recorded here so it stays visible and can only shrink, rather than
+        // quietly clearing a bar it does not clear. Direction is conservative -- silence scores as
+        // a failure on V9, so the published retrieval ceiling is a lower bound.
+        ["v9"] = 0.0727,
     };
+
+    /// <summary>
+    /// Every arm the probe runner is expected to tally. Named here rather than inferred from the
+    /// record, so an arm that stops reporting fails instead of passing by absence.
+    /// </summary>
+    private static readonly string[] ExpectedProbeArms =
+        ["v1", "v2", "v3", "v6", "v8", "v9", "v9strip"];
 
     private const double SeparabilityMaxAuc = 0.75;
 

--- a/tests/AgentEval.Tests/Cli/BenchLongMemEvalCommandTests.cs
+++ b/tests/AgentEval.Tests/Cli/BenchLongMemEvalCommandTests.cs
@@ -40,7 +40,17 @@ public sealed class BenchLongMemEvalCommandTests
         Assert.Contains("Overall accuracy:        50.0%", invocation.Output);
         Assert.Contains("(1/2 scored, 3 selected)", invocation.Output);
         Assert.Contains("Inconclusive judgments:  1", invocation.Output);
-        Assert.DoesNotContain("5000", invocation.Output);
+
+        // Scoped to the accuracy line rather than the whole transcript. The guard is against a
+        // mis-scaled percent -- 50.0% rendering as "5000" -- but the transcript also prints the
+        // workspace path, which is a randomly named temp directory. A run that drew
+        // "...96f2e438390616129bc35000e..." failed this assertion on a hex coincidence rather than
+        // on a rendering bug, so the substring is now checked where the rendering actually happens.
+        var accuracyLine = Assert.Single(
+            invocation.Output
+                .Split('\n')
+                .Where(line => line.Contains("Overall accuracy:", StringComparison.Ordinal)));
+        Assert.DoesNotContain("5000", accuracyLine);
 
         var runDirectory = Assert.Single(fixture.RunDirectories());
         var summary = JsonDocument.Parse(

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -143,15 +143,54 @@ def load_cache() -> None:
 
 
 #: Per-arm call and empty tallies, so the empty rate is a published, gateable statistic rather
-#: than something reconstructed forensically from a cache after the fact.
+#: than something reconstructed forensically from a cache after the fact. Keyed by
+#: (arm, population): a judge grade and a probe answer are different populations with different
+#: consequences, and pooling them diluted every denominator in the first cut of this instrument.
 _arm_calls: Counter = Counter()
 _arm_empty: Counter = Counter()
 
+#: An arm token is `v`, digits, and an OPTIONAL SUFFIX -- `v9strip` is a real arm, not a malformed
+#: `v9`. The first cut matched only `v\d` and fell back to `"v1"` for anything else, which filed
+#: all 700 v9strip calls under v1: v1's denominator went 220 -> 920, v9strip's empties landed in
+#: v1's numerator, and v9strip itself got no bucket and therefore no ceiling.
+#:
+#: There is deliberately NO fallback to a real arm. An unattributable key becomes "unknown", which
+#: the corpus gate fails on, because an arm nobody can name is an arm nobody is watching.
+_ARM_TOKEN = re.compile("^v[0-9]+[a-z]*$")
 
-def _arm_of(cache_key: str) -> str:
-    """The probe arm a cache key belongs to, e.g. 'v3' from '<question>:v3:2'."""
-    match = re.search(":(v" + chr(92) + "d)(?::|$)", cache_key)
-    return match.group(1) if match else "v1"
+
+def _arm_and_kind(cache_key: str) -> tuple[str, str]:
+    """The probe arm and population a cache key belongs to.
+
+    Keys are ``<question>:<arm>[:<index>...][:judge]`` -- e.g. ``a1b2:v6:3:0`` or
+    ``a1b2:v9strip:judge``. The population matters because the two failures are not the same
+    event: an empty JUDGE grade is a missing grade, while an empty PROBE answer is a missing
+    answer that V3 and V6 then score as a pass.
+    """
+    parts = cache_key.split(":")
+    arm = parts[1] if len(parts) > 1 else ""
+    kind = "judge" if len(parts) > 2 and parts[-1] == "judge" else "probe"
+    return (arm if _ARM_TOKEN.match(arm) else "unknown"), kind
+
+
+def _arm_row(arm: str) -> dict:
+    """One published row per arm, probe answers and judge grades kept apart.
+
+    ``calls``/``empty``/``rate`` describe PROBE ANSWERS only. That is the population the ceiling
+    is about, and pooling judge grades into it is precisely what let V9's true 7.3% read as 3.8%
+    and V3's 78.2% read as 66.7% -- every affected arm was understated, never overstated.
+    """
+    probe, judge = _arm_calls[(arm, "probe")], _arm_calls[(arm, "judge")]
+    probe_empty, judge_empty = _arm_empty[(arm, "probe")], _arm_empty[(arm, "judge")]
+    return {
+        "population": "probe_answers",
+        "calls": probe,
+        "empty": probe_empty,
+        "rate": round(probe_empty / probe, 4) if probe else None,
+        "judge_calls": judge,
+        "judge_empty": judge_empty,
+        "judge_rate": round(judge_empty / judge, 4) if judge else None,
+    }
 
 
 #: Hard ceiling for the retry above. A reasoning deployment can spend an arbitrary amount on
@@ -177,7 +216,7 @@ def complete(prompt: str, *, cache_key: str, max_tokens: int = 900) -> str:
         # and the length-retry above never gets the chance to fire.
         if _cache.get(cache_key):
             _stats["cache_hit"] += 1
-            _arm_calls[_arm_of(cache_key)] += 1
+            _arm_calls[_arm_and_kind(cache_key)] += 1
             return _cache[cache_key]
         if cache_key in _cache:
             _stats["empty_cache_entry_repaid"] += 1
@@ -200,7 +239,7 @@ def complete(prompt: str, *, cache_key: str, max_tokens: int = 900) -> str:
             )
             with urllib.request.urlopen(request, timeout=180) as response:
                 payload = json.loads(response.read().decode("utf-8"))
-            _arm = _arm_of(cache_key)
+            _arm = _arm_and_kind(cache_key)
             _arm_calls[_arm] += 1
             choice = payload["choices"][0]
             text = (choice["message"].get("content") or "").strip()
@@ -811,12 +850,12 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
             "by_cache_key": dict(sorted(_empty_reasons.items())),
         } if _empty_reasons or _stats["retried_for_length"] else {"count": 0},
         # Published and gateable, per a consumer's ask, so this class dies at authoring time
-        # instead of being rediscovered forensically. The V2 0/1436 against V3 258/387 spread shows
-        # the statistic discriminates cleanly between an arm that is fine and one that is not.
+        # instead of being rediscovered forensically. The V2 0/1100 against V3 258/330 spread shows
+        # the statistic discriminates cleanly between an arm that is fine and one that is not --
+        # but only once judge grades are kept out of the denominator, which is the correction here.
         "empty_rate_by_arm": {
-            arm: {"calls": _arm_calls[arm], "empty": _arm_empty[arm],
-                  "rate": round(_arm_empty[arm] / _arm_calls[arm], 4) if _arm_calls[arm] else None}
-            for arm in sorted(set(_arm_calls) | set(_arm_empty))
+            arm: _arm_row(arm)
+            for arm in sorted({a for a, _kind in set(_arm_calls) | set(_arm_empty)})
         },
         "v8_full_haystack": _interference(records),
         "v9_reference_retrieval": _retrieval_headroom(records),
@@ -927,11 +966,107 @@ def self_test() -> None:
     bare = "No, not yet."
     check("negative gold with no content is undecidable", _v3_decidable(bare, known), False)
 
+    # --- Arm attribution. Also a real shipped defect, not a hypothetical. ---------------------
+    # 0.27.0-beta matched an arm token as `v` plus digits and fell back to "v1" on no match, so
+    # every `v9strip` key -- a real arm, 700 calls -- was filed under v1. The published effect:
+    # v1's denominator read 920 against a true 220, v9strip's empties were counted in v1's
+    # numerator, and v9strip had no row of its own and therefore no ceiling to breach.
+    check("suffixed arm keeps its own identity", _arm_and_kind("a1:v9strip"), ("v9strip", "probe"))
+    check("suffixed arm's judge call is not a probe answer",
+          _arm_and_kind("a1:v9strip:judge"), ("v9strip", "judge"))
+
+    # Judge grades are a separate population. Pooling them into an arm's denominator understated
+    # every affected arm: v3's 258 empties over 330 probe answers (78.2%) read as 258/387 (66.7%),
+    # and v9's 7.3% read as 3.8% -- under a 5% ceiling it should never have cleared.
+    check("indexed probe answer", _arm_and_kind("a1:v6:3:0"), ("v6", "probe"))
+    check("indexed judge grade", _arm_and_kind("a1:v6:3:0:judge"), ("v6", "judge"))
+
+    # No fallback to a real arm. An unattributable key must be visibly unattributed, because the
+    # corpus gate fails on "unknown" -- silently crediting it to v1 is what hid this for a release.
+    check("unattributable key does not borrow a real arm",
+          _arm_and_kind("garbage")[0], "unknown")
+    check("malformed arm token does not borrow a real arm",
+          _arm_and_kind("a1:vX:judge")[0], "unknown")
+
     if failures:
         for f in failures:
             print(f"self-test FAIL  {f}")
         raise SystemExit(1)
-    print("self-test OK  (10 evidence-screen cases)")
+    print("self-test OK  (10 evidence-screen cases, 6 arm-attribution cases)")
+
+
+def restamp_empty_rates_from_cache(verticals: list[str]) -> None:
+    """Recompute the per-arm empty rates from the shared call cache. Makes no API calls.
+
+    The rates are a property of the cached calls, not of a fresh run, so a mis-attribution in the
+    tallying can be corrected without re-probing -- and must be, because the wrong figures shipped
+    inside seven corpora in 0.27.0-beta. This deliberately reuses `_arm_and_kind` rather than
+    reimplementing the parse: two copies of an attribution rule is how the first one drifted.
+
+    Only the empty-rate fields are touched. Everything else in the probe record was measured by a
+    run and is not this tool's to rewrite.
+    """
+    load_cache()
+    if not _cache:
+        raise SystemExit(f"no call cache at {CACHE_PATH}; nothing to recompute")
+
+    _arm_calls.clear()
+    _arm_empty.clear()
+    for cache_key, value in _cache.items():
+        bucket = _arm_and_kind(cache_key)
+        _arm_calls[bucket] += 1
+        if not (value or "").strip():
+            _arm_empty[bucket] += 1
+
+    arms = sorted({arm for arm, _kind in set(_arm_calls) | set(_arm_empty)})
+    by_arm = {arm: _arm_row(arm) for arm in arms}
+    rate_text = {
+        arm: (f"{row['empty']}/{row['calls']}"
+              + (f" ({row['rate']:.1%})" if row["rate"] else ""))
+        for arm, row in by_arm.items()
+    }
+    for arm in arms:
+        row = by_arm[arm]
+        print(f"  {arm:9s} probe {row['empty']:4d}/{row['calls']:<5d} "
+              f"judge {row['judge_empty']:4d}/{row['judge_calls']:<5d}")
+
+    for vertical in verticals:
+        corpus_id = f"agenteval-typedmemeval-{vertical}-{tmc.CORPUS_REVISION}"
+        meta_path = tmc.DATA_ROOT / vertical / f"{corpus_id}.meta.json"
+        metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+        probes = metadata.get("probes")
+        if not probes:
+            print(f"{vertical}: no probe record, skipped", flush=True)
+            continue
+
+        probes["empty_rate_by_arm"] = by_arm
+        probes["empty_rate_scope"] = (
+            "family-wide, derived from the shared reference-model call cache and split by "
+            "population: `calls`/`empty`/`rate` are PROBE ANSWERS, and judge grades are carried "
+            "alongside rather than pooled into them. Per-corpus attribution arrives with the next "
+            "full run.")
+
+        disclosure = probes.get("empty_completion_disclosure")
+        if isinstance(disclosure, dict):
+            disclosure["measured_over"] = (
+                f"the {len(_cache)} cached reference-model calls present in this tree, attributed "
+                "by cache-key arm and split into probe answers and judge grades; not necessarily "
+                "the full historical run")
+            disclosure["empty_completion_rate"] = rate_text
+            disclosure["correction"] = (
+                "SUPERSEDES the figures published in 0.27.0-beta, which were UNDERSTATED in every "
+                "affected arm. That cut parsed an arm token as `v` plus digits only, so the 700 "
+                "`v9strip` calls fell through a fallback into v1 (denominator 220 -> 920) and "
+                "`v9strip` itself got no bucket and so no ceiling; judge grades were also pooled "
+                "into each arm's denominator. Corrected, probe-answer only: v3 66.7% -> 78.2%, "
+                "v6 21.1% -> 27.0%, v9 3.8% -> 7.3%, v1 0.4% -> 0.0%. Judge grades are healthy at "
+                "0/1246 empty, so the pooling diluted the rates without changing their direction. "
+                "The V3/V6 re-run requirement is unchanged and slightly larger than first stated.")
+        metadata["probes"] = probes
+        meta_path.write_text(
+            json.dumps(metadata, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8", newline="\n")
+        print(f"{vertical}: empty-rate stamp corrected", flush=True)
 
 
 def main() -> None:
@@ -941,10 +1076,17 @@ def main() -> None:
     parser.add_argument("--workers", type=int, default=8)
     parser.add_argument("--self-test", action="store_true",
                         help="check the evidence screen against known-bad cases; needs no credentials")
+    parser.add_argument("--restamp-empty-rates-from-cache", action="store_true",
+                        help="recompute empty_rate_by_arm from the shared call cache and rewrite "
+                             "that field alone in every corpus; makes no API calls")
     args = parser.parse_args()
 
     if args.self_test:
         self_test()
+        return
+
+    if args.restamp_empty_rates_from_cache:
+        restamp_empty_rates_from_cache(args.verticals or list(tmc.VERTICALS))
         return
 
     load_cache()


### PR DESCRIPTION
## What this fixes

`0.27.0-beta` shipped a per-arm empty-response statistic so that *"a reasoning deployment burned its completion budget"* would fail at authoring time instead of being discovered forensically. **The instrument itself was mis-measuring**, in two ways, and both understated the defect it exists to expose.

**1. A fallback that borrowed a real arm's identity.** Arm tokens were parsed as `v` + digits, with `return "v1"` on no match. `v9strip` is a real arm, not a malformed `v9`, so its **700 calls were filed under v1**: v1's denominator read 920 against a true 220, v9strip's empties landed in v1's numerator, and **v9strip had no row and therefore no ceiling** — it cleared the gate by not being in the gate.

**2. Judge grades pooled into probe denominators.** Judge calls are a different population — and a healthy one (**0 empty of 1246**) — so including them mechanically dragged every rate down.

## Corrected figures (probe answers only)

| arm | published in 0.27.0-beta | corrected |
|---|---|---|
| v3 | 258/387 (66.7%) | **258/330 (78.2%)** |
| v6 | 182/861 (21.1%) | **182/675 (27.0%)** |
| v9 | 8/212 (3.8%) | **8/110 (7.3%)** |
| v1 | 4/920 (0.4%) | **0/110 (0.0%)** |
| v9strip | *not measured* | **4/352 (1.1%)** |

**V9's true rate breaches the 5% ceiling and always did** — pooling 102 judge grades into 110 probe calls is the only reason it read as passing. It is recorded as a **ratchet entry**, visible and able only to shrink, rather than silently clearing a bar it does not clear. Its direction is conservative (silence scores as a failure on V9), so the published retrieval ceiling remains a lower bound.

Every error runs the same way: **understated, never overstated.** No conclusion flips — **V3/V6 remain uncitable pending re-run**, by a wider margin than first stated.

## Hardening

The gate now asserts the recorded arm set **equals** a C# list, rather than checking only that *present* arms are under their ceilings — the same pass-by-absence defence the V7 separability test uses, and the fix for an arm going unmonitored. An unattributable key becomes `unknown`, which the gate fails on, instead of borrowing a real arm's identity.

## Blast radius

**Corpus bytes are untouched.** Only the metadata stamp changed, so every `probed_corpus_sha256` still matches and **no probe re-run was required**. Recomputed offline from the same call cache via `--restamp-empty-rates-from-cache`, which reuses the runner's own attribution rather than reimplementing it — two copies of that rule is how the first one drifted.

## Verification

- **Falsified three ways**: removing an arm, injecting an `unknown` bucket, and regressing a rate each fail the gate.
- **985/985** memory tests pass.
- **6 attribution cases** added to the runner's CI self-test (already wired into `docs-toc-check.yml`).
- Stamped data re-derived by an **independent** parse across all 7 corpora — all agree.

Also backfills the `0.27.0-beta` changelog link reference, missed in that cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ