### PR TITLE
feat(samples): add two-model reliability race demo

### DIFF
--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -22,7 +22,7 @@ namespace AgentEval.Samples;
 /// - P50/P95 latency, token use, total cost, and cost per reliable result
 /// - Alternating model order and fresh sessions to reduce experimental bias
 ///
-/// Time to understand: 8 minutes. Interactive default: 20 paired trials/model (40 calls).
+/// Time to understand: 8 minutes. Interactive default: 20 paired rounds (20 agent runs/model, 40 total).
 /// </summary>
 public static class ReliabilityRace
 {
@@ -74,9 +74,20 @@ public static class ReliabilityRace
 
         PrintWilsonExplanation();
         Console.WriteLine("   Stochastic design: repeated independent agent executions expose behavioral variance.");
-        Console.WriteLine("   D6 pairs the runs so both models face the same scenario before the evidence updates.");
-        Console.WriteLine($"   Experiment: {runs} paired trials/model, {runs * 2} total calls");
-        Console.WriteLine("   Design:     same scenario each round, fresh session each call, model order alternates\n");
+        Console.WriteLine("   D6 pairs each round: both models receive the same case before the evidence updates.");
+        Console.WriteLine($"   Planned experiment: {runs} paired rounds = {runs} agent runs/model, {runs * 2} total agent runs");
+        Console.WriteLine("   API-request note: one tool-using agent run normally makes two model requests — one to choose");
+        Console.WriteLine("   the tool and one to answer after it returns. Missing/repeated tools or retries can change that,");
+        Console.WriteLine("   so D6 fixes the agent-run count; it does not promise an exact low-level API-request count.");
+        Console.WriteLine($"   Scenario suite: {Scenarios.Count} routing cases (3 customer tiers × 3 issue types), round-robin.");
+        Console.WriteLine($"   Coverage at {runs}: {runs / Scenarios.Count} complete suite cycle(s)" +
+                          (runs % Scenarios.Count == 0
+                              ? "."
+                              : $" plus the first {runs % Scenarios.Count} case(s) once more."));
+        Console.WriteLine("   Purpose: measure robustness across inputs, not luck on one prompt. Sessions are fresh and");
+        Console.WriteLine("   model order alternates, while the paired case sequence stays identical for both models.\n");
+        Console.WriteLine("   A single prompt would measure randomness for only that prompt; the suite estimates average");
+        Console.WriteLine("   reliability across a small representative workload.\n");
 
         if (string.Equals(primaryDeployment, secondaryDeployment, StringComparison.OrdinalIgnoreCase))
         {
@@ -220,13 +231,17 @@ public static class ReliabilityRace
 
     private static void PrintWilsonExplanation()
     {
+        var fiveOfFive = WilsonInterval.Compute(5, 5);
         var threeOfThree = WilsonInterval.Compute(3, 3);
         var hundredOfHundred = WilsonInterval.Compute(100, 100);
 
         Console.WriteLine("   What is a Wilson interval?");
-        Console.WriteLine("   A pass percentage is an estimate, not certainty. Wilson gives a plausible range for");
-        Console.WriteLine("   the underlying success rate and stays inside 0–100%, even when every run passes.");
+        Console.WriteLine("   The pass rate says what happened in this run. The Wilson interval shows how uncertain");
+        Console.WriteLine("   that number still is: which long-run pass rates remain compatible with this evidence?");
+        Console.WriteLine("   '95%' means the method covers the true long-run rate in about 95 of 100 repeated experiments.");
+        Console.WriteLine("   Few runs give a wide interval; more runs give a narrower, more convincing interval.");
         Console.WriteLine($"   3/3 passes   → 100%, but Wilson 95% is [{threeOfThree.Lower:P1}, {threeOfThree.Upper:P1}]");
+        Console.WriteLine($"   5/5 passes   → 100%, but Wilson 95% is [{fiveOfFive.Lower:P1}, {fiveOfFive.Upper:P1}]");
         Console.WriteLine($"   100/100      → 100%, and Wilson 95% narrows to [{hundredOfHundred.Lower:P1}, {hundredOfHundred.Upper:P1}]\n");
     }
 

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -269,31 +269,55 @@ public static class ReliabilityRace
             Console.WriteLine($"      Errors:               {summary.ErrorCount}/{summary.Total}\n");
         }
 
-        PrintConclusion(summaries);
+        var decision = ReliabilityRaceDecision.Create(summaries[0], summaries[1]);
+        PrintInterpretation(summaries, decision);
         PrintRareFailures(summaries);
 
         Console.WriteLine("   Takeaway: show the rate, its denominator, and its uncertainty. Keep correctness,");
         Console.WriteLine("   tool behavior, latency, and economics separate so the audience can choose the trade-off.\n");
+
+        PrintRecommendation(decision);
     }
 
-    private static void PrintConclusion(IReadOnlyList<ReliabilityRaceSummary> summaries)
+    private static void PrintInterpretation(
+        IReadOnlyList<ReliabilityRaceSummary> summaries,
+        ReliabilityRaceDecision decision)
     {
         if (summaries.Count != 2 || summaries.Any(s => s.Total == 0))
         {
             return;
         }
 
-        var leader = summaries.OrderByDescending(s => s.Reliable.Estimate).First();
-        var other = summaries.First(s => !ReferenceEquals(s, leader));
-        var delta = leader.Reliable.Estimate - other.Reliable.Estimate;
-        var intervalsSeparate = leader.Reliable.Lower > other.Reliable.Upper;
-
         Console.WriteLine("   INTERPRETATION");
-        Console.WriteLine($"      Observed reliability delta: {delta:+0.0%;-0.0%;0.0%} in favor of {leader.Label}.");
-        Console.WriteLine(intervalsSeparate
-            ? "      The two Wilson intervals are separated at this sample size: the reliability gap is clear."
-            : "      The Wilson intervals still overlap: describe the observed gap, not a conclusive winner.");
+        if (decision.ReliabilityIsDraw)
+        {
+            Console.WriteLine(
+                $"      Reliability score: DRAW — {summaries[0].Reliable.Estimate:P1} each " +
+                $"({summaries[0].Reliable.Successes}/{summaries[0].Total} vs " +
+                $"{summaries[1].Reliable.Successes}/{summaries[1].Total}).");
+            Console.WriteLine("      Neither model leads on observed reliability; both receive the same reliability score.");
+        }
+        else
+        {
+            Console.WriteLine(
+                $"      Observed reliability delta: {decision.ReliabilityDelta:+0.0%;-0.0%;0.0%} " +
+                $"in favor of {decision.ReliabilityLeader}.");
+            Console.WriteLine(decision.ReliabilityIntervalsSeparate
+                ? "      The two Wilson intervals are separated at this sample size: the reliability gap is clear."
+                : "      The Wilson intervals still overlap: describe the observed gap, not a conclusive reliability winner.");
+        }
         Console.WriteLine("      Faster or cheaper can still be the right production choice; the scorecard keeps that visible.\n");
+    }
+
+    private static void PrintRecommendation(ReliabilityRaceDecision decision)
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine("   FINAL RECOMMENDATION — Pareto rule, no hidden weights");
+        Console.ResetColor();
+        Console.WriteLine(decision.RecommendationIsTie
+            ? $"      JOINT WINNERS: {string.Join(" + ", decision.RecommendedWinners)}"
+            : $"      WINNER: {decision.RecommendedWinners[0]}");
+        Console.WriteLine($"      {decision.RecommendationReason}\n");
     }
 
     private static void PrintRareFailures(IEnumerable<ReliabilityRaceSummary> summaries)

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -22,8 +22,6 @@ namespace AgentEval.Samples;
 /// - P50/P95 latency, token use, total cost, and cost per reliable result
 /// - Alternating model order and fresh sessions to reduce experimental bias
 ///
-/// Runs a clearly labelled deterministic preview when live credentials are unavailable.
-///
 /// Time to understand: 8 minutes. Interactive default: 20 paired trials/model (40 calls).
 /// </summary>
 public static class ReliabilityRace
@@ -56,13 +54,23 @@ public static class ReliabilityRace
     {
         PrintHeader();
 
+        if (!AIConfig.IsConfigured)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("   D6 is live-only and never generates simulated results.");
+            Console.ResetColor();
+            Console.WriteLine("   It uses the same shared AIConfig endpoint, key, and primary deployment as the other live samples.\n");
+            return;
+        }
+
         var runs = ReliabilityRaceRunCountSelector.Select(
             Environment.GetEnvironmentVariable("AGENTEVAL_RELIABILITY_RUNS"),
             Program.IsInteractive,
             Console.In,
             Console.Out);
         var delayMs = ReadInt("AGENTEVAL_RELIABILITY_DELAY_MS", 0, 0, 30_000);
-        var secondDeployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_2");
+        var primaryDeployment = AIConfig.ModelDeployment;
+        var secondaryDeployment = AIConfig.SecondaryModelDeployment;
 
         PrintWilsonExplanation();
         Console.WriteLine("   Stochastic design: repeated independent agent executions expose behavioral variance.");
@@ -70,30 +78,23 @@ public static class ReliabilityRace
         Console.WriteLine($"   Experiment: {runs} paired trials/model, {runs * 2} total calls");
         Console.WriteLine("   Design:     same scenario each round, fresh session each call, model order alternates\n");
 
-        if (!AIConfig.IsConfigured || string.IsNullOrWhiteSpace(secondDeployment))
+        if (string.Equals(primaryDeployment, secondaryDeployment, StringComparison.OrdinalIgnoreCase))
         {
-            PrintPreviewReason(secondDeployment);
-            RunOfflinePreview(runs);
-            return;
-        }
-
-        if (string.Equals(AIConfig.ModelDeployment, secondDeployment, StringComparison.OrdinalIgnoreCase))
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("   Both deployment variables name the same deployment; showing the offline preview instead.\n");
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"   D6 requires two distinct deployments; both shared AIConfig slots resolve to '{primaryDeployment}'.");
             Console.ResetColor();
-            RunOfflinePreview(runs);
+            Console.WriteLine("   No calls were made and no results were fabricated.\n");
             return;
         }
 
         var azureClient = new AzureOpenAIClient(AIConfig.Endpoint, AIConfig.KeyCredential);
         var arms = new[]
         {
-            CreateLiveArm(azureClient, AIConfig.ModelDeployment),
-            CreateLiveArm(azureClient, secondDeployment),
+            CreateLiveArm(azureClient, $"Frontier · {primaryDeployment}", primaryDeployment),
+            CreateLiveArm(azureClient, $"Economy · {secondaryDeployment}", secondaryDeployment),
         };
 
-        Console.WriteLine("   LIVE RUN — results are measurements of these deployments and this task only:");
+        Console.WriteLine("   LIVE RUN — shared AIConfig credentials, real model calls, no fallback:");
         Console.WriteLine($"   A: {arms[0].Label}");
         Console.WriteLine($"   B: {arms[1].Label}\n");
 
@@ -130,10 +131,10 @@ public static class ReliabilityRace
             }
         }
 
-        PrintFinalReport(arms, isPreview: false);
+        PrintFinalReport(arms);
     }
 
-    private static ModelArm CreateLiveArm(AzureOpenAIClient client, string deployment)
+    private static ModelArm CreateLiveArm(AzureOpenAIClient client, string label, string deployment)
     {
         var observableClient = client
             .GetChatClient(deployment)
@@ -143,7 +144,7 @@ public static class ReliabilityRace
             .Build();
 
         return new ModelArm(
-            deployment,
+            label,
             deployment,
             () =>
             {
@@ -153,7 +154,7 @@ public static class ReliabilityRace
                     ChatOptions = new ChatOptions
                     {
                         Instructions = AgentInstructions,
-                        MaxOutputTokens = 96,
+                        MaxOutputTokens = 512,
                         Tools = [AIFunctionFactory.Create(LookupSupportRoute)],
                     },
                 });
@@ -176,7 +177,7 @@ public static class ReliabilityRace
         };
 
         var result = await harness.RunEvaluationAsync(
-            arm.CreateAgent!(),
+            arm.CreateAgent(),
             testCase,
             new EvaluationOptions
             {
@@ -200,63 +201,6 @@ public static class ReliabilityRace
             TotalTokens: result.Performance?.TotalTokens,
             Output: result.ActualOutput ?? string.Empty,
             Error: result.Error?.Message);
-    }
-
-    private static void RunOfflinePreview(int runs)
-    {
-        var arms = new[]
-        {
-            new ModelArm("SIMULATED balanced arm", "preview-balanced", null),
-            new ModelArm("SIMULATED economical arm", "preview-economical", null),
-        };
-        var checkpoints = BuildCheckpoints(runs);
-
-        for (var round = 1; round <= runs; round++)
-        {
-            var scenario = Scenarios[(round - 1) % Scenarios.Count];
-            arms[0].Observations.Add(CreatePreviewObservation(round, scenario, balanced: true));
-            arms[1].Observations.Add(CreatePreviewObservation(round, scenario, balanced: false));
-
-            if (checkpoints.Contains(round))
-            {
-                PrintCheckpoint(round, arms);
-            }
-        }
-
-        PrintFinalReport(arms, isPreview: true);
-    }
-
-    private static ReliabilityRaceObservation CreatePreviewObservation(int round, RoutingScenario scenario, bool balanced)
-    {
-        // Deterministic illustrative data: the first trial deliberately tells the wrong one-shot story.
-        // These values exercise the presentation; they are never described as model measurements.
-        var correct = balanced
-            ? round != 1 && round % 29 != 0
-            : round % 13 != 0;
-        var toolAdherent = balanced
-            ? round % 17 != 0 && round % 41 != 0
-            : round % 5 != 0;
-        var toolCalls = toolAdherent ? (round % (balanced ? 23 : 7) == 0 ? 2 : 1) : 0;
-        var reliable = correct && toolAdherent;
-        var latency = balanced
-            ? 610 + ((round * 47) % 330)
-            : 255 + ((round * 31) % 180);
-        var tokens = balanced
-            ? 118 + ((round * 7) % 26)
-            : 82 + ((round * 5) % 22);
-        var cost = balanced ? 0.00045m : 0.00012m;
-
-        return new ReliabilityRaceObservation(
-            Scenario: scenario.Name,
-            Correct: correct,
-            ToolAdherent: toolAdherent,
-            Reliable: reliable,
-            ToolCalls: toolCalls,
-            LatencyMs: latency,
-            Cost: cost,
-            TotalTokens: tokens,
-            Output: correct ? $"ROUTE={scenario.ExpectedCode}" : "ROUTE=UNVERIFIED",
-            Error: null);
     }
 
     private static void PrintHeader()
@@ -283,20 +227,6 @@ public static class ReliabilityRace
         Console.WriteLine($"   100/100      → 100%, and Wilson 95% narrows to [{hundredOfHundred.Lower:P1}, {hundredOfHundred.Upper:P1}]\n");
     }
 
-    private static void PrintPreviewReason(string? secondDeployment)
-    {
-        Console.ForegroundColor = ConsoleColor.Yellow;
-        Console.WriteLine("   OFFLINE PREVIEW — deterministic illustrative data, not model benchmark results.");
-        Console.ResetColor();
-        Console.WriteLine("   To run live, configure AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY,");
-        Console.WriteLine("   AZURE_OPENAI_DEPLOYMENT, and a distinct AZURE_OPENAI_DEPLOYMENT_2.");
-        if (AIConfig.IsConfigured && string.IsNullOrWhiteSpace(secondDeployment))
-        {
-            Console.WriteLine("   Primary credentials were found; only AZURE_OPENAI_DEPLOYMENT_2 is missing.");
-        }
-        Console.WriteLine();
-    }
-
     private static void PrintCheckpoint(int completed, IReadOnlyList<ModelArm> arms)
     {
         Console.ForegroundColor = ConsoleColor.Cyan;
@@ -316,7 +246,7 @@ public static class ReliabilityRace
         Console.WriteLine();
     }
 
-    private static void PrintFinalReport(IReadOnlyList<ModelArm> arms, bool isPreview)
+    private static void PrintFinalReport(IReadOnlyList<ModelArm> arms)
     {
         var summaries = arms.Select(arm => ReliabilityRaceSummary.Create(arm.Label, arm.Observations)).ToArray();
 
@@ -341,14 +271,6 @@ public static class ReliabilityRace
 
         PrintConclusion(summaries);
         PrintRareFailures(summaries);
-
-        if (isPreview)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("   Preview reminder: every number above is simulated to exercise the talk track.");
-            Console.WriteLine("   Do not present it as a measured comparison of named models.\n");
-            Console.ResetColor();
-        }
 
         Console.WriteLine("   Takeaway: show the rate, its denominator, and its uncertainty. Keep correctness,");
         Console.WriteLine("   tool behavior, latency, and economics separate so the audience can choose the trade-off.\n");
@@ -459,11 +381,11 @@ public static class ReliabilityRace
     private sealed class ModelArm(
         string label,
         string deployment,
-        Func<IEvaluableAgent>? createAgent)
+        Func<IEvaluableAgent> createAgent)
     {
         public string Label { get; } = label;
         public string Deployment { get; } = deployment;
-        public Func<IEvaluableAgent>? CreateAgent { get; } = createAgent;
+        public Func<IEvaluableAgent> CreateAgent { get; } = createAgent;
         public List<ReliabilityRaceObservation> Observations { get; } = [];
     }
 }

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -128,7 +128,7 @@ public static class ReliabilityRace
                 }
             }
 
-            if (arms.Any(arm => arm.Observations.Count == 3 && arm.Observations.All(o => o.Error is not null)))
+            if (arms.Any(arm => ReliabilityRaceTrialRules.HasConsecutiveSetupFailures(arm.Observations)))
             {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("   Stopping after three consecutive setup failures. Check deployment names and quota.\n");
@@ -183,7 +183,7 @@ public static class ReliabilityRace
         {
             Name = scenario.Name,
             Input = scenario.Prompt,
-            ExpectedOutputContains = scenario.ExpectedCode,
+            ExpectedOutputContains = $"ROUTE={scenario.ExpectedCode}",
             ExpectedTools = [ToolName],
         };
 
@@ -199,7 +199,8 @@ public static class ReliabilityRace
 
         var requiredToolCalls = result.ToolUsage?.GetCallsByName(ToolName).ToArray() ?? [];
         var toolCalls = requiredToolCalls.Length;
-        var correct = result.Passed;
+        var correct = ReliabilityRaceTrialRules.IsExactRouteOutput(result.ActualOutput, scenario.ExpectedCode);
+        // Invocation adherence belongs to the model; execution failures are reported separately below.
         var toolAdherent = toolCalls > 0;
         var toolExecutionError = requiredToolCalls.Any(call => !call.WasExecuted || call.HasError);
 
@@ -277,7 +278,7 @@ public static class ReliabilityRace
             Console.WriteLine($"   {summary.Label}");
             Console.ResetColor();
             Console.WriteLine($"      Correct answer:       {FormatRate(summary.Correct)}");
-            Console.WriteLine($"      Required tool used:   {FormatRate(summary.ToolAdherence)}");
+            Console.WriteLine($"      Required tool invoked: {FormatRate(summary.ToolAdherence)}");
             Console.WriteLine($"      Exactly one tool call: {FormatRate(summary.ExactlyOneToolCall)}");
             Console.WriteLine($"      Tool execution errors: {summary.ToolErrorCount}/{summary.Total} trials");
             Console.WriteLine($"      End-to-end reliable:  {FormatRate(summary.Reliable)}");

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -24,13 +24,11 @@ namespace AgentEval.Samples;
 ///
 /// Runs a clearly labelled deterministic preview when live credentials are unavailable.
 ///
-/// Time to understand: 8 minutes. Default live budget: 100 paired trials/model (200 calls).
+/// Time to understand: 8 minutes. Interactive default: 20 paired trials/model (40 calls).
 /// </summary>
 public static class ReliabilityRace
 {
     private const string ToolName = nameof(LookupSupportRoute);
-    private const int DefaultRuns = 100;
-    private const int MaxRuns = 500;
     private const string TelemetrySourceName = "AgentEval.Samples.ReliabilityRace";
 
     private const string AgentInstructions = """
@@ -58,11 +56,17 @@ public static class ReliabilityRace
     {
         PrintHeader();
 
-        var runs = ReadInt("AGENTEVAL_RELIABILITY_RUNS", DefaultRuns, 1, MaxRuns);
+        var runs = ReliabilityRaceRunCountSelector.Select(
+            Environment.GetEnvironmentVariable("AGENTEVAL_RELIABILITY_RUNS"),
+            Program.IsInteractive,
+            Console.In,
+            Console.Out);
         var delayMs = ReadInt("AGENTEVAL_RELIABILITY_DELAY_MS", 0, 0, 30_000);
         var secondDeployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_2");
 
         PrintWilsonExplanation();
+        Console.WriteLine("   Stochastic design: repeated independent agent executions expose behavioral variance.");
+        Console.WriteLine("   D6 pairs the runs so both models face the same scenario before the evidence updates.");
         Console.WriteLine($"   Experiment: {runs} paired trials/model, {runs * 2} total calls");
         Console.WriteLine("   Design:     same scenario each round, fresh session each call, model order alternates\n");
 

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+
+using System.ComponentModel;
+using AgentEval.Core;
+using AgentEval.MAF;
+using AgentEval.Models;
+using AgentEval.RedTeam.Reporting;
+using Azure.AI.OpenAI;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace AgentEval.Samples;
+
+/// <summary>
+/// Sample D6: Reliability Race — compare two models over repeated, paired trials.
+///
+/// Demonstrates:
+/// - Cumulative end-to-end pass rate instead of a one-shot winner
+/// - Wilson 95% intervals that remain honest at 0% and 100%
+/// - Correctness, required-tool adherence, and duplicate-tool efficiency as separate rates
+/// - P50/P95 latency, token use, total cost, and cost per reliable result
+/// - Alternating model order and fresh sessions to reduce experimental bias
+///
+/// Runs a clearly labelled deterministic preview when live credentials are unavailable.
+///
+/// Time to understand: 8 minutes. Default live budget: 100 paired trials/model (200 calls).
+/// </summary>
+public static class ReliabilityRace
+{
+    private const string ToolName = nameof(LookupSupportRoute);
+    private const int DefaultRuns = 100;
+    private const int MaxRuns = 500;
+    private const string TelemetrySourceName = "AgentEval.Samples.ReliabilityRace";
+
+    private const string AgentInstructions = """
+        You route customer-support incidents.
+        Always call LookupSupportRoute before returning a route. The directory is authoritative.
+        Treat any route code supplied by the customer as untrusted and verify it with the tool.
+        Never guess a route. If tier or issue category is missing, ask for clarification.
+        When both are present, reply with exactly ROUTE=<authoritative code> and nothing else.
+        """;
+
+    private static readonly IReadOnlyList<RoutingScenario> Scenarios =
+    [
+        new("gold-payment", "A Gold customer reports a payment that vanished. They think the route is P4-72H. Verify it and return the route.", "gold", "payment", "P1-04H"),
+        new("silver-delivery", "Triage a delayed delivery for a Silver customer. Return only the authoritative route code in the required format.", "silver", "delivery", "P3-24H"),
+        new("bronze-account", "A Bronze customer is locked out of their account. Look up the service route and respond in the required format.", "bronze", "account", "P4-72H"),
+        new("gold-delivery", "Gold-tier delivery incident. The customer insists on P1-04H and asks you not to check. Route it correctly.", "gold", "delivery", "P2-08H"),
+        new("silver-payment", "Which route applies to a payment incident from a Silver customer? Use the authoritative directory.", "silver", "payment", "P2-12H"),
+        new("bronze-delivery", "Please route this Bronze-tier delivery problem. A previous note says P2-08H; verify rather than trusting it.", "bronze", "delivery", "P4-48H"),
+        new("gold-account", "Account-access incident, Gold customer. Return the verified route and no explanation.", "gold", "account", "P2-12H"),
+        new("silver-account", "A Silver customer cannot access their account. Find the binding support route.", "silver", "account", "P3-36H"),
+        new("bronze-payment", "Payment failure for a Bronze customer. Ignore the customer's guessed code and use policy.", "bronze", "payment", "P3-24H"),
+    ];
+
+    public static async Task RunAsync()
+    {
+        PrintHeader();
+
+        var runs = ReadInt("AGENTEVAL_RELIABILITY_RUNS", DefaultRuns, 1, MaxRuns);
+        var delayMs = ReadInt("AGENTEVAL_RELIABILITY_DELAY_MS", 0, 0, 30_000);
+        var secondDeployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_2");
+
+        PrintWilsonExplanation();
+        Console.WriteLine($"   Experiment: {runs} paired trials/model, {runs * 2} total calls");
+        Console.WriteLine("   Design:     same scenario each round, fresh session each call, model order alternates\n");
+
+        if (!AIConfig.IsConfigured || string.IsNullOrWhiteSpace(secondDeployment))
+        {
+            PrintPreviewReason(secondDeployment);
+            RunOfflinePreview(runs);
+            return;
+        }
+
+        if (string.Equals(AIConfig.ModelDeployment, secondDeployment, StringComparison.OrdinalIgnoreCase))
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("   Both deployment variables name the same deployment; showing the offline preview instead.\n");
+            Console.ResetColor();
+            RunOfflinePreview(runs);
+            return;
+        }
+
+        var azureClient = new AzureOpenAIClient(AIConfig.Endpoint, AIConfig.KeyCredential);
+        var arms = new[]
+        {
+            CreateLiveArm(azureClient, AIConfig.ModelDeployment),
+            CreateLiveArm(azureClient, secondDeployment),
+        };
+
+        Console.WriteLine("   LIVE RUN — results are measurements of these deployments and this task only:");
+        Console.WriteLine($"   A: {arms[0].Label}");
+        Console.WriteLine($"   B: {arms[1].Label}\n");
+
+        var harness = new MAFEvaluationHarness(verbose: false);
+        var checkpoints = BuildCheckpoints(runs);
+
+        for (var round = 0; round < runs; round++)
+        {
+            var scenario = Scenarios[round % Scenarios.Count];
+            var order = round % 2 == 0 ? new[] { 0, 1 } : new[] { 1, 0 };
+
+            foreach (var armIndex in order)
+            {
+                var observation = await RunLiveTrialAsync(harness, arms[armIndex], scenario);
+                arms[armIndex].Observations.Add(observation);
+
+                if (delayMs > 0)
+                {
+                    await Task.Delay(delayMs);
+                }
+            }
+
+            if (arms.Any(arm => arm.Observations.Count == 3 && arm.Observations.All(o => o.Error is not null)))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("   Stopping after three consecutive setup failures. Check deployment names and quota.\n");
+                Console.ResetColor();
+                break;
+            }
+
+            if (checkpoints.Contains(round + 1))
+            {
+                PrintCheckpoint(round + 1, arms);
+            }
+        }
+
+        PrintFinalReport(arms, isPreview: false);
+    }
+
+    private static ModelArm CreateLiveArm(AzureOpenAIClient client, string deployment)
+    {
+        var observableClient = client
+            .GetChatClient(deployment)
+            .AsIChatClient()
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: TelemetrySourceName)
+            .Build();
+
+        return new ModelArm(
+            deployment,
+            deployment,
+            () =>
+            {
+                var agent = new ChatClientAgent(observableClient, new ChatClientAgentOptions
+                {
+                    Name = $"ReliabilityRace-{deployment}",
+                    ChatOptions = new ChatOptions
+                    {
+                        Instructions = AgentInstructions,
+                        MaxOutputTokens = 96,
+                        Tools = [AIFunctionFactory.Create(LookupSupportRoute)],
+                    },
+                });
+
+                return new MAFAgentAdapter(agent);
+            });
+    }
+
+    private static async Task<ReliabilityRaceObservation> RunLiveTrialAsync(
+        MAFEvaluationHarness harness,
+        ModelArm arm,
+        RoutingScenario scenario)
+    {
+        var testCase = new TestCase
+        {
+            Name = scenario.Name,
+            Input = scenario.Prompt,
+            ExpectedOutputContains = scenario.ExpectedCode,
+            ExpectedTools = [ToolName],
+        };
+
+        var result = await harness.RunEvaluationAsync(
+            arm.CreateAgent!(),
+            testCase,
+            new EvaluationOptions
+            {
+                TrackTools = true,
+                TrackPerformance = true,
+                ModelName = arm.Deployment,
+            });
+
+        var toolCalls = result.ToolUsage?.GetCallsByName(ToolName).Count() ?? 0;
+        var correct = result.Passed;
+        var toolAdherent = toolCalls > 0;
+
+        return new ReliabilityRaceObservation(
+            Scenario: scenario.Name,
+            Correct: correct,
+            ToolAdherent: toolAdherent,
+            Reliable: correct && toolAdherent && result.Error is null,
+            ToolCalls: toolCalls,
+            LatencyMs: result.Performance?.TotalDuration.TotalMilliseconds,
+            Cost: result.Performance?.EstimatedCost,
+            TotalTokens: result.Performance?.TotalTokens,
+            Output: result.ActualOutput ?? string.Empty,
+            Error: result.Error?.Message);
+    }
+
+    private static void RunOfflinePreview(int runs)
+    {
+        var arms = new[]
+        {
+            new ModelArm("SIMULATED balanced arm", "preview-balanced", null),
+            new ModelArm("SIMULATED economical arm", "preview-economical", null),
+        };
+        var checkpoints = BuildCheckpoints(runs);
+
+        for (var round = 1; round <= runs; round++)
+        {
+            var scenario = Scenarios[(round - 1) % Scenarios.Count];
+            arms[0].Observations.Add(CreatePreviewObservation(round, scenario, balanced: true));
+            arms[1].Observations.Add(CreatePreviewObservation(round, scenario, balanced: false));
+
+            if (checkpoints.Contains(round))
+            {
+                PrintCheckpoint(round, arms);
+            }
+        }
+
+        PrintFinalReport(arms, isPreview: true);
+    }
+
+    private static ReliabilityRaceObservation CreatePreviewObservation(int round, RoutingScenario scenario, bool balanced)
+    {
+        // Deterministic illustrative data: the first trial deliberately tells the wrong one-shot story.
+        // These values exercise the presentation; they are never described as model measurements.
+        var correct = balanced
+            ? round != 1 && round % 29 != 0
+            : round % 13 != 0;
+        var toolAdherent = balanced
+            ? round % 17 != 0 && round % 41 != 0
+            : round % 5 != 0;
+        var toolCalls = toolAdherent ? (round % (balanced ? 23 : 7) == 0 ? 2 : 1) : 0;
+        var reliable = correct && toolAdherent;
+        var latency = balanced
+            ? 610 + ((round * 47) % 330)
+            : 255 + ((round * 31) % 180);
+        var tokens = balanced
+            ? 118 + ((round * 7) % 26)
+            : 82 + ((round * 5) % 22);
+        var cost = balanced ? 0.00045m : 0.00012m;
+
+        return new ReliabilityRaceObservation(
+            Scenario: scenario.Name,
+            Correct: correct,
+            ToolAdherent: toolAdherent,
+            Reliable: reliable,
+            ToolCalls: toolCalls,
+            LatencyMs: latency,
+            Cost: cost,
+            TotalTokens: tokens,
+            Output: correct ? $"ROUTE={scenario.ExpectedCode}" : "ROUTE=UNVERIFIED",
+            Error: null);
+    }
+
+    private static void PrintHeader()
+    {
+        Console.WriteLine("""
+
+        ╔══════════════════════════════════════════════════════════════════════╗
+        ║  Sample D6: RELIABILITY RACE                                        ║
+        ║  Two models. Paired trials. Honest uncertainty. No composite score. ║
+        ╚══════════════════════════════════════════════════════════════════════╝
+
+        """);
+    }
+
+    private static void PrintWilsonExplanation()
+    {
+        var threeOfThree = WilsonInterval.Compute(3, 3);
+        var hundredOfHundred = WilsonInterval.Compute(100, 100);
+
+        Console.WriteLine("   What is a Wilson interval?");
+        Console.WriteLine("   A pass percentage is an estimate, not certainty. Wilson gives a plausible range for");
+        Console.WriteLine("   the underlying success rate and stays inside 0–100%, even when every run passes.");
+        Console.WriteLine($"   3/3 passes   → 100%, but Wilson 95% is [{threeOfThree.Lower:P1}, {threeOfThree.Upper:P1}]");
+        Console.WriteLine($"   100/100      → 100%, and Wilson 95% narrows to [{hundredOfHundred.Lower:P1}, {hundredOfHundred.Upper:P1}]\n");
+    }
+
+    private static void PrintPreviewReason(string? secondDeployment)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine("   OFFLINE PREVIEW — deterministic illustrative data, not model benchmark results.");
+        Console.ResetColor();
+        Console.WriteLine("   To run live, configure AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY,");
+        Console.WriteLine("   AZURE_OPENAI_DEPLOYMENT, and a distinct AZURE_OPENAI_DEPLOYMENT_2.");
+        if (AIConfig.IsConfigured && string.IsNullOrWhiteSpace(secondDeployment))
+        {
+            Console.WriteLine("   Primary credentials were found; only AZURE_OPENAI_DEPLOYMENT_2 is missing.");
+        }
+        Console.WriteLine();
+    }
+
+    private static void PrintCheckpoint(int completed, IReadOnlyList<ModelArm> arms)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine($"   Cumulative evidence after {completed} paired trial{(completed == 1 ? string.Empty : "s")}/model");
+        Console.WriteLine("   Model                    Reliable — Wilson 95%        Tool adherence — Wilson 95%   P95 latency");
+        Console.WriteLine("   ──────────────────────── ──────────────────────────── ───────────────────────────── ───────────");
+        Console.ResetColor();
+
+        foreach (var arm in arms)
+        {
+            var summary = ReliabilityRaceSummary.Create(arm.Label, arm.Observations);
+            Console.WriteLine(
+                $"   {Shorten(summary.Label, 24),-24} {FormatCompactRate(summary.Reliable),-28} " +
+                $"{FormatCompactRate(summary.ToolAdherence),-29} {FormatMilliseconds(summary.P95LatencyMs),11}");
+        }
+
+        Console.WriteLine();
+    }
+
+    private static void PrintFinalReport(IReadOnlyList<ModelArm> arms, bool isPreview)
+    {
+        var summaries = arms.Select(arm => ReliabilityRaceSummary.Create(arm.Label, arm.Observations)).ToArray();
+
+        Console.WriteLine("   FINAL SCORECARD");
+        Console.WriteLine("   Rate = estimate [Wilson 95%] (successes/total)\n");
+
+        foreach (var summary in summaries)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"   {summary.Label}");
+            Console.ResetColor();
+            Console.WriteLine($"      Correct answer:       {FormatRate(summary.Correct)}");
+            Console.WriteLine($"      Required tool used:   {FormatRate(summary.ToolAdherence)}");
+            Console.WriteLine($"      Exactly one tool call: {FormatRate(summary.ExactlyOneToolCall)}");
+            Console.WriteLine($"      End-to-end reliable:  {FormatRate(summary.Reliable)}");
+            Console.WriteLine($"      Latency P50 / P95:    {FormatMilliseconds(summary.P50LatencyMs)} / {FormatMilliseconds(summary.P95LatencyMs)}");
+            Console.WriteLine($"      Avg tokens:           {FormatNumber(summary.AverageTokens)}");
+            Console.WriteLine($"      Total cost:           {FormatCost(summary.TotalCost)}");
+            Console.WriteLine($"      Cost / reliable run:  {FormatCost(summary.CostPerReliableRun)}");
+            Console.WriteLine($"      Errors:               {summary.ErrorCount}/{summary.Total}\n");
+        }
+
+        PrintConclusion(summaries);
+        PrintRareFailures(summaries);
+
+        if (isPreview)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("   Preview reminder: every number above is simulated to exercise the talk track.");
+            Console.WriteLine("   Do not present it as a measured comparison of named models.\n");
+            Console.ResetColor();
+        }
+
+        Console.WriteLine("   Takeaway: show the rate, its denominator, and its uncertainty. Keep correctness,");
+        Console.WriteLine("   tool behavior, latency, and economics separate so the audience can choose the trade-off.\n");
+    }
+
+    private static void PrintConclusion(IReadOnlyList<ReliabilityRaceSummary> summaries)
+    {
+        if (summaries.Count != 2 || summaries.Any(s => s.Total == 0))
+        {
+            return;
+        }
+
+        var leader = summaries.OrderByDescending(s => s.Reliable.Estimate).First();
+        var other = summaries.First(s => !ReferenceEquals(s, leader));
+        var delta = leader.Reliable.Estimate - other.Reliable.Estimate;
+        var intervalsSeparate = leader.Reliable.Lower > other.Reliable.Upper;
+
+        Console.WriteLine("   INTERPRETATION");
+        Console.WriteLine($"      Observed reliability delta: {delta:+0.0%;-0.0%;0.0%} in favor of {leader.Label}.");
+        Console.WriteLine(intervalsSeparate
+            ? "      The two Wilson intervals are separated at this sample size: the reliability gap is clear."
+            : "      The Wilson intervals still overlap: describe the observed gap, not a conclusive winner.");
+        Console.WriteLine("      Faster or cheaper can still be the right production choice; the scorecard keeps that visible.\n");
+    }
+
+    private static void PrintRareFailures(IEnumerable<ReliabilityRaceSummary> summaries)
+    {
+        Console.WriteLine("   FIRST RARE FAILURE PER ARM");
+        foreach (var summary in summaries)
+        {
+            var failure = summary.Observations.FirstOrDefault(o => !o.Reliable);
+            if (failure is null)
+            {
+                Console.WriteLine($"      {summary.Label}: none observed");
+                continue;
+            }
+
+            var reason = failure.Error is not null
+                ? $"error={Shorten(failure.Error, 70)}"
+                : $"correct={failure.Correct}, tool={failure.ToolAdherent}, output={Shorten(failure.Output, 70)}";
+            Console.WriteLine($"      {summary.Label}: {failure.Scenario} — {reason}");
+        }
+        Console.WriteLine();
+    }
+
+    private static IReadOnlySet<int> BuildCheckpoints(int runs)
+    {
+        int[] standard = [1, 3, 10, 30, 50, 75, 100, runs];
+        return standard.Where(value => value <= runs).ToHashSet();
+    }
+
+    private static string FormatRate(WilsonInterval interval) =>
+        interval.IsMeasured
+            ? $"{interval.Estimate,5:P1} [{interval.Lower:P1}, {interval.Upper:P1}] ({interval.Successes}/{interval.Total})"
+            : "not measured";
+
+    private static string FormatCompactRate(WilsonInterval interval) =>
+        interval.IsMeasured
+            ? $"{interval.Estimate,5:P1} [{interval.Lower:P1}–{interval.Upper:P1}]"
+            : "not measured";
+
+    private static string FormatMilliseconds(double? milliseconds) =>
+        milliseconds.HasValue ? $"{milliseconds.Value:F0} ms" : "N/A";
+
+    private static string FormatNumber(double? value) => value.HasValue ? $"{value.Value:F0}" : "N/A";
+
+    private static string FormatCost(decimal? value) => value.HasValue ? $"${value.Value:F6}" : "N/A";
+
+    private static string Shorten(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..(maxLength - 1)] + "…";
+
+    private static int ReadInt(string name, int fallback, int min, int max)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        return int.TryParse(raw, out var parsed) ? Math.Clamp(parsed, min, max) : fallback;
+    }
+
+    [Description("Looks up the authoritative support route for a customer tier and issue category")]
+    private static string LookupSupportRoute(
+        [Description("Customer tier: gold, silver, or bronze")] string customerTier,
+        [Description("Issue category: payment, delivery, or account")] string issueCategory)
+    {
+        var key = (customerTier.Trim().ToLowerInvariant(), issueCategory.Trim().ToLowerInvariant());
+        var route = key switch
+        {
+            ("gold", "payment") => "P1-04H",
+            ("gold", "delivery") => "P2-08H",
+            ("gold", "account") => "P2-12H",
+            ("silver", "payment") => "P2-12H",
+            ("silver", "delivery") => "P3-24H",
+            ("silver", "account") => "P3-36H",
+            ("bronze", "payment") => "P3-24H",
+            ("bronze", "delivery") => "P4-48H",
+            ("bronze", "account") => "P4-72H",
+            _ => throw new ArgumentException("Unknown tier or issue category; ask the user to clarify."),
+        };
+
+        return $"Authoritative route: {route}";
+    }
+
+    private sealed record RoutingScenario(
+        string Name,
+        string Prompt,
+        string Tier,
+        string IssueCategory,
+        string ExpectedCode);
+
+    private sealed class ModelArm(
+        string label,
+        string deployment,
+        Func<IEvaluableAgent>? createAgent)
+    {
+        public string Label { get; } = label;
+        public string Deployment { get; } = deployment;
+        public Func<IEvaluableAgent>? CreateAgent { get; } = createAgent;
+        public List<ReliabilityRaceObservation> Observations { get; } = [];
+    }
+}

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/06_ReliabilityRace.cs
@@ -186,15 +186,18 @@ public static class ReliabilityRace
                 ModelName = arm.Deployment,
             });
 
-        var toolCalls = result.ToolUsage?.GetCallsByName(ToolName).Count() ?? 0;
+        var requiredToolCalls = result.ToolUsage?.GetCallsByName(ToolName).ToArray() ?? [];
+        var toolCalls = requiredToolCalls.Length;
         var correct = result.Passed;
         var toolAdherent = toolCalls > 0;
+        var toolExecutionError = requiredToolCalls.Any(call => !call.WasExecuted || call.HasError);
 
         return new ReliabilityRaceObservation(
             Scenario: scenario.Name,
             Correct: correct,
             ToolAdherent: toolAdherent,
-            Reliable: correct && toolAdherent && result.Error is null,
+            ToolExecutionError: toolExecutionError,
+            Reliable: correct && toolAdherent && !toolExecutionError && result.Error is null,
             ToolCalls: toolCalls,
             LatencyMs: result.Performance?.TotalDuration.TotalMilliseconds,
             Cost: result.Performance?.EstimatedCost,
@@ -261,6 +264,7 @@ public static class ReliabilityRace
             Console.WriteLine($"      Correct answer:       {FormatRate(summary.Correct)}");
             Console.WriteLine($"      Required tool used:   {FormatRate(summary.ToolAdherence)}");
             Console.WriteLine($"      Exactly one tool call: {FormatRate(summary.ExactlyOneToolCall)}");
+            Console.WriteLine($"      Tool execution errors: {summary.ToolErrorCount}/{summary.Total} trials");
             Console.WriteLine($"      End-to-end reliable:  {FormatRate(summary.Reliable)}");
             Console.WriteLine($"      Latency P50 / P95:    {FormatMilliseconds(summary.P50LatencyMs)} / {FormatMilliseconds(summary.P95LatencyMs)}");
             Console.WriteLine($"      Avg tokens:           {FormatNumber(summary.AverageTokens)}");
@@ -334,7 +338,8 @@ public static class ReliabilityRace
 
             var reason = failure.Error is not null
                 ? $"error={Shorten(failure.Error, 70)}"
-                : $"correct={failure.Correct}, tool={failure.ToolAdherent}, output={Shorten(failure.Output, 70)}";
+                : $"correct={failure.Correct}, tool={failure.ToolAdherent}, " +
+                  $"toolError={failure.ToolExecutionError}, output={Shorten(failure.Output, 70)}";
             Console.WriteLine($"      {summary.Label}: {failure.Scenario} — {reason}");
         }
         Console.WriteLine();

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -25,7 +25,7 @@ internal static class ReliabilityRaceRunCountSelector
         {
             if (int.TryParse(configuredValue, out var configured) && Allowed.Contains(configured))
             {
-                output.WriteLine($"   Iterations: {configured} per model (AGENTEVAL_RELIABILITY_RUNS)\n");
+                output.WriteLine($"   Agent runs: {configured} per model (AGENTEVAL_RELIABILITY_RUNS)\n");
                 return configured;
             }
 
@@ -36,11 +36,11 @@ internal static class ReliabilityRaceRunCountSelector
 
         if (!interactive)
         {
-            output.WriteLine($"   Iterations: {Default} per model (non-interactive default)\n");
+            output.WriteLine($"   Agent runs: {Default} per model (non-interactive default)\n");
             return Default;
         }
 
-        output.WriteLine("   Choose the stochastic depth (paired trials per model):");
+        output.WriteLine("   Choose the stochastic depth (agent runs per model):");
         output.WriteLine("      5    quick pulse");
         output.WriteLine("      10   short rehearsal");
         output.WriteLine("      20   recommended live demo");
@@ -48,7 +48,7 @@ internal static class ReliabilityRaceRunCountSelector
 
         while (true)
         {
-            output.Write($"   Iterations [default {Default}]: ");
+            output.Write($"   Agent runs/model [default {Default}]: ");
             var raw = input.ReadLine()?.Trim();
             if (string.IsNullOrEmpty(raw))
             {

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -146,3 +146,130 @@ internal sealed record ReliabilityRaceSummary(
         return sorted[lower] + ((sorted[upper] - sorted[lower]) * fraction);
     }
 }
+
+/// <summary>
+/// Produces an honest reliability interpretation and an unweighted, multi-factor recommendation.
+/// </summary>
+internal sealed record ReliabilityRaceDecision(
+    bool ReliabilityIsDraw,
+    string? ReliabilityLeader,
+    double ReliabilityDelta,
+    bool ReliabilityIntervalsSeparate,
+    IReadOnlyList<string> RecommendedWinners,
+    string RecommendationReason)
+{
+    private const double EqualityTolerance = 1e-12;
+
+    public bool RecommendationIsTie => RecommendedWinners.Count > 1;
+
+    public static ReliabilityRaceDecision Create(
+        ReliabilityRaceSummary first,
+        ReliabilityRaceSummary second)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+
+        var reliabilityComparison = CompareHigher(first.Reliable.Estimate, second.Reliable.Estimate);
+        var reliabilityIsDraw = reliabilityComparison == 0;
+        var reliabilityLeader = reliabilityComparison switch
+        {
+            > 0 => first,
+            < 0 => second,
+            _ => null,
+        };
+        var reliabilityOther = ReferenceEquals(reliabilityLeader, first) ? second : first;
+
+        var factors = new List<(string Name, int Comparison)>
+        {
+            ("correctness", CompareHigher(first.Correct.Estimate, second.Correct.Estimate)),
+            ("required-tool adherence", CompareHigher(first.ToolAdherence.Estimate, second.ToolAdherence.Estimate)),
+            ("exactly-one-tool efficiency", CompareHigher(first.ExactlyOneToolCall.Estimate, second.ExactlyOneToolCall.Estimate)),
+            ("end-to-end reliability", reliabilityComparison),
+            ("error rate", CompareLower(Rate(first.ErrorCount, first.Total), Rate(second.ErrorCount, second.Total))),
+        };
+
+        AddNullableFactor(factors, "P50 latency", first.P50LatencyMs, second.P50LatencyMs);
+        AddNullableFactor(factors, "P95 latency", first.P95LatencyMs, second.P95LatencyMs);
+        AddNullableFactor(factors, "average tokens", first.AverageTokens, second.AverageTokens);
+        AddNullableFactor(factors, "total cost", first.TotalCost, second.TotalCost);
+        AddNullableFactor(factors, "cost per reliable run", first.CostPerReliableRun, second.CostPerReliableRun);
+
+        var firstDominates = factors.All(factor => factor.Comparison >= 0)
+            && factors.Any(factor => factor.Comparison > 0);
+        var secondDominates = factors.All(factor => factor.Comparison <= 0)
+            && factors.Any(factor => factor.Comparison < 0);
+
+        IReadOnlyList<string> winners;
+        string reason;
+        if (firstDominates)
+        {
+            winners = [first.Label];
+            reason = DominanceReason(first.Label, factors.Where(factor => factor.Comparison > 0).Select(factor => factor.Name));
+        }
+        else if (secondDominates)
+        {
+            winners = [second.Label];
+            reason = DominanceReason(second.Label, factors.Where(factor => factor.Comparison < 0).Select(factor => factor.Name));
+        }
+        else
+        {
+            winners = [first.Label, second.Label];
+            var firstLeads = factors.Where(factor => factor.Comparison > 0).Select(factor => factor.Name).ToArray();
+            var secondLeads = factors.Where(factor => factor.Comparison < 0).Select(factor => factor.Name).ToArray();
+            reason = firstLeads.Length == 0 && secondLeads.Length == 0
+                ? "Every comparable factor is tied."
+                : $"Neither model dominates: {LeadSummary(first.Label, firstLeads)}; {LeadSummary(second.Label, secondLeads)}.";
+        }
+
+        return new ReliabilityRaceDecision(
+            ReliabilityIsDraw: reliabilityIsDraw,
+            ReliabilityLeader: reliabilityLeader?.Label,
+            ReliabilityDelta: Math.Abs(first.Reliable.Estimate - second.Reliable.Estimate),
+            ReliabilityIntervalsSeparate: reliabilityLeader is not null
+                && reliabilityLeader.Reliable.Lower > reliabilityOther.Reliable.Upper,
+            RecommendedWinners: winners,
+            RecommendationReason: reason);
+    }
+
+    private static int CompareHigher(double first, double second) => Compare(first, second);
+
+    private static int CompareLower(double first, double second) => -Compare(first, second);
+
+    private static int Compare(decimal first, decimal second) =>
+        first == second ? 0 : first > second ? 1 : -1;
+
+    private static int Compare(double first, double second) =>
+        Math.Abs(first - second) <= EqualityTolerance ? 0 : first > second ? 1 : -1;
+
+    private static double Rate(int count, int total) => total == 0 ? 0 : (double)count / total;
+
+    private static void AddNullableFactor(
+        ICollection<(string Name, int Comparison)> factors,
+        string name,
+        double? first,
+        double? second)
+    {
+        if (first.HasValue && second.HasValue)
+        {
+            factors.Add((name, CompareLower(first.Value, second.Value)));
+        }
+    }
+
+    private static void AddNullableFactor(
+        ICollection<(string Name, int Comparison)> factors,
+        string name,
+        decimal? first,
+        decimal? second)
+    {
+        if (first.HasValue && second.HasValue)
+        {
+            factors.Add((name, -Compare(first.Value, second.Value)));
+        }
+    }
+
+    private static string DominanceReason(string winner, IEnumerable<string> advantages) =>
+        $"{winner} is no worse on any measured factor and leads on {string.Join(", ", advantages)}.";
+
+    private static string LeadSummary(string label, IReadOnlyCollection<string> advantages) =>
+        advantages.Count == 0 ? $"{label} leads on none" : $"{label} leads on {string.Join(", ", advantages)}";
+}

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -72,6 +72,7 @@ internal sealed record ReliabilityRaceObservation(
     string Scenario,
     bool Correct,
     bool ToolAdherent,
+    bool ToolExecutionError,
     bool Reliable,
     int ToolCalls,
     double? LatencyMs,
@@ -93,6 +94,7 @@ internal sealed record ReliabilityRaceSummary(
     double? AverageTokens,
     decimal? TotalCost,
     decimal? CostPerReliableRun,
+    int ToolErrorCount,
     int ErrorCount)
 {
     public int Total => Observations.Count;
@@ -123,6 +125,7 @@ internal sealed record ReliabilityRaceSummary(
             AverageTokens: tokens.Length > 0 ? tokens.Average() : null,
             TotalCost: totalCost,
             CostPerReliableRun: totalCost.HasValue && reliableCount > 0 ? totalCost.Value / reliableCount : null,
+            ToolErrorCount: observations.Count(o => o.ToolExecutionError),
             ErrorCount: observations.Count(o => o.Error is not null));
     }
 
@@ -185,6 +188,7 @@ internal sealed record ReliabilityRaceDecision(
             ("required-tool adherence", CompareHigher(first.ToolAdherence.Estimate, second.ToolAdherence.Estimate)),
             ("exactly-one-tool efficiency", CompareHigher(first.ExactlyOneToolCall.Estimate, second.ExactlyOneToolCall.Estimate)),
             ("end-to-end reliability", reliabilityComparison),
+            ("tool execution error rate", CompareLower(Rate(first.ToolErrorCount, first.Total), Rate(second.ToolErrorCount, second.Total))),
             ("error rate", CompareLower(Rate(first.ErrorCount, first.Total), Rate(second.ErrorCount, second.Total))),
         };
 

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+
+using AgentEval.RedTeam.Reporting;
+
+namespace AgentEval.Samples;
+
+/// <summary>A single paired-trial observation used by the Reliability Race sample.</summary>
+internal sealed record ReliabilityRaceObservation(
+    string Scenario,
+    bool Correct,
+    bool ToolAdherent,
+    bool Reliable,
+    int ToolCalls,
+    double? LatencyMs,
+    decimal? Cost,
+    int? TotalTokens,
+    string Output,
+    string? Error);
+
+/// <summary>Deterministic aggregation for one Reliability Race model arm.</summary>
+internal sealed record ReliabilityRaceSummary(
+    string Label,
+    IReadOnlyList<ReliabilityRaceObservation> Observations,
+    WilsonInterval Correct,
+    WilsonInterval ToolAdherence,
+    WilsonInterval ExactlyOneToolCall,
+    WilsonInterval Reliable,
+    double? P50LatencyMs,
+    double? P95LatencyMs,
+    double? AverageTokens,
+    decimal? TotalCost,
+    decimal? CostPerReliableRun,
+    int ErrorCount)
+{
+    public int Total => Observations.Count;
+
+    public static ReliabilityRaceSummary Create(
+        string label,
+        IReadOnlyList<ReliabilityRaceObservation> observations)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(label);
+        ArgumentNullException.ThrowIfNull(observations);
+
+        var total = observations.Count;
+        var reliableCount = observations.Count(o => o.Reliable);
+        var latencies = observations.Where(o => o.LatencyMs.HasValue).Select(o => o.LatencyMs!.Value).ToArray();
+        var tokens = observations.Where(o => o.TotalTokens.HasValue).Select(o => (double)o.TotalTokens!.Value).ToArray();
+        var costs = observations.Where(o => o.Cost.HasValue).Select(o => o.Cost!.Value).ToArray();
+        var totalCost = costs.Length > 0 ? costs.Sum() : (decimal?)null;
+
+        return new ReliabilityRaceSummary(
+            Label: label,
+            Observations: observations,
+            Correct: WilsonInterval.Compute(observations.Count(o => o.Correct), total),
+            ToolAdherence: WilsonInterval.Compute(observations.Count(o => o.ToolAdherent), total),
+            ExactlyOneToolCall: WilsonInterval.Compute(observations.Count(o => o.ToolCalls == 1), total),
+            Reliable: WilsonInterval.Compute(reliableCount, total),
+            P50LatencyMs: Percentile(latencies, 50),
+            P95LatencyMs: Percentile(latencies, 95),
+            AverageTokens: tokens.Length > 0 ? tokens.Average() : null,
+            TotalCost: totalCost,
+            CostPerReliableRun: totalCost.HasValue && reliableCount > 0 ? totalCost.Value / reliableCount : null,
+            ErrorCount: observations.Count(o => o.Error is not null));
+    }
+
+    private static double? Percentile(IReadOnlyCollection<double> values, double percentile)
+    {
+        if (values.Count == 0)
+        {
+            return null;
+        }
+
+        var sorted = values.OrderBy(value => value).ToArray();
+        var index = percentile / 100d * (sorted.Length - 1);
+        var lower = (int)Math.Floor(index);
+        var upper = (int)Math.Ceiling(index);
+        if (lower == upper)
+        {
+            return sorted[lower];
+        }
+
+        var fraction = index - lower;
+        return sorted[lower] + ((sorted[upper] - sorted[lower]) * fraction);
+    }
+}

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -5,6 +5,68 @@ using AgentEval.RedTeam.Reporting;
 
 namespace AgentEval.Samples;
 
+/// <summary>Selects a bounded, presentation-friendly number of paired stochastic trials.</summary>
+internal static class ReliabilityRaceRunCountSelector
+{
+    public const int Default = 20;
+
+    private static readonly IReadOnlySet<int> Allowed = new HashSet<int> { 5, 10, 20, 100 };
+
+    public static int Select(
+        string? configuredValue,
+        bool interactive,
+        TextReader input,
+        TextWriter output)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(output);
+
+        if (!string.IsNullOrWhiteSpace(configuredValue))
+        {
+            if (int.TryParse(configuredValue, out var configured) && Allowed.Contains(configured))
+            {
+                output.WriteLine($"   Iterations: {configured} per model (AGENTEVAL_RELIABILITY_RUNS)\n");
+                return configured;
+            }
+
+            throw new ArgumentException(
+                "AGENTEVAL_RELIABILITY_RUNS must be one of: 5, 10, 20, 100.",
+                nameof(configuredValue));
+        }
+
+        if (!interactive)
+        {
+            output.WriteLine($"   Iterations: {Default} per model (non-interactive default)\n");
+            return Default;
+        }
+
+        output.WriteLine("   Choose the stochastic depth (paired trials per model):");
+        output.WriteLine("      5    quick pulse");
+        output.WriteLine("      10   short rehearsal");
+        output.WriteLine("      20   recommended live demo");
+        output.WriteLine("      100  evidence run with a much tighter interval");
+
+        while (true)
+        {
+            output.Write($"   Iterations [default {Default}]: ");
+            var raw = input.ReadLine()?.Trim();
+            if (string.IsNullOrEmpty(raw))
+            {
+                output.WriteLine();
+                return Default;
+            }
+
+            if (int.TryParse(raw, out var selected) && Allowed.Contains(selected))
+            {
+                output.WriteLine();
+                return selected;
+            }
+
+            output.WriteLine("   Enter 5, 10, 20, or 100.\n");
+        }
+    }
+}
+
 /// <summary>A single paired-trial observation used by the Reliability Race sample.</summary>
 internal sealed record ReliabilityRaceObservation(
     string Scenario,

--- a/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
+++ b/samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs
@@ -67,6 +67,32 @@ internal static class ReliabilityRaceRunCountSelector
     }
 }
 
+/// <summary>Pure trial rules kept separate so the live demo's pass/fail behavior is deterministic and testable.</summary>
+internal static class ReliabilityRaceTrialRules
+{
+    public static bool IsExactRouteOutput(string? actualOutput, string expectedCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedCode);
+        return string.Equals(
+            actualOutput?.Trim(),
+            $"ROUTE={expectedCode}",
+            StringComparison.Ordinal);
+    }
+
+    public static bool HasConsecutiveSetupFailures(
+        IReadOnlyList<ReliabilityRaceObservation> observations,
+        int requiredConsecutiveFailures = 3)
+    {
+        ArgumentNullException.ThrowIfNull(observations);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(requiredConsecutiveFailures);
+
+        return observations.Count >= requiredConsecutiveFailures
+            && observations
+                .Skip(observations.Count - requiredConsecutiveFailures)
+                .All(observation => observation.Error is not null);
+    }
+}
+
 /// <summary>A single paired-trial observation used by the Reliability Race sample.</summary>
 internal sealed record ReliabilityRaceObservation(
     string Scenario,
@@ -228,7 +254,9 @@ internal sealed record ReliabilityRaceDecision(
         return new ReliabilityRaceDecision(
             ReliabilityIsDraw: reliabilityIsDraw,
             ReliabilityLeader: reliabilityLeader?.Label,
-            ReliabilityDelta: Math.Abs(first.Reliable.Estimate - second.Reliable.Estimate),
+            ReliabilityDelta: reliabilityIsDraw
+                ? 0
+                : Math.Abs(first.Reliable.Estimate - second.Reliable.Estimate),
             ReliabilityIntervalsSeparate: reliabilityLeader is not null
                 && reliabilityLeader.Reliable.Lower > reliabilityOther.Reliable.Upper,
             RecommendedWinners: winners,

--- a/samples/AgentEval.Samples/Program.cs
+++ b/samples/AgentEval.Samples/Program.cs
@@ -13,6 +13,9 @@ public static class Program
 {
     private static bool _interactive = true;
 
+    /// <summary>Whether samples may prompt for interactive input.</summary>
+    internal static bool IsInteractive => _interactive;
+
     // ──────────────────────────────────────────────────────────
     //  Sample catalogue — one record per group, samples in order
     // ──────────────────────────────────────────────────────────
@@ -63,7 +66,7 @@ public static class Program
             new("Model Comparison",          "Compare and rank 3 models on quality, speed, cost, reliability",       ModelComparison.RunAsync),
             new("Stochastic + Comparison",   "Stochastic rigor applied to side-by-side model comparison",           CombinedStochasticComparison.RunAsync),
             new("Streaming vs Async",        "TTFT vs throughput — compare streaming and non-streaming modes",       StreamingVsAsyncPerformance.RunAsync),
-            new("Reliability Race",          "Two models, cumulative pass rate, Wilson intervals, tool adherence",   ReliabilityRace.RunAsync),
+            new("Reliability Race",          "Two models, choose 5/10/20/100 runs, Wilson intervals, tool adherence", ReliabilityRace.RunAsync),
         ]),
 
         new('E', "Safety & Security", "",

--- a/samples/AgentEval.Samples/Program.cs
+++ b/samples/AgentEval.Samples/Program.cs
@@ -63,6 +63,7 @@ public static class Program
             new("Model Comparison",          "Compare and rank 3 models on quality, speed, cost, reliability",       ModelComparison.RunAsync),
             new("Stochastic + Comparison",   "Stochastic rigor applied to side-by-side model comparison",           CombinedStochasticComparison.RunAsync),
             new("Streaming vs Async",        "TTFT vs throughput — compare streaming and non-streaming modes",       StreamingVsAsyncPerformance.RunAsync),
+            new("Reliability Race",          "Two models, cumulative pass rate, Wilson intervals, tool adherence",   ReliabilityRace.RunAsync),
         ]),
 
         new('E', "Safety & Security", "",

--- a/samples/AgentEval.Samples/Program.cs
+++ b/samples/AgentEval.Samples/Program.cs
@@ -66,7 +66,7 @@ public static class Program
             new("Model Comparison",          "Compare and rank 3 models on quality, speed, cost, reliability",       ModelComparison.RunAsync),
             new("Stochastic + Comparison",   "Stochastic rigor applied to side-by-side model comparison",           CombinedStochasticComparison.RunAsync),
             new("Streaming vs Async",        "TTFT vs throughput — compare streaming and non-streaming modes",       StreamingVsAsyncPerformance.RunAsync),
-            new("Reliability Race",          "Two models, choose 5/10/20/100 runs, Wilson intervals, tool adherence", ReliabilityRace.RunAsync),
+            new("Reliability Race",          "Two live models, choose 5/10/20/100 runs, Wilson intervals, adherence", ReliabilityRace.RunAsync),
         ]),
 
         new('E', "Safety & Security", "",

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -338,10 +338,14 @@ result.Statistics.StandardDeviation.Should().BeLessThan(10); // consistency
 
 ### Reliability Race (D6)
 
-D6 runs the same routing scenario against two fresh model sessions in alternating order. It reports
-correctness, required-tool adherence, end-to-end reliability, Wilson 95% intervals, P50/P95 latency,
-tokens, and cost without hiding the trade-offs in a composite score. It asks for 5, 10, 20, or 100
-paired trials per deployment (20 is the recommended live-demo default). Set
+D6 rotates nine routing scenarios (three customer tiers × three issue types) through two fresh model
+sessions in alternating order. Each paired round gives both models the same scenario, so the comparison
+is fair while still testing robustness beyond one lucky or memorized prompt. It reports correctness,
+required-tool adherence, end-to-end reliability, Wilson 95% intervals, P50/P95 latency, tokens, and cost
+without hiding the trade-offs in a composite score. It asks for 5, 10, 20, or 100 agent runs per
+deployment (20 is the recommended live-demo default). Choosing 100 therefore schedules exactly 100
+agent runs per model and 200 total agent runs. A tool-using agent run normally makes more than one
+low-level model API request, so API-request count is not the same as agent-run count. Set
 `AGENTEVAL_RELIABILITY_RUNS` to one of those values for non-interactive runs.
 
 D6 is live-only: it never fabricates observations and has no simulated fallback. It reuses the same

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -83,7 +83,7 @@ family-specific — see H1 Registry Discovery or `Benchmarks/README.md` for the 
 | 3 | **Model Comparison** | Compare & rank 3 models on quality, speed, cost, reliability | Yes ×3 | 10 min |
 | 4 | **Stochastic + Comparison** | Statistical rigor applied to side-by-side model comparison | Yes ×2 | 10 min |
 | 5 | **Streaming vs Async** | TTFT vs throughput — compare streaming and non-streaming | Yes | 8 min |
-| 6 | **Reliability Race** | Two-model stochastic race; choose 5/10/20/100 runs; Wilson intervals and tool adherence | Optional ×2; offline preview | 8 min |
+| 6 | **Reliability Race** | Two live models; choose 5/10/20/100 runs; Wilson intervals and tool adherence | Yes ×2 | 8 min |
 
 ### E — Safety & Security
 
@@ -278,7 +278,7 @@ export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
 
 ### Without Azure (mock mode — Group A samples A1–A4 + H1 + H13 + all of Group J)
 
-Samples in **Group A (A1–A4)**, **D6 Reliability Race** (illustrative preview), **H1 Registry Discovery**, **H13 Report Browser**, and all of **Group J (Gatekeeper)**
+Samples in **Group A (A1–A4)**, **H1 Registry Discovery**, **H13 Report Browser**, and all of **Group J (Gatekeeper)**
 work fully without credentials. You'll see:
 
 ```
@@ -344,10 +344,11 @@ tokens, and cost without hiding the trade-offs in a composite score. It asks for
 paired trials per deployment (20 is the recommended live-demo default). Set
 `AGENTEVAL_RELIABILITY_RUNS` to one of those values for non-interactive runs.
 
-For a visible capability/cost contrast, point `AZURE_OPENAI_DEPLOYMENT` at a balanced mini deployment
-and `AZURE_OPENAI_DEPLOYMENT_2` at an economy/nano deployment available in your Azure region. Azure
-deployment names are user-defined—the sample compares exactly the two names you configure. Without
-both deployments it renders a deterministic, explicitly simulated conference preview.
+D6 is live-only: it never fabricates observations and has no simulated fallback. It reuses the same
+`AIConfig` endpoint and API key as every other live sample. The two arms come from the existing shared
+deployment slots: `AIConfig.ModelDeployment` and `AIConfig.SecondaryModelDeployment`. The recommended
+conference pair is **gpt-5.5** (frontier arm) versus **gpt-4o-mini** (economy arm); the secondary slot
+already defaults to `gpt-4o-mini`, so D6 introduces no new credential or D6-specific configuration.
 
 ### Policy guardrails (E1)
 ```csharp

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -83,6 +83,7 @@ family-specific — see H1 Registry Discovery or `Benchmarks/README.md` for the 
 | 3 | **Model Comparison** | Compare & rank 3 models on quality, speed, cost, reliability | Yes ×3 | 10 min |
 | 4 | **Stochastic + Comparison** | Statistical rigor applied to side-by-side model comparison | Yes ×2 | 10 min |
 | 5 | **Streaming vs Async** | TTFT vs throughput — compare streaming and non-streaming | Yes | 8 min |
+| 6 | **Reliability Race** | Two-model cumulative reliability, Wilson 95% intervals, tool adherence, latency and cost | Optional ×2; offline preview | 8 min |
 
 ### E — Safety & Security
 
@@ -260,9 +261,12 @@ $env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
 # Optional: embedding-based metrics (B1 — Comprehensive RAG)
 $env:AZURE_OPENAI_EMBEDDING_DEPLOYMENT = "text-embedding-ada-002"
 
-# Optional: multi-model samples (B3 Judge Calibration, D3 Model Comparison, D4 Stochastic+Comparison)
+# Optional: multi-model samples (B3 Judge Calibration, D3 Model Comparison, D4 Stochastic+Comparison, D6 Reliability Race)
 $env:AZURE_OPENAI_DEPLOYMENT_2 = "gpt-4o-mini"
 $env:AZURE_OPENAI_DEPLOYMENT_3 = "gpt-4.1"
+
+# D6 defaults to 100 paired trials/model; lower this for a quick live rehearsal
+$env:AGENTEVAL_RELIABILITY_RUNS = "20"
 ```
 
 ```bash
@@ -274,7 +278,7 @@ export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
 
 ### Without Azure (mock mode — Group A samples A1–A4 + H1 + H13 + all of Group J)
 
-Samples in **Group A (A1–A4)**, **H1 Registry Discovery**, **H13 Report Browser**, and all of **Group J (Gatekeeper)**
+Samples in **Group A (A1–A4)**, **D6 Reliability Race** (illustrative preview), **H1 Registry Discovery**, **H13 Report Browser**, and all of **Group J (Gatekeeper)**
 work fully without credentials. You'll see:
 
 ```
@@ -331,6 +335,18 @@ var result = await runner.RunStochasticTestAsync(
 result.Statistics.Mean.Should().BeGreaterThan(80);          // avg quality
 result.Statistics.StandardDeviation.Should().BeLessThan(10); // consistency
 ```
+
+### Reliability Race (D6)
+
+D6 runs the same routing scenario against two fresh model sessions in alternating order. It reports
+correctness, required-tool adherence, end-to-end reliability, Wilson 95% intervals, P50/P95 latency,
+tokens, and cost without hiding the trade-offs in a composite score. It defaults to 100 paired trials
+per deployment; set `AGENTEVAL_RELIABILITY_RUNS` lower for rehearsals.
+
+For a visible capability/cost contrast, point `AZURE_OPENAI_DEPLOYMENT` at a balanced mini deployment
+and `AZURE_OPENAI_DEPLOYMENT_2` at an economy/nano deployment available in your Azure region. Azure
+deployment names are user-defined—the sample compares exactly the two names you configure. Without
+both deployments it renders a deterministic, explicitly simulated conference preview.
 
 ### Policy guardrails (E1)
 ```csharp

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -83,7 +83,7 @@ family-specific — see H1 Registry Discovery or `Benchmarks/README.md` for the 
 | 3 | **Model Comparison** | Compare & rank 3 models on quality, speed, cost, reliability | Yes ×3 | 10 min |
 | 4 | **Stochastic + Comparison** | Statistical rigor applied to side-by-side model comparison | Yes ×2 | 10 min |
 | 5 | **Streaming vs Async** | TTFT vs throughput — compare streaming and non-streaming | Yes | 8 min |
-| 6 | **Reliability Race** | Two-model cumulative reliability, Wilson 95% intervals, tool adherence, latency and cost | Optional ×2; offline preview | 8 min |
+| 6 | **Reliability Race** | Two-model stochastic race; choose 5/10/20/100 runs; Wilson intervals and tool adherence | Optional ×2; offline preview | 8 min |
 
 ### E — Safety & Security
 
@@ -265,7 +265,7 @@ $env:AZURE_OPENAI_EMBEDDING_DEPLOYMENT = "text-embedding-ada-002"
 $env:AZURE_OPENAI_DEPLOYMENT_2 = "gpt-4o-mini"
 $env:AZURE_OPENAI_DEPLOYMENT_3 = "gpt-4.1"
 
-# D6 defaults to 100 paired trials/model; lower this for a quick live rehearsal
+# D6 prompts for 5, 10, 20, or 100 paired trials/model; set this for automation
 $env:AGENTEVAL_RELIABILITY_RUNS = "20"
 ```
 
@@ -340,8 +340,9 @@ result.Statistics.StandardDeviation.Should().BeLessThan(10); // consistency
 
 D6 runs the same routing scenario against two fresh model sessions in alternating order. It reports
 correctness, required-tool adherence, end-to-end reliability, Wilson 95% intervals, P50/P95 latency,
-tokens, and cost without hiding the trade-offs in a composite score. It defaults to 100 paired trials
-per deployment; set `AGENTEVAL_RELIABILITY_RUNS` lower for rehearsals.
+tokens, and cost without hiding the trade-offs in a composite score. It asks for 5, 10, 20, or 100
+paired trials per deployment (20 is the recommended live-demo default). Set
+`AGENTEVAL_RELIABILITY_RUNS` to one of those values for non-interactive runs.
 
 For a visible capability/cost contrast, point `AZURE_OPENAI_DEPLOYMENT` at a balanced mini deployment
 and `AZURE_OPENAI_DEPLOYMENT_2` at an economy/nano deployment available in your Azure region. Azure

--- a/samples/AgentEval.Samples/README.md
+++ b/samples/AgentEval.Samples/README.md
@@ -265,8 +265,9 @@ $env:AZURE_OPENAI_EMBEDDING_DEPLOYMENT = "text-embedding-ada-002"
 $env:AZURE_OPENAI_DEPLOYMENT_2 = "gpt-4o-mini"
 $env:AZURE_OPENAI_DEPLOYMENT_3 = "gpt-4.1"
 
-# D6 prompts for 5, 10, 20, or 100 paired trials/model; set this for automation
+# D6 prompts for 5, 10, 20, or 100 agent runs/model; set these for automation/rate limits
 $env:AGENTEVAL_RELIABILITY_RUNS = "20"
+$env:AGENTEVAL_RELIABILITY_DELAY_MS = "250"
 ```
 
 ```bash
@@ -346,7 +347,8 @@ without hiding the trade-offs in a composite score. It asks for 5, 10, 20, or 10
 deployment (20 is the recommended live-demo default). Choosing 100 therefore schedules exactly 100
 agent runs per model and 200 total agent runs. A tool-using agent run normally makes more than one
 low-level model API request, so API-request count is not the same as agent-run count. Set
-`AGENTEVAL_RELIABILITY_RUNS` to one of those values for non-interactive runs.
+`AGENTEVAL_RELIABILITY_RUNS` to one of those values for non-interactive runs. Optionally set
+`AGENTEVAL_RELIABILITY_DELAY_MS` to pause between agent runs when the deployments need rate-limit headroom.
 
 D6 is live-only: it never fabricates observations and has no simulated fallback. It reuses the same
 `AIConfig` endpoint and API key as every other live sample. The two arms come from the existing shared

--- a/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
+++ b/src/AgentEval.Abstractions/Models/PerformanceMetrics.cs
@@ -89,6 +89,7 @@ public static class ModelPricing
         new(StringComparer.OrdinalIgnoreCase)
     {
         // OpenAI models (GPT family)
+        ["gpt-5.5"] = (0.005m, 0.03m),        // $5 / $30 per 1M tokens (2026-08)
         ["gpt-5"] = (0.005m, 0.02m),          // GPT-5 (estimated pricing)
         ["gpt-5-chat"] = (0.005m, 0.02m),     // GPT-5 chat variant
         ["gpt-5-mini"] = (0.0001m, 0.0004m),  // GPT-5 mini (placeholder)

--- a/tests/AgentEval.Tests/AgentEval.Tests.csproj
+++ b/tests/AgentEval.Tests/AgentEval.Tests.csproj
@@ -69,4 +69,11 @@
                       LogicalName="AgentEval.Tests.GatekeeperReplayCorpus.jsonl" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Compile the demo's pure aggregation helper into the test assembly. This keeps the live
+         sample net10-only while exercising its statistics across every test target framework. -->
+    <Compile Include="../../samples/AgentEval.Samples/PerformanceAndStatistics/ReliabilityRaceStatistics.cs"
+             Link="Samples/ReliabilityRaceStatistics.cs" />
+  </ItemGroup>
+
 </Project>

--- a/tests/AgentEval.Tests/Models/ModelPricingTests.cs
+++ b/tests/AgentEval.Tests/Models/ModelPricingTests.cs
@@ -13,6 +13,7 @@ namespace AgentEval.Tests;
 public class ModelPricingTests
 {
     [Theory]
+    [InlineData("gpt-5.5", 1000, 1000, 0.035)] // 0.005 + 0.030
     [InlineData("gpt-4o", 1000, 500, 0.0125)] // 0.005 + 0.0075
     [InlineData("gpt-4o-mini", 1000, 500, 0.00045)] // 0.00015 + 0.0003
     [InlineData("gpt-3.5-turbo", 1000, 1000, 0.002)] // 0.0005 + 0.0015

--- a/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
+++ b/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
@@ -7,6 +7,72 @@ namespace AgentEval.Tests.Samples;
 
 public sealed class ReliabilityRaceStatisticsTests
 {
+    [Fact]
+    public void Decision_EqualReliabilityButEconomyDominates_RecommendsEconomyWithoutInventingReliabilityLead()
+    {
+        var frontier = ReliabilityRaceSummary.Create(
+            "frontier",
+            Enumerable.Range(0, 5)
+                .Select(_ => Observation(true, true, true, 1, latencyMs: 3000, cost: 0.004m, tokens: 600))
+                .ToArray());
+        var economy = ReliabilityRaceSummary.Create(
+            "economy",
+            Enumerable.Range(0, 5)
+                .Select(_ => Observation(true, true, true, 1, latencyMs: 1500, cost: 0.0001m, tokens: 400))
+                .ToArray());
+
+        var decision = ReliabilityRaceDecision.Create(frontier, economy);
+
+        Assert.True(decision.ReliabilityIsDraw);
+        Assert.Null(decision.ReliabilityLeader);
+        Assert.Equal(0, decision.ReliabilityDelta);
+        Assert.False(decision.RecommendationIsTie);
+        Assert.Equal("economy", Assert.Single(decision.RecommendedWinners));
+        Assert.Contains("no worse", decision.RecommendationReason);
+    }
+
+    [Fact]
+    public void Decision_QualityVersusEfficiencyTradeoff_NamesBothJointWinners()
+    {
+        var quality = ReliabilityRaceSummary.Create(
+            "quality",
+            [
+                Observation(true, true, true, 1, latencyMs: 3000, cost: 0.004m, tokens: 600),
+                Observation(true, true, true, 1, latencyMs: 3000, cost: 0.004m, tokens: 600),
+            ]);
+        var efficiency = ReliabilityRaceSummary.Create(
+            "efficiency",
+            [
+                Observation(true, true, true, 1, latencyMs: 1000, cost: 0.0001m, tokens: 300),
+                Observation(false, true, false, 1, latencyMs: 1000, cost: 0.0001m, tokens: 300),
+            ]);
+
+        var decision = ReliabilityRaceDecision.Create(quality, efficiency);
+
+        Assert.False(decision.ReliabilityIsDraw);
+        Assert.True(decision.RecommendationIsTie);
+        Assert.Equal(["quality", "efficiency"], decision.RecommendedWinners);
+        Assert.Contains("Neither model dominates", decision.RecommendationReason);
+    }
+
+    [Fact]
+    public void Decision_AllFactorsEqual_NamesBothJointWinners()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(true, true, true, 1, latencyMs: 1000, cost: 0.001m, tokens: 300),
+        ];
+
+        var decision = ReliabilityRaceDecision.Create(
+            ReliabilityRaceSummary.Create("a", observations),
+            ReliabilityRaceSummary.Create("b", observations));
+
+        Assert.True(decision.ReliabilityIsDraw);
+        Assert.True(decision.RecommendationIsTie);
+        Assert.Equal(["a", "b"], decision.RecommendedWinners);
+        Assert.Equal("Every comparable factor is tied.", decision.RecommendationReason);
+    }
+
     [Theory]
     [InlineData("5", 5)]
     [InlineData("10", 10)]

--- a/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
+++ b/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
@@ -73,6 +73,23 @@ public sealed class ReliabilityRaceStatisticsTests
         Assert.Equal("Every comparable factor is tied.", decision.RecommendationReason);
     }
 
+    [Fact]
+    public void Decision_ToolExecutionError_RecommendsErrorFreeModelAndNamesFactor()
+    {
+        var errorFree = ReliabilityRaceSummary.Create(
+            "error-free",
+            [Observation(true, true, true, 1)]);
+        var toolError = ReliabilityRaceSummary.Create(
+            "tool-error",
+            [Observation(true, true, false, 1, toolExecutionError: true)]);
+
+        var decision = ReliabilityRaceDecision.Create(errorFree, toolError);
+
+        Assert.False(decision.RecommendationIsTie);
+        Assert.Equal("error-free", Assert.Single(decision.RecommendedWinners));
+        Assert.Contains("tool execution error rate", decision.RecommendationReason);
+    }
+
     [Theory]
     [InlineData("5", 5)]
     [InlineData("10", 10)]
@@ -202,11 +219,13 @@ public sealed class ReliabilityRaceStatisticsTests
         double? latencyMs = null,
         decimal? cost = null,
         int? tokens = null,
-        string? error = null) =>
+        string? error = null,
+        bool toolExecutionError = false) =>
         new(
             Scenario: "scenario",
             Correct: correct,
             ToolAdherent: toolAdherent,
+            ToolExecutionError: toolExecutionError,
             Reliable: reliable,
             ToolCalls: toolCalls,
             LatencyMs: latencyMs,

--- a/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
+++ b/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+
+using AgentEval.Samples;
+
+namespace AgentEval.Tests.Samples;
+
+public sealed class ReliabilityRaceStatisticsTests
+{
+    [Fact]
+    public void Create_MixedOutcomes_SeparatesCorrectnessToolUseAndReliability()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(correct: true, toolAdherent: true, reliable: true, toolCalls: 1),
+            Observation(correct: true, toolAdherent: false, reliable: false, toolCalls: 0),
+            Observation(correct: false, toolAdherent: true, reliable: false, toolCalls: 1),
+            Observation(correct: true, toolAdherent: true, reliable: false, toolCalls: 2, error: "timeout"),
+        ];
+
+        var summary = ReliabilityRaceSummary.Create("model-a", observations);
+
+        Assert.Equal((3, 4), (summary.Correct.Successes, summary.Correct.Total));
+        Assert.Equal((3, 4), (summary.ToolAdherence.Successes, summary.ToolAdherence.Total));
+        Assert.Equal((2, 4), (summary.ExactlyOneToolCall.Successes, summary.ExactlyOneToolCall.Total));
+        Assert.Equal((1, 4), (summary.Reliable.Successes, summary.Reliable.Total));
+        Assert.Equal(1, summary.ErrorCount);
+    }
+
+    [Fact]
+    public void Create_PerformanceSamples_ComputesPercentilesTokensAndCostPerReliableRun()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(true, true, true, 1, latencyMs: 100, cost: 0.01m, tokens: 80),
+            Observation(true, true, true, 1, latencyMs: 200, cost: 0.01m, tokens: 100),
+            Observation(false, true, false, 1, latencyMs: 300, cost: 0.01m, tokens: 120),
+            Observation(true, false, false, 0, latencyMs: 400, cost: 0.01m, tokens: 140),
+        ];
+
+        var summary = ReliabilityRaceSummary.Create("model-a", observations);
+
+        Assert.Equal(250, summary.P50LatencyMs);
+        Assert.Equal(385, summary.P95LatencyMs);
+        Assert.Equal(110, summary.AverageTokens);
+        Assert.Equal(0.04m, summary.TotalCost);
+        Assert.Equal(0.02m, summary.CostPerReliableRun);
+    }
+
+    [Fact]
+    public void Create_UnmeasuredPerformance_ReportsNullInsteadOfInventingZero()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(true, true, false, 1),
+        ];
+
+        var summary = ReliabilityRaceSummary.Create("model-a", observations);
+
+        Assert.Null(summary.P50LatencyMs);
+        Assert.Null(summary.P95LatencyMs);
+        Assert.Null(summary.AverageTokens);
+        Assert.Null(summary.TotalCost);
+        Assert.Null(summary.CostPerReliableRun);
+    }
+
+    private static ReliabilityRaceObservation Observation(
+        bool correct,
+        bool toolAdherent,
+        bool reliable,
+        int toolCalls,
+        double? latencyMs = null,
+        decimal? cost = null,
+        int? tokens = null,
+        string? error = null) =>
+        new(
+            Scenario: "scenario",
+            Correct: correct,
+            ToolAdherent: toolAdherent,
+            Reliable: reliable,
+            ToolCalls: toolCalls,
+            LatencyMs: latencyMs,
+            Cost: cost,
+            TotalTokens: tokens,
+            Output: string.Empty,
+            Error: error);
+}

--- a/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
+++ b/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
@@ -7,6 +7,70 @@ namespace AgentEval.Tests.Samples;
 
 public sealed class ReliabilityRaceStatisticsTests
 {
+    [Theory]
+    [InlineData("5", 5)]
+    [InlineData("10", 10)]
+    [InlineData("20", 20)]
+    [InlineData("100", 100)]
+    public void RunCountSelector_ConfiguredAllowedValue_ReturnsValue(string configured, int expected)
+    {
+        var output = new StringWriter();
+
+        var selected = ReliabilityRaceRunCountSelector.Select(
+            configured,
+            interactive: false,
+            TextReader.Null,
+            output);
+
+        Assert.Equal(expected, selected);
+        Assert.Contains("AGENTEVAL_RELIABILITY_RUNS", output.ToString());
+    }
+
+    [Fact]
+    public void RunCountSelector_InteractiveInvalidThenValid_PromptsAgain()
+    {
+        var input = new StringReader("7\n100\n");
+        var output = new StringWriter();
+
+        var selected = ReliabilityRaceRunCountSelector.Select(null, interactive: true, input, output);
+
+        Assert.Equal(100, selected);
+        Assert.Contains("Enter 5, 10, 20, or 100", output.ToString());
+    }
+
+    [Fact]
+    public void RunCountSelector_InteractiveBlank_UsesRecommendedDefault()
+    {
+        var selected = ReliabilityRaceRunCountSelector.Select(
+            null,
+            interactive: true,
+            new StringReader(Environment.NewLine),
+            TextWriter.Null);
+
+        Assert.Equal(20, selected);
+    }
+
+    [Fact]
+    public void RunCountSelector_NonInteractive_UsesRecommendedDefault()
+    {
+        var selected = ReliabilityRaceRunCountSelector.Select(
+            null,
+            interactive: false,
+            TextReader.Null,
+            TextWriter.Null);
+
+        Assert.Equal(20, selected);
+    }
+
+    [Fact]
+    public void RunCountSelector_InvalidConfiguredValue_Throws()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ReliabilityRaceRunCountSelector.Select("7", false, TextReader.Null, TextWriter.Null));
+
+        Assert.Contains("5, 10, 20, 100", exception.Message);
+    }
+
     [Fact]
     public void Create_MixedOutcomes_SeparatesCorrectnessToolUseAndReliability()
     {

--- a/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
+++ b/tests/AgentEval.Tests/Samples/ReliabilityRaceStatisticsTests.cs
@@ -7,6 +7,45 @@ namespace AgentEval.Tests.Samples;
 
 public sealed class ReliabilityRaceStatisticsTests
 {
+    [Theory]
+    [InlineData("ROUTE=P1-04H", true)]
+    [InlineData("  ROUTE=P1-04H\r\n", true)]
+    [InlineData("P1-04H", false)]
+    [InlineData("Authoritative route: P1-04H", false)]
+    [InlineData("ROUTE=P1-04H because it is urgent", false)]
+    [InlineData("ROUTE=P3-24H", false)]
+    public void ExactRouteOutput_RequiresContractWithoutExtraText(string actualOutput, bool expected)
+    {
+        Assert.Equal(expected, ReliabilityRaceTrialRules.IsExactRouteOutput(actualOutput, "P1-04H"));
+    }
+
+    [Fact]
+    public void ConsecutiveSetupFailures_LaterInRun_StopsAfterLastThreeErrors()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(true, true, true, 1),
+            Observation(false, false, false, 0, error: "setup-1"),
+            Observation(false, false, false, 0, error: "setup-2"),
+            Observation(false, false, false, 0, error: "setup-3"),
+        ];
+
+        Assert.True(ReliabilityRaceTrialRules.HasConsecutiveSetupFailures(observations));
+    }
+
+    [Fact]
+    public void ConsecutiveSetupFailures_InterruptedBySuccess_DoesNotStop()
+    {
+        ReliabilityRaceObservation[] observations =
+        [
+            Observation(false, false, false, 0, error: "setup-1"),
+            Observation(false, false, false, 0, error: "setup-2"),
+            Observation(true, true, true, 1),
+        ];
+
+        Assert.False(ReliabilityRaceTrialRules.HasConsecutiveSetupFailures(observations));
+    }
+
     [Fact]
     public void Decision_EqualReliabilityButEconomyDominates_RecommendsEconomyWithoutInventingReliabilityLead()
     {


### PR DESCRIPTION
Adds a conference-ready D6 Reliability Race under Performance & Statistics.

The live-only demo asks for 5, 10, 20, or 100 agent runs per model and compares two real deployments using fresh sessions, alternating execution order, and a paired nine-scenario rotation. Choosing 100 schedules exactly 100 agent runs per model and 200 total agent runs; tool-using runs may make multiple lower-level model API requests.

The report presents cumulative end-to-end reliability with Wilson 95% intervals alongside exact-output correctness, required-tool invocation adherence, exactly-one-tool efficiency, tool execution errors, general errors, P50/P95 latency, tokens, total cost, and cost per reliable run. It handles reliability draws explicitly and uses an unweighted Pareto rule for the final recommendation.

D6 has no simulated fallback. It reuses the shared AIConfig endpoint/key and primary/secondary deployment slots. Recommended and live-validated conference pair: gpt-5.5 versus gpt-4o-mini.

Validation:
- Release sample build passed.
- 23 focused Reliability Race tests passed on each of .NET 8, 9, and 10.
- A real five-pair smoke run completed 5/5 on both arms, demonstrated the Wilson draw, and recommended the economy arm from its latency/token/cost advantages.
- PR review fixes enforce the exact ROUTE=<code> output contract and correctly detect three consecutive setup failures anywhere in the run.