### PR TITLE
Give "premature" precedence over "wrong" on prospective questions

### DIFF
--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
@@ -81,6 +81,13 @@ internal static class TypedMemEvalJudgePrompts
         the reminder fired early, the pass is described as expired before it expired, the move is
         described as done. That is a different failure from being wrong about a date, and it is the
         one this vertical exists to catch.
+
+        PRECEDENCE — "premature" outranks "wrong" HERE, on this vertical only. Every premature
+        answer also commits to a value gold does not support, so "wrong" is always literally
+        available and the more specific label loses by default: a reminder that fired early was
+        being graded "wrong about a date", which is the one distinction this vertical exists to
+        draw. When the disagreement is that gold says a thing has NOT happened yet and the answer
+        says it HAS, choose "premature". Use "wrong" only when the mismatch is something else.
         """;
 
     private const string ArithmeticBody = """

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -1,15 +1,36 @@
 {
   "judge_prompt_fingerprint": "4c626f05634ba997b067990f5e525861c762e6c25fd86b1a8989dd4141ea76ff",
-  "measured_at": null,
-  "model": null,
-  "agreement": null,
-  "status": "not_measured",
-  "cases": null,
-  "runs": 0,
-  "per_vertical": {},
+  "measured_at": "2026-08-28",
+  "model": "gpt-5.5",
+  "agreement": 0.94,
+  "status": "measured",
+  "cases": 168,
+  "runs": 3,
+  "per_vertical": {
+    "Prospective": 1.0,
+    "Episodic": 0.958,
+    "Arithmetic": 1.0,
+    "WorkingMemory": 1.0,
+    "Forgetting": 0.917,
+    "Bitemporal": 0.792,
+    "Temporal": 0.917
+  },
   "disagreements": {
-    "every_run": [],
-    "run_varying": []
+    "every_run": [
+      "cal-bit-011",
+      "cal-bit-012",
+      "cal-bit-015",
+      "cal-bit-022",
+      "cal-for-006",
+      "cal-tem-013"
+    ],
+    "run_varying": [
+      "cal-bit-002",
+      "cal-bit-014",
+      "cal-epi-014",
+      "cal-for-012",
+      "cal-tem-016"
+    ]
   },
   "superseded": {
     "judge_prompt_fingerprint": "edc5fbaa733cdad29007980165465522177bb0bfdfaa492b85d92fa217523e01",
@@ -25,5 +46,5 @@
       "Forgetting": 0.917
     }
   },
-  "note": "ProspectiveBody gained a precedence rule - premature outranks wrong, on that vertical only - so the fingerprint moved and the previous measurement describes a judge that no longer exists. Recorded honestly as not_measured rather than carried forward; the live arm against gpt-5.5 is the next step and this file is filled in from its output. The superseded record is kept because its SCOPE is the more useful part of it: it reads agreement 0.983 over 120 cases, and the calibration set holds 168 across 7 verticals. Bitemporal and Temporal arrived in 0.26.0-beta with 24 cases each, both routed to StandardBody, which was already inside the fingerprint - so the fingerprint never changed, the tripwire never fired, and a measurement over 5 of 7 verticals was read as a family-wide number for eight days. The gate now asserts the recorded case count equals the live set and that every vertical in the enum has a per-vertical entry, so growing the set fails the build instead of quietly diluting the number. Three local runs of the NEW prompt scored 0.881 / 0.869 / 0.869 over all 168 cases, but against gpt-4o-mini and not the gpt-5.5 this record names; they are not written here because they measure a different judge, and swapping the recorded model without saying so is the same class of silent substitution this file exists to prevent."
+  "note": "Three runs at this fingerprint: 0.946 / 0.958 / 0.940. The lowest is recorded and the per-vertical figures come from that same lowest run, so this record never quotes the best of a set. Bitemporal ran 0.750 / 0.792 / 0.792 - its worst is 0.750, lower than the 0.792 recorded here, and that is the number to argue with. BITEMPORAL IS THE FINDING AND IT IS NOT NEW. Six of its 24 cases fail, four of them in every run, all with one shape: the label says Wrong and the judge says Premature. The cause is a collision between two verticals' contracts inside the SHARED Preamble, which defines premature as asserting as already true something gold says has not happened yet. Bitemporal golds read 'the correction had not been recorded yet', which satisfies that definition literally, so a capable judge labels them Premature; the hand labels say Wrong because in bitemporal the defect is a transaction-time mismatch rather than an early assertion. Both readings follow from the text as written, which is the defect. This predates the ProspectiveBody edit that moved the fingerprint. Bitemporal routes to Standard(), built from Preamble + StandardBody + Closing + ContractFor, and all four are byte-identical to main - the added text is in ProspectiveBody, which Bitemporal never sees. It has been true since Bitemporal shipped in 0.26.0-beta and was invisible because the superseded record measured 120 cases across the five verticals that existed on 2026-08-15. The published family-wide agreement never included the vertical that is worst. NOT FIXED HERE, ON PURPOSE. The two repairs are to disambiguate premature from wrong for transaction-time golds, or to relabel the six cases - and relabelling to move a number is the move this file exists to prevent. The threshold is also family-wide at 0.85, so Bitemporal at 0.792 passes because six verticals near 0.98 carry it: the same mean-satisfiable-by-averaging shape the corpus calibration had, where arithmetic's duration sat at 0.083 behind a green 0.700 mean. A per-vertical floor is the obvious next gate and is deliberately left as a decision, because adding it turns CI red until the Preamble collision is resolved. cal-for-006 disagrees in every run and was not relabelled: an answer replaces a cancelled gym membership with an invented move to a different gym, the judge reads the no-longer as satisfied, the label treats the fabricated replacement as a committed value gold does not carry."
 }

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -1,25 +1,29 @@
 {
-  "judge_prompt_fingerprint": "edc5fbaa733cdad29007980165465522177bb0bfdfaa492b85d92fa217523e01",
-  "measured_at": "2026-08-15",
-  "model": "gpt-5.5",
-  "agreement": 0.983,
-  "status": "measured",
-  "cases": 120,
-  "runs": 2,
-  "per_vertical": {
-    "Prospective": 1.0,
-    "Episodic": 1.0,
-    "Arithmetic": 1.0,
-    "WorkingMemory": 1.0,
-    "Forgetting": 0.917
-  },
+  "judge_prompt_fingerprint": "4c626f05634ba997b067990f5e525861c762e6c25fd86b1a8989dd4141ea76ff",
+  "measured_at": null,
+  "model": null,
+  "agreement": null,
+  "status": "not_measured",
+  "cases": null,
+  "runs": 0,
+  "per_vertical": {},
   "disagreements": {
-    "every_run": [
-      "cal-for-006"
-    ],
-    "run_varying": [
-      "cal-for-012"
-    ]
+    "every_run": [],
+    "run_varying": []
   },
-  "note": "Two runs of the live arm at this fingerprint: 0.992 and 0.983. The lower is recorded, and the per-vertical figures come from that same lower run, so this record never quotes the best of a set. The previous fingerprint's measurement (84bacb9b..., 0.975 over three runs) is superseded and not comparable: ArithmeticBody gained a rule that direction is part of a difference's value, added in response to calibration case cal-ari-016, where the old template's grade-the-arithmetic-not-the-phrasing wording let 'went up by 46' pass against a gold of 46 lower. cal-ari-016 now agrees in both runs and Arithmetic is at 1.0. One case disagrees in every run and was not relabelled to improve the number: cal-for-006, where an answer replaces a cancelled gym membership with an invented move to a different gym; the judge reads the no-longer as satisfied, the label treats the fabricated replacement as a committed value gold does not carry. cal-for-012 disagrees in one run of the two - the Forgetting boundary where the preamble's definition of abstained meets the over-forgetting rule - which is judge noise at the boundary rather than drift, and the reason this file records runs rather than a single point."
+  "superseded": {
+    "judge_prompt_fingerprint": "edc5fbaa733cdad29007980165465522177bb0bfdfaa492b85d92fa217523e01",
+    "measured_at": "2026-08-15",
+    "model": "gpt-5.5",
+    "agreement": 0.983,
+    "cases": 120,
+    "per_vertical": {
+      "Prospective": 1.0,
+      "Episodic": 1.0,
+      "Arithmetic": 1.0,
+      "WorkingMemory": 1.0,
+      "Forgetting": 0.917
+    }
+  },
+  "note": "ProspectiveBody gained a precedence rule - premature outranks wrong, on that vertical only - so the fingerprint moved and the previous measurement describes a judge that no longer exists. Recorded honestly as not_measured rather than carried forward; the live arm against gpt-5.5 is the next step and this file is filled in from its output. The superseded record is kept because its SCOPE is the more useful part of it: it reads agreement 0.983 over 120 cases, and the calibration set holds 168 across 7 verticals. Bitemporal and Temporal arrived in 0.26.0-beta with 24 cases each, both routed to StandardBody, which was already inside the fingerprint - so the fingerprint never changed, the tripwire never fired, and a measurement over 5 of 7 verticals was read as a family-wide number for eight days. The gate now asserts the recorded case count equals the live set and that every vertical in the enum has a per-vertical entry, so growing the set fails the build instead of quietly diluting the number. Three local runs of the NEW prompt scored 0.881 / 0.869 / 0.869 over all 168 cases, but against gpt-4o-mini and not the gpt-5.5 this record names; they are not written here because they measure a different judge, and swapping the recorded model without saying so is the same class of silent substitution this file exists to prevent."
 }

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeCalibrationTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeCalibrationTests.cs
@@ -249,6 +249,35 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("model").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("measured_at").GetString()));
         Assert.Equal("measured", root.GetProperty("status").GetString());
+
+        // The record has to describe the set it is read as validating. Without this the fingerprint
+        // is the only thing holding it, and the fingerprint covers the prompt TEXT, not the case
+        // list — so cases can be added under an unchanged fingerprint and the stored agreement
+        // silently describes a shrinking fraction of them. That is exactly what happened: Bitemporal
+        // and Temporal arrived in 0.26.0-beta with 48 cases between them, both routed to
+        // StandardBody, which was already in the fingerprint. Nothing changed, nothing fired, and a
+        // measurement over 120 of 168 cases went on being read as a family-wide number.
+        var recordedCases = root.GetProperty("cases").GetInt32();
+        Assert.True(
+            recordedCases == Cases.Count,
+            $"the recorded measurement covers {recordedCases} cases but the calibration set holds " +
+            $"{Cases.Count}. Growing the set cannot invalidate a stored number on its own — the " +
+            $"fingerprint pins the prompt text, not the case list — so re-measure and restate the " +
+            $"count. A record that describes a subset is not evidence about the whole.");
+
+        // Same failure, per vertical: a vertical added with no entry here would be absent rather
+        // than low, and absence reads as nothing to see. Checked against the enum and not against
+        // the calibration file, so the expectation cannot shrink alongside the thing it measures.
+        var perVertical = root.GetProperty("per_vertical");
+        var unmeasured = Enum.GetValues<TypedMemEvalVertical>()
+            .Where(vertical => !perVertical.TryGetProperty(vertical.ToString(), out _))
+            .ToArray();
+
+        Assert.True(
+            unmeasured.Length == 0,
+            $"verticals with no recorded per-vertical agreement: {string.Join(", ", unmeasured)}. " +
+            $"Each one has its own template and its own failure modes; one missing here is one the " +
+            $"family-wide number is averaging over without ever having seen.");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes the scheduled [LLM Integration Tests run](https://github.com/AgentEvalHQ/AgentEval/actions/runs/32700167748), which failed at **0.845** agreement against a **0.85** floor (142/168, `gpt-4o-mini`).

## The defect

The margin was one case, but the disagreements weren't noise. Four `premature-fires-early` cases — `cal-pro-001`, `-009`, `-013`, `-022` — all expected `Premature` and all came back `Wrong`. In every one the judge's **reasoning was the premature definition verbatim**:

> *"answer incorrectly asserts that the move has already occurred, while the gold answer states that it has not yet happened"*

Only the label was wrong. **`premature` is a strict subtype of `wrong`** — every premature answer also commits to a value gold doesn't support, so `wrong` is always literally available and the more specific label loses by default. The precedence rules covered hedging, negative gold and missing detail; nothing said which of these two wins.

## Why it's scoped to the prospective body

Putting the rule in the shared preamble was **measured and rejected**. Bitemporal gold routinely reads *"the correction had not been recorded yet"* — structurally identical to the premature pattern, semantically unrelated (belief time vs valid time, not an event that hasn't happened). The judge applied the rule faithfully and bitemporal went from **1 disagreement to 6**, every one `got Premature`.

The prompt already describes `premature` in its prospective section as *"the one this vertical exists to catch"*. That's where its precedence belongs.

## Measured, three runs

Against the deployment CI actually failed on, because a judge is stochastic and one green run proves nothing at a marginal threshold:

| | agreement | bitemporal disagreements | premature over-applied |
|---|---|---|---|
| baseline | **0.845** (142/168) ❌ | 1 | — |
| run 1 | **0.881** (148/168) | 1 | 0 |
| run 2 | **0.869** (146/168) | 1 | 0 |
| run 3 | **0.869** (146/168) | 1 | 0 |

**The 0.85 floor is untouched.** Lowering it was the obvious way to make this green, and it's the one thing this repo refuses everywhere else it states a bar.

## Deliberately not done

- **Five further disagreements** form a second pattern — `missing-required-detail` judged `missed` where the humans said `wrong`. Two neighbouring cases (`cal-tem-011/013`) look like genuine disagreement about what the humans meant rather than judge error, and tuning the prompt until it reproduces every label is overfitting to the very set that exists to catch the judge.
- **The workflow defaults this judge to `gpt-4o-mini`** while the judge code's own comments assume a reasoning deployment (*"no temperature, which such deployments reject outright"*) and the probes run `gpt-5.5`. Flagged, not changed — it carries a cost decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ