### PR TITLE
release: 0.30.0-beta — Semantic, Conjunction, and a judge that reports its route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alternating. Editing the shared preamble changes grading for all seven verticals, so it needs its
   own controls and its own before/after.
 
+- **TypedMemEval-Conjunction: the cross-type vertical (ADR-027 §10).** Questions no single memory
+  type can answer — a fact of type A must be resolved and an operation of type B applied to it.
+  Retrieving either half is necessary and neither is sufficient, so a stack strong on one type and
+  weak on the other scores like a stack weak on both. Three shapes: `value-then-count` (Semantic
+  current-value + Arithmetic count), `alias-then-count` (Semantic co-reference + Arithmetic count),
+  `order-then-value` (Temporal order + Semantic current-value).
+
+  Probed: **V1 49/50, V9 18/50, headroom 0.62** — tied with Arithmetic for the largest in the
+  family. **Read the shapes, never the mean:** `alias-then-count` 0.93, `value-then-count` 0.85,
+  **`order-then-value` 0.00 — saturated under BM25** and unable to discriminate retrievers at all.
+  That is the mean-satisfiable-by-averaging defect one level up, at headroom rather than coverage,
+  and it is declared in the corpus rather than left inside an average.
+
+  The **first vertical with genuinely mixed gold** (35 `arithmetic+semantic`, 15
+  `semantic+temporal`), so a per-type denominator is computable. §10's instruction not to inherit
+  the parts' certifications was load-bearing: its own V7 caught two gold-only constructions the
+  parent verticals' passes would have papered over.
+
+- **TypedMemEval-Semantic: resolution rather than recall (ADR-027 §3.1, narrowed).** §2.1 refused
+  plain-fact Semantic as saturated by construction; these three shapes share the property plain
+  recall lacks — retrieving the evidence is necessary and **not sufficient**. `current-value`
+  (an attribute replaced *k* times), `co-reference` (a fact asked under a different designation),
+  `source-attribution` (which conversation a belief came from).
+
+  Probed V1 50/50, V9 34/50, headroom 0.32. **It ships with no judge body, and that is the
+  finding** — 0.958 across three runs on the shared preamble alone. Bitemporal and Temporal each
+  needed one because each genuinely collided with the preamble; Semantic does not collide.
+
+- **Per-item gold type labels (ADR-027 §10 commitment 1).** Every gold item now carries the memory
+  type it belongs to, in the **sidecar** rather than the corpus: `corpus_sha256` covers the whole
+  corpus JSON, so putting them in the extension would have moved the sha of every vertical and
+  invalidated every probe record with it.
+
+- **`bench typedmemeval` had no way to reach `EvidenceCaptureMode.Full` — the caller never set
+  it.** Every layer underneath was correct: the option exists, `TypedMemEvalOptions` maps it
+  faithfully, and the guard permits content under `Full`. But the command passed `options: null`
+  unconditionally, so an adapter attaching retrieved text had it rejected with
+  `evidence_content_not_allowed`. New `--evidence-detail references|content`, default
+  `references`, rejected rather than silently defaulted on a typo, loud on stdout when engaged.
+
+  *(This entry was written for the original PR and lost when two changelog edits to the same region
+  were squashed; restored here rather than left as a shipped feature with no record.)*
+
+### Added
+
+- **`tools/validate_factgrain_axis.py`** — the R2 instrument. Fact-grain competition was proposed
+  as a paired second difficulty axis; this shows it **cannot be validated against our own arms**.
+  The only measure that predicts V9 misses is derived from the same BM25 that V9 *is*, so predictor
+  and outcome share an instrument; both retriever-independent measures carry no signal. V1 and V8
+  pass every question, so V9 is the only arm with variance and it is lexical. Committed as a
+  runnable script so the negative result is reproducible.
+
+## [0.29.0-beta] - 2026-08-28
+
 ### Fixed
 
 - **Bitemporal had no judge template, and the shared preamble mis-graded it — then the first fix

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
          whose assemblies reported 0.16.0.0 — and `AgentEvalVersion` in result provenance reads
          Assembly.GetName().Version, so every result that release produced was stamped with a
          version that had not been current since 0.16. The consuming project caught it. -->
-    <Version>0.29.0-beta</Version>
+    <Version>0.30.0-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>


### PR DESCRIPTION
Cuts `0.30.0-beta` for #182–#186. **Not tagged** — the consuming project probes `main` *before* the tag under the restored standing arrangement, and the T-0 notice with checkable predictions goes to them first.

## Two changelog defects fixed while cutting this, both from the previous release

**`0.29.0-beta` was tagged and published with no version heading.** Its entries sat under `[Unreleased]` and would have been silently absorbed into this cut, making it look like 0.30 shipped work that went out a week earlier. Heading created, dated to the tag.

**The `--evidence-detail` entry was missing entirely.** #182 and #183 both edited the same changelog region and the squash dropped #183's — a shipped feature with no record. Restored, with a note saying why it arrives a release late rather than backdating it.

## What the cut contains

| | |
|---|---|
| **Conjunction** | cross-type vertical, headroom **0.62** — but read the shapes: `order-then-value` is **0.00, saturated** |
| **Semantic** | resolution not recall; ships with **no judge body**, and that is the finding |
| Per-item gold type labels | in the **sidecar** — `corpus_sha256` covers the corpus JSON |
| Per-vertical judge floor | 0.80, falsification-verified |
| `question_asks` | the judge reports the route it took, asserted independently of the outcome |
| Temporal judge body | the second and last vertical falling through to `StandardBody` |
| `--evidence-detail` | the caller never set it |
| R2 instrument | the fact-grain axis cannot be validated against our own arms |

Nine verticals, 470 questions. 1031/1031 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ