### PR TITLE
bench typedmemeval could not reach Full evidence capture — the caller never set it

### DIFF
--- a/src/AgentEval.Cli/Commands/BenchTypedMemEvalCommand.cs
+++ b/src/AgentEval.Cli/Commands/BenchTypedMemEvalCommand.cs
@@ -45,13 +45,43 @@ public static class BenchTypedMemEvalCommand
 {
     /// <summary>Runs the bench typedmemeval command using auto-discovered workspace root.</summary>
     public static Task<int> RunAsync(string vertical, string? subject, string? root, CancellationToken ct = default)
-        => RunAsync(vertical, subject, root, chatClientOverride: null, ct);
+        => RunAsync(vertical, subject, root, captureEvidenceContent: false, chatClientOverride: null, ct);
+
+    /// <summary>Runs the command with an explicit evidence-detail opt-in.</summary>
+    /// <param name="captureEvidenceContent">
+    /// Opt in to <see cref="EvidenceCaptureMode.Full"/>, which permits the adapter to attach the
+    /// retrieved TEXT and not merely identifiers. Default false, and it must stay that way: the
+    /// content is whatever the agent retrieved, so it may carry anything the corpus carries. The
+    /// safe-schema screen still rejects credential-shaped and control-byte content under Full.
+    /// </param>
+    public static Task<int> RunAsync(
+        string vertical, string? subject, string? root, bool captureEvidenceContent,
+        CancellationToken ct = default)
+        => RunAsync(vertical, subject, root, captureEvidenceContent, chatClientOverride: null, ct);
+
+    /// <summary>
+    /// Turns the caller's evidence-detail choice into runner options, or null to take the runner's
+    /// defaults.
+    /// </summary>
+    /// <remarks>
+    /// Extracted so the opt-in is testable without a deployment. This is the seam that was missing:
+    /// the command previously passed <c>options: null</c> unconditionally, so no caller could reach
+    /// <see cref="EvidenceCaptureMode.Full"/> however they invoked it, and an adapter that honoured
+    /// the request had its content rejected by the safe schema. The consuming project hit the same
+    /// shape independently in their own facade — the mapping was faithful in both codebases and
+    /// neither caller ever set the field.
+    /// </remarks>
+    internal static TypedMemEvalOptions? BuildRunOptions(bool captureEvidenceContent)
+        => captureEvidenceContent
+            ? new TypedMemEvalOptions { EvidenceCaptureMode = EvidenceCaptureMode.Full }
+            : null;
 
     /// <summary>Internal overload exposed for tests; allows chat-client injection.</summary>
     internal static async Task<int> RunAsync(
         string vertical,
         string? subject,
         string? root,
+        bool captureEvidenceContent,
         Microsoft.Extensions.AI.IChatClient? chatClientOverride,
         CancellationToken ct = default)
     {
@@ -139,13 +169,23 @@ public static class BenchTypedMemEvalCommand
         Console.WriteLine($"   Corpus:              {descriptor.CorpusId} ({descriptor.QuestionCount} embedded questions, no download)");
         Console.WriteLine($"   Grounding:           {descriptor.RequiredGrounding}");
         Console.WriteLine("   Scoring:             typed outcome vector — no single percentage");
+        if (captureEvidenceContent)
+        {
+            // Loud on purpose. This is the difference between storing which sessions were
+            // retrieved and storing what they SAID, and nobody should discover it from a JSON
+            // field after the run.
+            Console.WriteLine();
+            Console.WriteLine("   ⚠ EVIDENCE DETAIL:   content — retrieved TEXT will be stored in the result,");
+            Console.WriteLine("                        not just identifiers. Use only on corpora you control.");
+        }
         Console.WriteLine();
 
         // ── Run ──────────────────────────────────────────────────────────────
         ExternalBenchmarkResult result;
         try
         {
-            result = await new TypedMemEvalRunner(chatClient).RunAsync(agent, descriptor.Vertical, options: null, ct);
+            result = await new TypedMemEvalRunner(chatClient)
+                .RunAsync(agent, descriptor.Vertical, BuildRunOptions(captureEvidenceContent), ct);
         }
         catch (ArgumentException ex) when (ex.ParamName == "agent")
         {
@@ -226,6 +266,7 @@ public static class BenchTypedMemEvalCommand
                 ["max_judge_retries"] = result.Options.MaxJudgeRetries,
                 ["judge_max_output_tokens"] = result.Options.JudgeMaxOutputTokens,
                 ["evidence_capture_mode"] = (int)result.Options.EvidenceCaptureMode,
+                ["evidence_content_captured"] = result.Options.PersistsEvidenceContent ? 1 : 0,
                 ["evidence_top_k"] = result.Options.EvidenceTopK
             };
             if (typed.Coverage.Mean is { } coverageMean) metrics["coverage_mean"] = coverageMean;

--- a/src/AgentEval.Cli/Program.cs
+++ b/src/AgentEval.Cli/Program.cs
@@ -473,11 +473,13 @@ benchCmd.Add(benchNistCmd);
         var benchTmeVerticalOpt = new Option<string?>("--vertical") { Description = "prospective | episodic | arithmetic | workingmemory | forgetting. REQUIRED — the verticals measure different mechanisms, so there is no default." };
         var benchTmeSubjectOpt = new Option<string?>("--subject") { Description = "Subject name (agent under evaluation). REQUIRED." };
         var benchTmeRootOpt = new Option<string?>("--root") { Description = "Workspace root path (default: auto-detected)" };
+        var benchTmeEvidenceOpt = new Option<string?>("--evidence-detail") { Description = "references (default) | content. 'content' opts in to storing the retrieved TEXT in the result, not just which sessions were retrieved — it answers 'was the needed value actually in the prompt', which identifiers alone cannot. Off by default and loud when engaged: the content is whatever the agent retrieved, so use it only on corpora you control. Credential-shaped and control-byte content is still rejected." };
 
         var benchTmeCmd = new Command("typedmemeval", $"Run one TypedMemEval {TypedMemEvalVerticalDescriptor.CorpusRevision} (AgentEval) vertical — prospective, episodic, arithmetic, working-memory or forgetting memory behaviour, one embedded corpus each. Reads AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_API_KEY / AZURE_OPENAI_DEPLOYMENT — there is no stub fallback (the judge round-trip IS the correctness signal). Reports a typed outcome vector, never a single percentage; results are not comparable with LongMemEval.");
         benchTmeCmd.Add(benchTmeVerticalOpt);
         benchTmeCmd.Add(benchTmeSubjectOpt);
         benchTmeCmd.Add(benchTmeRootOpt);
+        benchTmeCmd.Add(benchTmeEvidenceOpt);
         benchTmeCmd.SetAction(async (ParseResult parseResult, CancellationToken ct) =>
         {
             var vertical = parseResult.GetValue(benchTmeVerticalOpt);
@@ -493,7 +495,20 @@ benchCmd.Add(benchNistCmd);
                 return 1;
             }
             var root = parseResult.GetValue(benchTmeRootOpt);
-            return await BenchTypedMemEvalCommand.RunAsync(vertical, subject, root, ct);
+
+            var evidenceDetail = parseResult.GetValue(benchTmeEvidenceOpt)?.Trim().ToLowerInvariant();
+            // Rejected rather than silently defaulted. A typo here is the difference between
+            // capturing content and not, and a run that quietly did the safer thing still wasted
+            // the spend the caller was paying for.
+            if (evidenceDetail is not (null or "references" or "content"))
+            {
+                Console.Error.WriteLine(
+                    $"Error: --evidence-detail must be 'references' or 'content', not '{evidenceDetail}'.");
+                return 1;
+            }
+
+            return await BenchTypedMemEvalCommand.RunAsync(
+                vertical, subject, root, captureEvidenceContent: evidenceDetail == "content", ct);
         });
         benchCmd.Add(benchTmeCmd);
     }

--- a/tests/AgentEval.Tests/Cli/BenchTypedMemEvalEvidenceOptInTests.cs
+++ b/tests/AgentEval.Tests/Cli/BenchTypedMemEvalEvidenceOptInTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 AgentEval Contributors
+
+using AgentEval.Cli.Commands;
+using AgentEval.Memory.External.Models;
+using AgentEval.Memory.External.TypedMemEval;
+using Xunit;
+
+namespace AgentEval.Tests.Cli;
+
+/// <summary>
+/// The opt-in has to REACH the capture layer, not merely exist on the command line.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The command passed <c>options: null</c> to the runner unconditionally, so
+/// <see cref="EvidenceCaptureMode.Full"/> was unreachable however it was invoked. Every layer
+/// underneath was correct — the option exists, the mapping copies it faithfully, the guard permits
+/// content under Full — and the run still failed with <c>evidence_content_not_allowed</c>, because
+/// the caller never set the field.
+/// </para>
+/// <para>
+/// The consuming project hit the identical shape in their own facade the same week: their builder
+/// set five properties and not this one, their mapping copied it faithfully, and an adapter
+/// honouring their flag had its content rejected. Two codebases, two surfaces, one defect —
+/// "reachable ≠ fed". A test that only checked the mapping would have passed in both.
+/// </para>
+/// </remarks>
+public sealed class BenchTypedMemEvalEvidenceOptInTests
+{
+    [Fact]
+    public void OptIn_ReachesTheRunnerAsFullCapture()
+    {
+        var options = BenchTypedMemEvalCommand.BuildRunOptions(captureEvidenceContent: true);
+
+        Assert.NotNull(options);
+        Assert.Equal(EvidenceCaptureMode.Full, options.EvidenceCaptureMode);
+
+        // The whole point of Full: content is permitted rather than rejected downstream.
+        Assert.True(options.ToExternalOptions(TypedMemEvalVerticals.All[0]).PersistsEvidenceContent);
+    }
+
+    [Fact]
+    public void WithoutTheOptIn_TheRunnerKeepsItsOwnDefaults()
+    {
+        // Null rather than an explicit References object: the default belongs to the runner, and
+        // restating it here would be a second place to change it.
+        Assert.Null(BenchTypedMemEvalCommand.BuildRunOptions(captureEvidenceContent: false));
+    }
+
+    [Fact]
+    public void TheDefaultIsNotFull()
+    {
+        // Content capture must never be what you get by not choosing. Asserted against the mapped
+        // options the runner actually receives, not against the enum's declared default.
+        var defaults = new TypedMemEvalOptions().ToExternalOptions(TypedMemEvalVerticals.All[0]);
+
+        Assert.NotEqual(EvidenceCaptureMode.Full, defaults.EvidenceCaptureMode);
+        Assert.False(defaults.PersistsEvidenceContent);
+    }
+}


### PR DESCRIPTION
Closes **D-1** from the consuming project. Their escalation path — re-run under `EvidenceCaptureMode.Full` to see whether the needed *value* was actually rendered — returned `evidence_content_not_allowed` and a null evidence block, **strictly less than identifiers mode provides**.

## The guard was never the problem

Every layer underneath is correct, and I checked each one rather than assuming:

| Layer | State |
|---|---|
| `EvidenceCaptureMode.Full` exists | ✅ |
| `TypedMemEvalOptions` maps it into `ExternalBenchmarkOptions` | ✅ faithfully, `TypedMemEvalOptions.cs:177` |
| Guard permits content under `Full` | ✅ `LongMemEvalEvidenceCapture.cs:175` — rejects only when `mode != Full` |
| Credential/control-byte screening still applies under `Full` | ✅ |
| **Command reaches it** | ❌ **`options: null`, unconditionally** |

So `Full` was unreachable however you invoked it, and an adapter honouring the request had its content rejected. The escalation path we *documented* was not reachable from the surface we *shipped*.

## The fix

`--evidence-detail references|content`, default `references`.

- **Typos rejected, not silently defaulted** — a run that quietly did the safer thing still spends what the caller was paying for.
- **Loud on stdout** when engaged. The difference is between storing *which* sessions were retrieved and storing *what they said*; nobody should discover that from a JSON field after the run.
- **Stamped** as `evidence_content_captured` in the sidecar.
- Credential-shaped and control-byte content still rejected under `Full`.

## Why the test is shaped this way

The seam is extracted as `BuildRunOptions` so the opt-in is testable without a deployment, and the test is **falsification-verified** — it fails against the old `options: null` behaviour:

```
OptIn_ReachesTheRunnerAsFullCapture [FAIL]     <- reverted to options: null
Failed: 1, Passed: 2
```

**A test that only checked the mapping would have passed the whole time.** That matters, because the consuming project hit the *identical shape* in their own facade the same week: a builder that set five properties and not this one, sitting above a mapping that copied it faithfully. Two codebases, two surfaces, one defect — **reachable ≠ fed**. Their framing is better than mine was: not *"the CLI cannot set it"* but *"the caller never set it"*.

Cost of finding it: ~4h30m and ~100 LLM calls on a run this silently downgraded.

9447/9449 passing on net10.0 (2 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ