### PR TITLE
Temporal judge body, a per-vertical floor, and a judge that reports the route it took

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Temporal had no judge template either — the second and last vertical falling through to
+  `StandardBody`.** Its only guidance was the shared preamble, which defines *missed* as
+  confidently asserting nothing is there when gold says something is. *"Nothing happened between
+  them"* matches that word for word, so the judge returned `Missed` where the label says `Wrong` —
+  but that answer **accepts both anchors** and makes a false claim about ordering, which is a
+  sequencing defect, not a retrieval one.
+
+  The body draws the line: accepts the events and misplaces them — including denying an interval
+  contains anything, or that any candidate is latest — is `wrong`, because **an empty interval is an
+  ordering claim, not a statement about what the record holds**; denying the record holds the events
+  at all is `missed`; an answer doing both is decided by the denial.
+
+  **Measured with a baseline first**, which the Bitemporal fix skipped. Four controls were authored
+  *before* the body existed — two `Wrong`, two `Missed`, so the set can fail in either direction —
+  and the baseline with them in and no body present was **Temporal 0.857 / 0.929**. `cal-tem-026` is
+  the over-correction guard: it says *"nothing lies between them"* while its operative claim is that
+  the record holds neither anchor, so a rule reading only the interval phrase breaks it. It holds.
+
+  **Temporal 28/28 on judgment in all three runs**; family **0.983** over 176 cases. The recorded
+  0.964 is run 2, where one case returned no verdict under an Azure content filter — infrastructure
+  rather than disagreement, but the live arm scores an absent verdict as a miss on purpose.
+
+  Open and deliberately not fixed here: the preamble gives *"I have no record of that"* as its
+  `abstained` example and *"you never told me about that"* as its `missed` example. Those are
+  near-synonyms, it is family-wide, and it is the likeliest cause of `cal-for-012`/`cal-for-013`
+  alternating. Editing the shared preamble changes grading for all seven verticals, so it needs its
+  own controls and its own before/after.
+
+### Fixed
+
 - **Bitemporal had no judge template, and the shared preamble mis-graded it — then the first fix
   overfitted and the calibration set could not tell.** Bitemporal shipped in `0.26.0-beta` with no
   body of its own, falling through to `StandardBody` (the two words "Grade this answer."). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A family-wide judge floor is satisfiable by averaging — added a per-vertical one.** Bitemporal
+  sat at **0.750** behind a green family **0.946** because six verticals near 0.98 averaged it away,
+  and the gate only ever read the mean. This is the same defect the corpus calibration had, where
+  arithmetic certified at 0.700 with its `duration` shape at 0.083. A **0.80 per-vertical floor**
+  now applies to both the recorded result and the live arm. Set below the family's 0.85 on purpose:
+  a vertical is 24–28 cases, so one boundary case moves it ~0.04 and a floor at parity would fail on
+  noise. Verified by falsification — forcing a vertical to 0.75 fires it.
+
+- **The judge now emits the discriminator branch it took, and CI asserts it independently of the
+  outcome.** A template that suppresses a label outright is indistinguishable from one that
+  discriminates correctly if you only ever check the final label — which is exactly how the first
+  Bitemporal body reached 24/24 while overfitted. `question_asks` is emitted in the judge's JSON at
+  **zero extra calls**, with two enums because the verticals discriminate on different axes:
+  Bitemporal `value`|`occurrence` (a property of the **question**), Temporal `ordering`|`presence`
+  (a property of what the **answer** commits to). Declared on 14 cases where the branch is
+  unambiguous and asserted only where declared — a `Correct` or `Abstained` answer has no meaningful
+  branch, so asserting one would be noise. Reaching the right outcome by the wrong route now fails
+  the build.
+
 - **Temporal had no judge template either — the second and last vertical falling through to
   `StandardBody`.** Its only guidance was the shared preamble, which defines *missed* as
   confidently asserting nothing is there when gold says something is. *"Nothing happened between

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
@@ -40,6 +40,17 @@ public sealed class TypedMemEvalJudgment
     /// <summary>Observed item pairs considered (list-order only).</summary>
     public int? OrderedPairsTotal { get; init; }
 
+    /// <summary>
+    /// Which branch of the vertical's discriminator the judge reports having taken, or null where
+    /// the contract does not ask for one.
+    /// </summary>
+    /// <remarks>
+    /// An independent observation of the step the outcome was derived from. Without it a template
+    /// that suppresses a label outright is indistinguishable from one that discriminates properly,
+    /// which is how the first Bitemporal body scored 24/24 while being overfitted.
+    /// </remarks>
+    public string? QuestionAsks { get; init; }
+
     /// <summary>Bounded AgentEval-owned failure code; never provider exception text.</summary>
     public string? SafeFailureCode { get; init; }
 
@@ -140,7 +151,7 @@ public sealed class TypedMemEvalJudge
                 _logger.LogWarning(
                     "TypedMemEval judge provider failure on a {Vertical} question: {FailureCode}",
                     vertical, safeCode);
-                parsed = new TypedMemEvalVerdict.Parsed(null, null, false, false, null, null, safeCode);
+                parsed = new TypedMemEvalVerdict.Parsed(null, null, false, false, null, null, null, safeCode);
                 raw = null;
             }
 
@@ -173,6 +184,7 @@ public sealed class TypedMemEvalJudge
             ClaimedNoLongerKnown = parsed.ClaimedNoLongerKnown,
             OrderedPairsCorrect = parsed.OrderedPairsCorrect,
             OrderedPairsTotal = parsed.OrderedPairsTotal,
+            QuestionAsks = parsed.QuestionAsks,
             SafeFailureCode = parsed.FailureCode,
             LlmCallCount = providerCalls,
             PrimaryLlmCallCount = primaryCalls,
@@ -192,6 +204,8 @@ public sealed class TypedMemEvalJudge
         => vertical switch
         {
             TypedMemEvalVertical.Forgetting => TypedMemEvalVerdict.Kind.Forgetting,
+            TypedMemEvalVertical.Bitemporal => TypedMemEvalVerdict.Kind.Bitemporal,
+            TypedMemEvalVertical.Temporal => TypedMemEvalVerdict.Kind.Temporal,
             TypedMemEvalVertical.Episodic when extension.Shape == "list-order"
                 => TypedMemEvalVerdict.Kind.ListOrder,
             _ => TypedMemEvalVerdict.Kind.Base

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
@@ -213,6 +213,9 @@ public sealed class TypedMemEvalJudge
             TypedMemEvalVertical.Bitemporal =>
                 TypedMemEvalJudgePrompts.Bitemporal(question, goldAnswer, agentResponse),
 
+            TypedMemEvalVertical.Temporal =>
+                TypedMemEvalJudgePrompts.Temporal(question, goldAnswer, agentResponse),
+
             TypedMemEvalVertical.Forgetting =>
                 TypedMemEvalJudgePrompts.Forgetting(question, goldAnswer, agentResponse),
 

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
@@ -278,6 +278,28 @@ internal static class TypedMemEvalJudgePrompts
              "ordered_pairs_correct": <integer>,
              "ordered_pairs_total": <integer>}
             """,
+        TypedMemEvalVerdict.Kind.Bitemporal => """
+
+            Reply with a single JSON object and nothing else:
+            {"outcome": "correct" | "wrong" | "abstained" | "missed" | "premature",
+             "reasoning": "<one or two sentences>",
+             "question_asks": "value" | "occurrence"}
+
+            question_asks is the branch you took above: "value" if the question asks which value the
+            record held at the as-of instant, "occurrence" if it asks whether a correction had been
+            made by then. Report what you actually decided, not what would justify the outcome.
+            """,
+        TypedMemEvalVerdict.Kind.Temporal => """
+
+            Reply with a single JSON object and nothing else:
+            {"outcome": "correct" | "wrong" | "abstained" | "missed" | "premature",
+             "reasoning": "<one or two sentences>",
+             "question_asks": "ordering" | "presence"}
+
+            question_asks is the branch you took above: "ordering" if the answer accepts the events
+            and misplaces them, "presence" if it denies the record holds them. Report what you
+            actually decided, not what would justify the outcome.
+            """,
         _ => """
 
             Reply with a single JSON object and nothing else:
@@ -309,7 +331,9 @@ internal static class TypedMemEvalJudgePrompts
             .Append(Closing).Append('\u001e')
             .Append(ContractFor(TypedMemEvalVerdict.Kind.Base)).Append('\u001e')
             .Append(ContractFor(TypedMemEvalVerdict.Kind.Forgetting)).Append('\u001e')
-            .Append(ContractFor(TypedMemEvalVerdict.Kind.ListOrder));
+            .Append(ContractFor(TypedMemEvalVerdict.Kind.ListOrder)).Append('\u001e')
+            .Append(ContractFor(TypedMemEvalVerdict.Kind.Bitemporal)).Append('\u001e')
+            .Append(ContractFor(TypedMemEvalVerdict.Kind.Temporal));
 
         var normalized = builder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal);
         // Not a security function: this identifies which prompt text produced a verdict.

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
@@ -133,6 +133,38 @@ internal static class TypedMemEvalJudgePrompts
         to a set containing a value the record did not hold at that instant.
         """;
 
+    /// <remarks>
+    /// Temporal shipped in 0.26.0-beta with no body of its own and fell through to
+    /// <c>StandardBody</c>, so the only guidance it had was the shared preamble - which defines
+    /// <i>missed</i> as confidently asserting that nothing is there when gold says something is.
+    /// "Nothing happened between them" matches that word for word, so the judge returned Missed
+    /// where the label says Wrong. But that answer ACCEPTS both anchors ("them") and makes a false
+    /// claim about ordering, which is a different defect from not holding the events at all: one is
+    /// a sequencing error, the other is a retrieval failure, and they route to different repairs.
+    /// </remarks>
+    private const string TemporalBody = """
+
+        This question is about the ORDER of events - which came first, what fell between two of
+        them, which is most recent. Session order and mention order are not evidence of event order;
+        grade against gold.
+
+        Two failures look alike here and are not. Decide which one the answer commits to:
+
+        - The answer ACCEPTS that the events are on record and gets their order, position or
+          recency wrong: that is "wrong". This includes denying that an interval contains anything
+          ("nothing happened between them") and denying that any candidate is the latest, because
+          both accept the events and make a false claim about how they are arranged. An empty
+          interval is an ordering claim, not a statement about what the record holds.
+
+        - The answer DENIES that the record holds the events at all ("neither is recorded", "none of
+          those appear in the record", "I have no record of the Kessel handover"): that is "missed".
+          The defect is that the events are not there to be ordered.
+
+        When an answer does both - accepts one event and denies another the record states - the
+        DENIAL decides, and the outcome is "missed". It has not committed to an ordering at all.
+
+        """;
+
     private const string ArithmeticBody = """
 
         This question has a derived numeric answer. Grade the ARITHMETIC, not the phrasing.
@@ -207,6 +239,9 @@ internal static class TypedMemEvalJudgePrompts
     internal static string Bitemporal(string question, string gold, string answer)
         => string.Format(Preamble + BitemporalBody + Closing, question, gold, answer);
 
+    internal static string Temporal(string question, string gold, string answer)
+        => string.Format(Preamble + TemporalBody + Closing, question, gold, answer);
+
     internal static string ListOrder(string question, string gold, string answer)
         => string.Format(Preamble + ListOrderBody + Closing, question, gold, answer);
 
@@ -267,6 +302,7 @@ internal static class TypedMemEvalJudgePrompts
             .Append(StandardBody).Append('\u001e')
             .Append(ProspectiveBody).Append('\u001e')
             .Append(BitemporalBody).Append('\u001e')
+            .Append(TemporalBody).Append('\u001e')
             .Append(ArithmeticBody).Append('\u001e')
             .Append(ListOrderBody).Append('\u001e')
             .Append(ForgettingBody).Append('\u001e')

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalVerdict.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalVerdict.cs
@@ -45,7 +45,21 @@ internal static class TypedMemEvalVerdict
         Forgetting,
 
         /// <summary>Adds the observed pairwise-order tally (Episodic list-order).</summary>
-        ListOrder
+        ListOrder,
+
+        /// <summary>
+        /// Adds which branch of the two-clock discriminator the judge took (Bitemporal).
+        /// </summary>
+        /// <remarks>
+        /// The outcome alone cannot say WHY it was chosen, so a template that suppresses a label
+        /// outright looks identical to one that discriminates correctly — which is exactly how the
+        /// first Bitemporal body scored 24/24 while being overfitted. Emitting the branch makes the
+        /// intermediate step assertable at no extra call.
+        /// </remarks>
+        Bitemporal,
+
+        /// <summary>Adds which branch of the ordering-versus-presence discriminator was taken (Temporal).</summary>
+        Temporal
     }
 
     private const string OutcomeProperty = """
@@ -109,12 +123,46 @@ internal static class TypedMemEvalVerdict
         }
         """);
 
+    private static readonly JsonElement s_bitemporal = ParseSchema($$"""
+        {
+          "type": "object",
+          "properties": {
+        {{OutcomeProperty}},
+            "question_asks": {
+              "type": "string",
+              "enum": ["value", "occurrence"],
+              "description": "Which the question asks for: the VALUE the record held at the as-of instant, or WHETHER a correction had been made by then. Report the branch you actually took."
+            }
+          },
+          "required": ["outcome", "reasoning", "question_asks"],
+          "additionalProperties": false
+        }
+        """);
+
+    private static readonly JsonElement s_temporal = ParseSchema($$"""
+        {
+          "type": "object",
+          "properties": {
+        {{OutcomeProperty}},
+            "question_asks": {
+              "type": "string",
+              "enum": ["ordering", "presence"],
+              "description": "Which failure the answer commits to: ORDERING, accepting the events and misplacing them, or PRESENCE, denying the record holds them. Report the branch you actually took."
+            }
+          },
+          "required": ["outcome", "reasoning", "question_asks"],
+          "additionalProperties": false
+        }
+        """);
+
     private static JsonElement ParseSchema(string json) => JsonDocument.Parse(json).RootElement.Clone();
 
     internal static JsonElement Schema(Kind kind) => kind switch
     {
         Kind.Forgetting => s_forgetting,
         Kind.ListOrder => s_listOrder,
+        Kind.Bitemporal => s_bitemporal,
+        Kind.Temporal => s_temporal,
         _ => s_base
     };
 
@@ -126,6 +174,7 @@ internal static class TypedMemEvalVerdict
         bool ClaimedNoLongerKnown,
         int? OrderedPairsCorrect,
         int? OrderedPairsTotal,
+        string? QuestionAsks,
         string? FailureCode);
 
     /// <summary>
@@ -180,7 +229,7 @@ internal static class TypedMemEvalVerdict
             };
 
             if (outcome is null)
-                return new Parsed(null, reasoning, false, false, null, null, "structured_outcome_out_of_enum");
+                return new Parsed(null, reasoning, false, false, null, null, null, "structured_outcome_out_of_enum");
 
             return new Parsed(
                 outcome,
@@ -191,11 +240,24 @@ internal static class TypedMemEvalVerdict
                     forgotten.ValueKind == JsonValueKind.True,
                 ReadInt(root, "ordered_pairs_correct"),
                 ReadInt(root, "ordered_pairs_total"),
+                ReadQuestionAsks(root),
                 null);
         }
     }
 
-    private static Parsed Fail(string code) => new(null, null, false, false, null, null, code);
+    private static Parsed Fail(string code) => new(null, null, false, false, null, null, null, code);
+
+    /// <summary>
+    /// The discriminator branch, lower-cased, or null when the judge did not emit one. Never
+    /// inferred from the outcome: the whole point is that it is an INDEPENDENT observation of the
+    /// step the outcome was derived from, so guessing it would defeat the assertion it exists for.
+    /// </summary>
+    private static string? ReadQuestionAsks(JsonElement root)
+        => root.TryGetProperty("question_asks", out var value) &&
+           value.ValueKind == JsonValueKind.String &&
+           value.GetString() is { Length: > 0 } text
+            ? text.Trim().ToLowerInvariant()
+            : null;
 
     private static int? ReadInt(JsonElement root, string name)
         => root.TryGetProperty(name, out var value) &&

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -1,10 +1,10 @@
 {
-  "judge_prompt_fingerprint": "927c572e35969dc907dd20ef7fd2688f13f420a04fdd7e7123bfcc2fdf513c02",
+  "judge_prompt_fingerprint": "4a6e357c23f02bd3bdbd56cd1548c4bf23632ccfee896a2f0b3c41e299e4ed75",
   "measured_at": "2026-08-28",
   "model": "gpt-5.5",
   "agreement": 0.983,
   "status": "measured",
-  "cases": 172,
+  "cases": 176,
   "runs": 3,
   "per_vertical": {
     "Prospective": 1.0,
@@ -13,33 +13,35 @@
     "WorkingMemory": 1.0,
     "Forgetting": 0.917,
     "Bitemporal": 1.0,
-    "Temporal": 0.958
+    "Temporal": 0.964
   },
   "disagreements": {
     "every_run": [
-      "cal-for-006",
-      "cal-tem-013"
+      "cal-for-006"
     ],
     "run_varying": [
-      "cal-for-012",
-      "cal-for-013"
+      "cal-epi-014",
+      "cal-for-012"
+    ],
+    "infrastructure_not_judgment": [
+      "cal-tem-028"
     ]
   },
   "superseded": {
-    "judge_prompt_fingerprint": "4c626f05634ba997b067990f5e525861c762e6c25fd86b1a8989dd4141ea76ff",
+    "judge_prompt_fingerprint": "927c572e35969dc907dd20ef7fd2688f13f420a04fdd7e7123bfcc2fdf513c02",
     "measured_at": "2026-08-28",
     "model": "gpt-5.5",
-    "agreement": 0.94,
-    "cases": 168,
+    "agreement": 0.983,
+    "cases": 172,
     "per_vertical": {
       "Prospective": 1.0,
-      "Episodic": 0.958,
+      "Episodic": 1.0,
       "Arithmetic": 1.0,
       "WorkingMemory": 1.0,
       "Forgetting": 0.917,
-      "Bitemporal": 0.792,
-      "Temporal": 0.917
+      "Bitemporal": 1.0,
+      "Temporal": 0.958
     }
   },
-  "note": "Three runs at this fingerprint: 0.988 / 0.983 / 0.983. The lowest is recorded, per-vertical from that same run. Bitemporal is 28/28 in ALL THREE runs. TWO CHANGES ARE MEASURED HERE TOGETHER. Bitemporal gained a judge body of its own - it shipped in 0.26.0-beta with none and fell through to StandardBody, the two words 'Grade this answer.' And the calibration set gained four Bitemporal cases whose correct label IS Premature (cal-bit-025 through 028), because it previously had none at all. THE SECOND EXISTS BECAUSE THE FIRST ATTEMPT WAS OVERFITTED AND THE SET COULD NOT SEE IT. Attempt one told the judge that premature 'will essentially never be the right label' on this vertical. That scored Bitemporal 24/24 - apparently perfect - because every Bitemporal case then in the set was labelled Correct, Wrong, Abstained or Missed. Zero were Premature, so a rule that suppressed Premature outright could not be penalised by the only instrument watching. The four controls were authored to make that failure visible, graded easy to hard, and they did their job immediately: attempt one scored 0 of 4 on them in all three runs. The shipped fix replaces the suppression rule with a question-type discriminator. The judge is told to decide FIRST what the question asks for: if it asks WHICH VALUE the record held, a later-recorded value is wrong (a transaction-time collapse); if it asks WHETHER a correction had been made by the as-of instant and gold says it had not, asserting that it had is premature, because what gold denies there is an EVENT and not a value. Where one answer does both - right value, false claim of occurrence - the premature assertion decides. The shared preamble was NOT touched, and blast radius was measured rather than assumed: all 172 cases, all seven verticals, three runs. cal-bit-011/012/015/022, the four that provoked this work, stay fixed. cal-for-006 and cal-tem-013 disagree in every run and predate all of it; cal-for-012 and cal-for-013 alternate across runs at the Forgetting abstained/missed boundary, which is judge noise there and unreachable from a Bitemporal template. Temporal has the same missing-body gap Bitemporal had and cal-tem-013 is its standing disagreement, so it is the obvious next candidate for the same treatment."
+  "note": "Three runs at this fingerprint: 0.989 / 0.983 / 0.989. The lowest is recorded with its own per-vertical figures. TEMPORAL GAINED A JUDGE BODY, the second and last vertical that had none. Like Bitemporal it fell through to StandardBody - the two words 'Grade this answer.' - so its only guidance was the shared preamble, which defines missed as confidently asserting nothing is there when gold says something is. 'Nothing happened between them' matches that word for word, so the judge returned Missed where the label says Wrong. But that answer ACCEPTS both anchors and makes a false claim about ordering, which is a sequencing defect rather than a retrieval one. The body draws the line explicitly: accepts the events and misplaces them - including denying an interval contains anything, or that any candidate is latest - is wrong, because an empty interval is an ordering claim and not a statement about what the record holds; denies the record holds the events at all is missed; an answer doing both is decided by the denial. MEASURED WITH A BASELINE FIRST, which is the discipline the Bitemporal fix skipped. Four Temporal controls were authored BEFORE the body existed - two Wrong and two Missed, so the set can fail in either direction - and the baseline was measured with them in and no body present: Temporal 0.857 / 0.929, with cal-tem-013 and cal-tem-025 failing in both runs. cal-tem-026 is the over-correction guard: it says 'nothing lies between them' but its operative claim is that the record holds neither anchor, so a rule reading only the interval phrase breaks it. It holds. TEMPORAL IS 28/28 ON JUDGMENT IN ALL THREE RUNS. The 0.964 recorded here is run 2, where cal-tem-028 returned no verdict at all under an Azure content filter. That is infrastructure, not a disagreement - the judge never answered - but the live arm scores an absent verdict as a miss on purpose, and the lowest run is recorded on purpose, so the conservative number stands and this note says what it is. Second content-filter hit of the day; cal-bit-023 did the same earlier. OPEN AND NOT FIXED HERE: the shared preamble gives 'I have no record of that' as its ABSTAINED example and 'you never told me about that' as its MISSED example. Those are near-synonyms, and the ambiguity is family-wide rather than Temporal's. It is the likeliest explanation for cal-for-012 and cal-for-013 alternating across runs on that same boundary. Fixing it means editing the shared preamble, which changes grading for all seven verticals, so it needs its own controls and its own before/after rather than riding along here."
 }

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -1,5 +1,5 @@
 {
-  "judge_prompt_fingerprint": "4a6e357c23f02bd3bdbd56cd1548c4bf23632ccfee896a2f0b3c41e299e4ed75",
+  "judge_prompt_fingerprint": "6f006dbb4014994ae2db341e6546a83093658a3e514a0aa2de10eed9a6879e7b",
   "measured_at": "2026-08-28",
   "model": "gpt-5.5",
   "agreement": 0.983,
@@ -7,32 +7,29 @@
   "cases": 176,
   "runs": 3,
   "per_vertical": {
-    "Prospective": 1.0,
+    "Prospective": 0.958,
     "Episodic": 1.0,
     "Arithmetic": 1.0,
     "WorkingMemory": 1.0,
     "Forgetting": 0.917,
     "Bitemporal": 1.0,
-    "Temporal": 0.964
+    "Temporal": 1.0
   },
   "disagreements": {
-    "every_run": [
-      "cal-for-006"
-    ],
+    "every_run": [],
     "run_varying": [
       "cal-epi-014",
-      "cal-for-012"
-    ],
-    "infrastructure_not_judgment": [
-      "cal-tem-028"
+      "cal-for-006",
+      "cal-for-012",
+      "cal-pro-017"
     ]
   },
   "superseded": {
-    "judge_prompt_fingerprint": "927c572e35969dc907dd20ef7fd2688f13f420a04fdd7e7123bfcc2fdf513c02",
+    "judge_prompt_fingerprint": "4a6e357c23f02bd3bdbd56cd1548c4bf23632ccfee896a2f0b3c41e299e4ed75",
     "measured_at": "2026-08-28",
     "model": "gpt-5.5",
     "agreement": 0.983,
-    "cases": 172,
+    "cases": 176,
     "per_vertical": {
       "Prospective": 1.0,
       "Episodic": 1.0,
@@ -40,8 +37,8 @@
       "WorkingMemory": 1.0,
       "Forgetting": 0.917,
       "Bitemporal": 1.0,
-      "Temporal": 0.958
+      "Temporal": 0.964
     }
   },
-  "note": "Three runs at this fingerprint: 0.989 / 0.983 / 0.989. The lowest is recorded with its own per-vertical figures. TEMPORAL GAINED A JUDGE BODY, the second and last vertical that had none. Like Bitemporal it fell through to StandardBody - the two words 'Grade this answer.' - so its only guidance was the shared preamble, which defines missed as confidently asserting nothing is there when gold says something is. 'Nothing happened between them' matches that word for word, so the judge returned Missed where the label says Wrong. But that answer ACCEPTS both anchors and makes a false claim about ordering, which is a sequencing defect rather than a retrieval one. The body draws the line explicitly: accepts the events and misplaces them - including denying an interval contains anything, or that any candidate is latest - is wrong, because an empty interval is an ordering claim and not a statement about what the record holds; denies the record holds the events at all is missed; an answer doing both is decided by the denial. MEASURED WITH A BASELINE FIRST, which is the discipline the Bitemporal fix skipped. Four Temporal controls were authored BEFORE the body existed - two Wrong and two Missed, so the set can fail in either direction - and the baseline was measured with them in and no body present: Temporal 0.857 / 0.929, with cal-tem-013 and cal-tem-025 failing in both runs. cal-tem-026 is the over-correction guard: it says 'nothing lies between them' but its operative claim is that the record holds neither anchor, so a rule reading only the interval phrase breaks it. It holds. TEMPORAL IS 28/28 ON JUDGMENT IN ALL THREE RUNS. The 0.964 recorded here is run 2, where cal-tem-028 returned no verdict at all under an Azure content filter. That is infrastructure, not a disagreement - the judge never answered - but the live arm scores an absent verdict as a miss on purpose, and the lowest run is recorded on purpose, so the conservative number stands and this note says what it is. Second content-filter hit of the day; cal-bit-023 did the same earlier. OPEN AND NOT FIXED HERE: the shared preamble gives 'I have no record of that' as its ABSTAINED example and 'you never told me about that' as its MISSED example. Those are near-synonyms, and the ambiguity is family-wide rather than Temporal's. It is the likeliest explanation for cal-for-012 and cal-for-013 alternating across runs on that same boundary. Fixing it means editing the shared preamble, which changes grading for all seven verticals, so it needs its own controls and its own before/after rather than riding along here."
+  "note": "Three runs at this fingerprint: 0.989 / 0.994 / 0.983. Lowest recorded, per-vertical from that same run. Bitemporal 28/28 and Temporal 28/28 in ALL THREE. For the first time no case disagrees in every run. THREE CHANGES SHIP TOGETHER, all adopted by the consuming project. (1) TemporalBody - the second and last vertical with no judge template. Like Bitemporal it fell through to StandardBody, the two words 'Grade this answer.' The preamble defines missed as confidently asserting nothing is there when gold says something is, and 'nothing happened between them' matches that word for word - but that answer ACCEPTS both anchors and misplaces them, which is a sequencing defect rather than a retrieval one. The body says: accepts the events and misplaces them, including an empty interval or no-latest claim, is wrong; denies the record holds them is missed; doing both is decided by the denial. Measured against a BASELINE TAKEN BEFORE THE BODY EXISTED - Temporal 0.857 / 0.929 with the controls already in. (2) A PER-VERTICAL FLOOR of 0.80, on this record AND on the live arm. A family-wide threshold is satisfiable by averaging, which is how Bitemporal sat at 0.750 behind a green 0.946 with nothing able to see it. Set below the family's 0.85 deliberately: a vertical is 24-28 cases, so one boundary case moves it about 0.04 and a floor at parity would fail on noise. Verified by falsification - forcing a vertical to 0.75 fires it. (3) question_asks, the discriminator branch, emitted by the judge and asserted INDEPENDENTLY of the outcome at zero extra calls. Two enums, because the verticals discriminate on different axes: Bitemporal value|occurrence, a property of the QUESTION; Temporal ordering|presence, a property of what the ANSWER commits to. Declared on 14 cases where the branch is unambiguous and asserted only where declared - a Correct or Abstained answer has no meaningful branch. This is the gate that would have caught the first Bitemporal body, which reached 24/24 while suppressing a label outright. No case reached its outcome by the wrong route in any run. cal-pro-017 appears in run 3 as Wrong -> Premature. That is 0.29's ProspectiveBody precedence rule firing, and it is the ONLY transition that rule can make - it chooses between two failure labels and can never move anything into or out of correct, so accuracy is invariant under it and only the failure distribution shifts. STILL OPEN: the preamble gives 'I have no record of that' as its ABSTAINED example and 'you never told me about that' as its MISSED example. Near-synonyms, family-wide, and the likeliest cause of cal-for-012 flapping. Parked for its own controlled change with its own controls and a seven-vertical before/after, per the consuming project's ruling."
 }

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
@@ -1858,7 +1858,8 @@
     "answer": "Dunmarsh, which is where she is recorded.",
     "expected": "Wrong",
     "rule": "bitemporal-present-tense-substitution",
-    "note": "Answers with the current record on a question about a past belief."
+    "note": "Answers with the current record on a question about a past belief.",
+    "question_asks": "value"
   },
   {
     "id": "cal-bit-012",
@@ -1869,7 +1870,8 @@
     "answer": "Both Bexmoor and Dunmarsh appear for her.",
     "expected": "Wrong",
     "rule": "bitemporal-lists-both-values",
-    "note": "Listing both refuses the discrimination the question asks for. Not an abstention, because it commits to a set containing a wrong member."
+    "note": "Listing both refuses the discrimination the question asks for. Not an abstention, because it commits to a set containing a wrong member.",
+    "question_asks": "value"
   },
   {
     "id": "cal-bit-013",
@@ -1902,7 +1904,8 @@
     "answer": "Fenwick Cross.",
     "expected": "Wrong",
     "rule": "bitemporal-depth-intermediate-value",
-    "note": "An intermediate value from the middle of the chain: the chain was followed but not cut at the asked instant."
+    "note": "An intermediate value from the middle of the chain: the chain was followed but not cut at the asked instant.",
+    "question_asks": "value"
   },
   {
     "id": "cal-bit-016",
@@ -1979,7 +1982,8 @@
     "answer": "Ilminster.",
     "expected": "Wrong",
     "rule": "bitemporal-depth-belief-wrong-value",
-    "note": "A value the file did not hold at the asked instant."
+    "note": "A value the file did not hold at the asked instant.",
+    "question_asks": "value"
   },
   {
     "id": "cal-bit-023",
@@ -2144,7 +2148,8 @@
     "answer": "Nothing happened between them.",
     "expected": "Wrong",
     "rule": "temporal-between-denies-middle",
-    "note": "The chain places an event between them, so this is wrong rather than an abstention."
+    "note": "The chain places an event between them, so this is wrong rather than an abstention.",
+    "question_asks": "ordering"
   },
   {
     "id": "cal-tem-014",
@@ -2177,7 +2182,8 @@
     "answer": "There is no record of a Kessel handover.",
     "expected": "Missed",
     "rule": "temporal-between-denies-endpoint",
-    "note": "Denies an event the record states."
+    "note": "Denies an event the record states.",
+    "question_asks": "presence"
   },
   {
     "id": "cal-tem-017",
@@ -2276,7 +2282,8 @@
     "answer": "Yes, it had already been recorded by then.",
     "expected": "Premature",
     "rule": "bitemporal-premature-correction-not-yet-recorded",
-    "note": "The unambiguous floor case. The question asks about the EVENT of recording rather than about a value, gold denies it with a date, and the answer asserts it as done. This is what premature means on this vertical, and a judge that cannot label this one has been told to suppress premature too hard."
+    "note": "The unambiguous floor case. The question asks about the EVENT of recording rather than about a value, gold denies it with a date, and the answer asserts it as done. This is what premature means on this vertical, and a judge that cannot label this one has been told to suppress premature too hard.",
+    "question_asks": "occurrence"
   },
   {
     "id": "cal-bit-026",
@@ -2287,7 +2294,8 @@
     "answer": "Yes, both corrections were in place by 16 January.",
     "expected": "Premature",
     "rule": "bitemporal-depth-premature-second-correction",
-    "note": "Half the answer is true - the first correction really had landed - so the judge has to notice that only the SECOND is over-claimed. Tests that a partially satisfied chain does not launder a premature assertion into correct."
+    "note": "Half the answer is true - the first correction really had landed - so the judge has to notice that only the SECOND is over-claimed. Tests that a partially satisfied chain does not launder a premature assertion into correct.",
+    "question_asks": "occurrence"
   },
   {
     "id": "cal-bit-027",
@@ -2298,7 +2306,8 @@
     "answer": "I think so - I believe it had been entered by then.",
     "expected": "Premature",
     "rule": "bitemporal-premature-hedged",
-    "note": "Precedence rule 1 says a stated position outranks hedging, so 'I think so' is graded as the yes it commits to. Premature, not abstained. Tests the interaction between the hedging rule and the premature rule, which no other bitemporal case exercises."
+    "note": "Precedence rule 1 says a stated position outranks hedging, so 'I think so' is graded as the yes it commits to. Premature, not abstained. Tests the interaction between the hedging rule and the premature rule, which no other bitemporal case exercises.",
+    "question_asks": "occurrence"
   },
   {
     "id": "cal-bit-028",
@@ -2309,7 +2318,8 @@
     "answer": "Halstead Vale, and yes, the correction had been applied by then.",
     "expected": "Premature",
     "rule": "bitemporal-depth-premature-with-correct-value",
-    "note": "The hardest of the four and the real trap. The VALUE matches gold exactly, so value-matching alone returns correct, and precedence rule 3 says extra correct detail never lowers the outcome - but the extra detail here is not correct, it asserts as done something gold dates five days later. A judge told that premature essentially never applies on this vertical will most likely fail this one first."
+    "note": "The hardest of the four and the real trap. The VALUE matches gold exactly, so value-matching alone returns correct, and precedence rule 3 says extra correct detail never lowers the outcome - but the extra detail here is not correct, it asserts as done something gold dates five days later. A judge told that premature essentially never applies on this vertical will most likely fail this one first.",
+    "question_asks": "occurrence"
   },
   {
     "id": "cal-tem-025",
@@ -2320,7 +2330,8 @@
     "answer": "Both the Kessel handover and the Ondrey audit are on record, but nothing falls between them.",
     "expected": "Wrong",
     "rule": "temporal-between-accepts-anchors-denies-content",
-    "note": "The clean statement of the distinction. The answer explicitly accepts both anchors as recorded and then makes a false claim about the interval, so the defect is ordering and not absence. Wrong, not missed."
+    "note": "The clean statement of the distinction. The answer explicitly accepts both anchors as recorded and then makes a false claim about the interval, so the defect is ordering and not absence. Wrong, not missed.",
+    "question_asks": "ordering"
   },
   {
     "id": "cal-tem-026",
@@ -2331,7 +2342,8 @@
     "answer": "I have no record of either the Kessel handover or the Ondrey audit, so nothing lies between them.",
     "expected": "Missed",
     "rule": "temporal-between-denies-both-anchors",
-    "note": "The mirror of cal-tem-025 and the one a too-broad rule breaks. The trailing clause is interval-shaped, but the operative claim is that the record does not hold the events at all. Missed, not wrong - a rule that reads 'nothing lies between' and stops has over-corrected."
+    "note": "The mirror of cal-tem-025 and the one a too-broad rule breaks. The trailing clause is interval-shaped, but the operative claim is that the record does not hold the events at all. Missed, not wrong - a rule that reads 'nothing lies between' and stops has over-corrected.",
+    "question_asks": "presence"
   },
   {
     "id": "cal-tem-027",
@@ -2342,7 +2354,8 @@
     "answer": "All three are in the record, but none of them is the most recent.",
     "expected": "Wrong",
     "rule": "temporal-recency-accepts-events-denies-ordering",
-    "note": "Denies that an ordering exists while accepting every event. Gold says one is latest, so this commits to a false claim about the sequence rather than failing to hold the events."
+    "note": "Denies that an ordering exists while accepting every event. Gold says one is latest, so this commits to a false claim about the sequence rather than failing to hold the events.",
+    "question_asks": "ordering"
   },
   {
     "id": "cal-tem-028",
@@ -2353,6 +2366,7 @@
     "answer": "The rewiring is recorded, but I have no record of the Harrow survey.",
     "expected": "Missed",
     "rule": "temporal-order-denies-one-event",
-    "note": "The hardest of the four. Half the answer accepts an event and half denies one the record states, and it commits to no ordering at all. The denial decides: missed. A rule that keys on 'accepts an event, therefore ordering error' will call this wrong."
+    "note": "The hardest of the four. Half the answer accepts an event and half denies one the record states, and it commits to no ordering at all. The denial decides: missed. A rule that keys on 'accepts an event, therefore ordering error' will call this wrong.",
+    "question_asks": "presence"
   }
 ]

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
@@ -2310,5 +2310,49 @@
     "expected": "Premature",
     "rule": "bitemporal-depth-premature-with-correct-value",
     "note": "The hardest of the four and the real trap. The VALUE matches gold exactly, so value-matching alone returns correct, and precedence rule 3 says extra correct detail never lowers the outcome - but the extra detail here is not correct, it asserts as done something gold dates five days later. A judge told that premature essentially never applies on this vertical will most likely fail this one first."
+  },
+  {
+    "id": "cal-tem-025",
+    "vertical": "Temporal",
+    "shape": "interval-position",
+    "question": "Between the Kessel handover and the Ondrey audit, what happened in between?",
+    "gold": "The Traymoor fit-out happened between them.",
+    "answer": "Both the Kessel handover and the Ondrey audit are on record, but nothing falls between them.",
+    "expected": "Wrong",
+    "rule": "temporal-between-accepts-anchors-denies-content",
+    "note": "The clean statement of the distinction. The answer explicitly accepts both anchors as recorded and then makes a false claim about the interval, so the defect is ordering and not absence. Wrong, not missed."
+  },
+  {
+    "id": "cal-tem-026",
+    "vertical": "Temporal",
+    "shape": "interval-position",
+    "question": "Between the Kessel handover and the Ondrey audit, what happened in between?",
+    "gold": "The Traymoor fit-out happened between them.",
+    "answer": "I have no record of either the Kessel handover or the Ondrey audit, so nothing lies between them.",
+    "expected": "Missed",
+    "rule": "temporal-between-denies-both-anchors",
+    "note": "The mirror of cal-tem-025 and the one a too-broad rule breaks. The trailing clause is interval-shaped, but the operative claim is that the record does not hold the events at all. Missed, not wrong - a rule that reads 'nothing lies between' and stops has over-corrected."
+  },
+  {
+    "id": "cal-tem-027",
+    "vertical": "Temporal",
+    "shape": "recency",
+    "question": "Of the Vance inspection, the Wrenfield sign-off and the Traymoor fit-out, which happened most recently?",
+    "gold": "The Traymoor fit-out is the most recent of the three.",
+    "answer": "All three are in the record, but none of them is the most recent.",
+    "expected": "Wrong",
+    "rule": "temporal-recency-accepts-events-denies-ordering",
+    "note": "Denies that an ordering exists while accepting every event. Gold says one is latest, so this commits to a false claim about the sequence rather than failing to hold the events."
+  },
+  {
+    "id": "cal-tem-028",
+    "vertical": "Temporal",
+    "shape": "occurrence-order",
+    "question": "Which happened first, the Harrow survey or the rewiring?",
+    "gold": "The Harrow survey happened before the rewiring.",
+    "answer": "The rewiring is recorded, but I have no record of the Harrow survey.",
+    "expected": "Missed",
+    "rule": "temporal-order-denies-one-event",
+    "note": "The hardest of the four. Half the answer accepts an event and half denies one the record states, and it commits to no ordering at all. The denial decides: missed. A rule that keys on 'accepts an event, therefore ordering error' will call this wrong."
   }
 ]

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeCalibrationTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeCalibrationTests.cs
@@ -47,6 +47,18 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
     /// </remarks>
     private const double AgreementThreshold = 0.85;
 
+    /// <summary>Floor each vertical must clear on its own, not merely on the family average.</summary>
+    /// <remarks>
+    /// A family-wide threshold is satisfiable by averaging, which is the same defect the corpus
+    /// calibration had: arithmetic certified at a mean of 0.700 while its duration shape sat at
+    /// 0.083. Bitemporal ran 0.750 behind a green 0.946 for the same reason — six verticals near
+    /// 0.98 carried it, and nothing looked underneath. Set below the family floor on purpose: a
+    /// single vertical is 24-28 cases, so one boundary case moves it ~0.04 and a floor equal to the
+    /// family's would fail on noise. What this catches is a vertical that has broadly stopped
+    /// working, which is what 0.750 was.
+    /// </remarks>
+    private const double PerVerticalAgreementThreshold = 0.80;
+
     private const string CalibrationResource = "Data.typedmemeval-judge-calibration.json";
     private const string RecordedResultResource = "Data.typedmemeval-judge-calibration-result.json";
 
@@ -278,6 +290,23 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
             $"verticals with no recorded per-vertical agreement: {string.Join(", ", unmeasured)}. " +
             $"Each one has its own template and its own failure modes; one missing here is one the " +
             $"family-wide number is averaging over without ever having seen.");
+
+        // The family floor alone is satisfiable by averaging. Bitemporal sat at 0.750 behind a
+        // green 0.946 because six verticals near 0.98 carried it, and the gate could not see it
+        // because it only ever read the mean.
+        var belowFloor = Enum.GetValues<TypedMemEvalVertical>()
+            .Where(vertical => perVertical.TryGetProperty(vertical.ToString(), out var value) &&
+                               value.GetDouble() < PerVerticalAgreementThreshold)
+            .Select(vertical =>
+                $"{vertical} {perVertical.GetProperty(vertical.ToString()).GetDouble():0.###}")
+            .ToArray();
+
+        Assert.True(
+            belowFloor.Length == 0,
+            $"verticals below the {PerVerticalAgreementThreshold} per-vertical floor: " +
+            $"{string.Join(", ", belowFloor)}. The family-wide figure can be green while one " +
+            $"vertical is broken, because the others average it away — fix the vertical's template " +
+            $"or say why the floor should move, but do not let the mean stand in for it.");
     }
 
     [Fact]
@@ -309,7 +338,8 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
         options.Validate();
 
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
-        var observed = new ConcurrentBag<(CalibrationCase Case, TypedMemEvalOutcome? Actual, string Detail)>();
+        var observed = new ConcurrentBag<(CalibrationCase Case, TypedMemEvalOutcome? Actual,
+            string? Branch, string Detail)>();
 
         // Bounded rather than unbounded: the whole set is one burst of judge calls, and a deployment
         // that throttles would turn a calibration measurement into a retry-accounting measurement.
@@ -339,6 +369,7 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
                 observed.Add((
                     calibrationCase,
                     judgment.Outcome,
+                    judgment.QuestionAsks,
                     judgment.Outcome is null
                         ? $"no verdict ({judgment.SafeFailureCode})"
                         : judgment.Reasoning ?? "(no reasoning)"));
@@ -380,6 +411,39 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
 
         foreach (var line in disagreements)
             _output.WriteLine(line);
+
+        var lowVerticals = Enum.GetValues<TypedMemEvalVertical>()
+            .Select(vertical => (Vertical: vertical, Subset: results
+                .Where(r => string.Equals(r.Case.Vertical, vertical.ToString(), StringComparison.Ordinal))
+                .ToArray()))
+            .Where(pair => pair.Subset.Length > 0)
+            .Select(pair => (pair.Vertical, Share: (double)pair.Subset.Count(r =>
+                r.Actual == Enum.Parse<TypedMemEvalOutcome>(r.Case.Expected)) / pair.Subset.Length))
+            .Where(pair => pair.Share < PerVerticalAgreementThreshold)
+            .Select(pair => $"{pair.Vertical} {pair.Share:0.###}")
+            .ToArray();
+
+        Assert.True(
+            lowVerticals.Length == 0,
+            $"verticals below the {PerVerticalAgreementThreshold} floor in this run: " +
+            $"{string.Join(", ", lowVerticals)}. Measured live against '{deployment}'.");
+
+        // The discriminator branch, asserted independently of the outcome. Without this a template
+        // that suppresses a label outright is indistinguishable from one that discriminates
+        // properly — which is exactly how the first Bitemporal body reached 24/24 while overfitted.
+        // Declared only where the branch is unambiguous; a case with no declaration is not checked.
+        var wrongBranch = results
+            .Where(r => r.Case.QuestionAsks is not null)
+            .Where(r => !string.Equals(r.Branch, r.Case.QuestionAsks, StringComparison.Ordinal))
+            .Select(r => $"{r.Case.Id} expected question_asks={r.Case.QuestionAsks}, got {r.Branch ?? "none"}")
+            .OrderBy(line => line, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            wrongBranch.Length == 0,
+            $"the judge reached the right outcome by the wrong route on " +
+            $"{wrongBranch.Length} case(s):{Environment.NewLine}" +
+            string.Join(Environment.NewLine, wrongBranch));
 
         Assert.True(
             agreement >= AgreementThreshold,
@@ -439,7 +503,8 @@ public sealed class TypedMemEvalJudgeCalibrationTests(ITestOutputHelper output)
         string Expected,
         string Rule,
         string Note,
-        CalibrationDerivation? Derivation);
+        CalibrationDerivation? Derivation,
+        string? QuestionAsks = null);
 
     /// <summary>The gold derivation an Arithmetic case's judge call carries.</summary>
     private sealed record CalibrationDerivation(


### PR DESCRIPTION
Executes the coordination unit's ruling: land this before Semantic, with the per-vertical floor and the `question_asks` field shipping in it, so the new vertical's judge is built under both from day one.

## Temporal was the second and last vertical with no judge template

It fell through to `StandardBody` — the two words *"Grade this answer."* — so its only guidance was the shared preamble, which defines `missed` as *confidently asserting nothing is there when gold says something is*. **"Nothing happened between them" matches that word for word.** But that answer **accepts both anchors** and misplaces them: a sequencing defect, not a retrieval one, and they route to different repairs.

The body draws the line:

- accepts the events and gets order/position/recency wrong — **including denying an interval contains anything** — is `wrong`, because *an empty interval is an ordering claim, not a statement about what the record holds*
- denies the record holds the events at all is `missed`
- doing both is decided by the **denial**

**Measured against a baseline taken before the body existed** — the discipline the Bitemporal fix skipped. Four controls were authored first, two `Wrong` and two `Missed` so the set can fail either way. Baseline with them in and no body present: **Temporal 0.857 / 0.929**. `cal-tem-026` is the over-correction guard — it says *"nothing lies between them"* while its operative claim is that the record holds neither anchor, so a rule reading only the interval phrase breaks it. It holds.

## A family-wide judge floor is satisfiable by averaging

Bitemporal sat at **0.750** behind a green family **0.946**, because six verticals near 0.98 averaged it away and the gate only ever read the mean. Same shape as the corpus defect where arithmetic certified at 0.700 with `duration` at 0.083.

A **0.80 per-vertical floor** now applies to the recorded result *and* the live arm. Below the family's 0.85 on purpose: a vertical is 24–28 cases, so one boundary case moves it ~0.04 and a floor at parity would fail on noise. **Verified by falsification** — forcing a vertical to 0.75 fires it.

## The judge now reports the route it took

Checking only the final label cannot tell a template that discriminates properly from one that **suppresses a label outright** — which is exactly how the first Bitemporal body reached 24/24 while overfitted, and it took a human asking *"isn't that too good?"* to find it.

`question_asks` is emitted in the judge's JSON at **zero extra calls**, with two enums because the verticals discriminate on different axes:

| Vertical | Enum | Property of |
|---|---|---|
| Bitemporal | `value` / `occurrence` | the **question** |
| Temporal | `ordering` / `presence` | what the **answer** commits to |

Declared on 14 cases where the branch is unambiguous, asserted only where declared — a `Correct` or `Abstained` answer has no meaningful branch, so asserting one would be noise. **Reaching the right outcome by the wrong route now fails the build.**

## Results

Three runs: **0.989 / 0.994 / 0.983**, lowest recorded.

| Vertical | |
|---|---|
| Bitemporal | **28/28** all three runs |
| Temporal | **28/28** all three runs |
| lowest any vertical | 0.917, clear of the 0.80 floor |
| wrong-route failures | **none, any run** |

For the first time, **no case disagrees in every run**.

`cal-pro-017` appears once as `Wrong → Premature`. That is `0.29`'s `ProspectiveBody` rule firing, and it is the **only** transition that rule can make — it chooses between two failure labels and can never move anything into or out of `correct`, so accuracy is invariant under it and only the failure distribution shifts. This is the live confirmation of the E-1 blast-radius statement.

## Still open, deliberately

The preamble gives *"I have no record of that"* as its `abstained` example and *"you never told me about that"* as its `missed` example. Near-synonyms, family-wide, and the likeliest cause of `cal-for-012` flapping. Parked for its own controlled change with its own controls and a seven-vertical before/after.

992/992 locally on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ