### PR TITLE
The preamble seam is not the defect I claimed, and my repair was a regression

### DIFF
--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -2,46 +2,50 @@
   "judge_prompt_fingerprint": "2fe921a6528c10fb29423ebe3100dc135634211c3bc60f4623fca7b8d91373e3",
   "measured_at": "2026-08-29",
   "model": "gpt-5.5",
-  "agreement": 0.991,
+  "agreement": 0.983,
   "status": "measured",
-  "cases": 224,
+  "cases": 230,
   "runs": 3,
   "per_vertical": {
     "Prospective": 1.0,
     "Episodic": 1.0,
     "Arithmetic": 1.0,
     "WorkingMemory": 1.0,
-    "Forgetting": 0.917,
+    "Forgetting": 0.885,
     "Bitemporal": 1.0,
     "Temporal": 1.0,
-    "Semantic": 1.0,
+    "Semantic": 0.962,
     "Conjunction": 1.0
   },
   "disagreements": {
     "every_run": [
-      "cal-for-006"
+      "cal-for-006",
+      "cal-for-012"
     ],
     "run_varying": [
-      "cal-for-012",
+      "cal-for-013",
+      "cal-sem-007",
+      "cal-sem-013",
       "cal-sem-020"
     ]
   },
   "superseded": {
-    "judge_prompt_fingerprint": "6f006dbb4014994ae2db341e6546a83093658a3e514a0aa2de10eed9a6879e7b",
-    "measured_at": "2026-08-28",
+    "judge_prompt_fingerprint": "2fe921a6528c10fb29423ebe3100dc135634211c3bc60f4623fca7b8d91373e3",
+    "measured_at": "2026-08-29",
     "model": "gpt-5.5",
-    "agreement": 0.98,
-    "cases": 200,
+    "agreement": 0.991,
+    "cases": 224,
     "per_vertical": {
       "Prospective": 1.0,
       "Episodic": 1.0,
       "Arithmetic": 1.0,
       "WorkingMemory": 1.0,
-      "Forgetting": 0.875,
+      "Forgetting": 0.917,
       "Bitemporal": 1.0,
       "Temporal": 1.0,
-      "Semantic": 0.958
+      "Semantic": 1.0,
+      "Conjunction": 1.0
     }
   },
-  "note": "Three runs: 0.991 / 0.991 / 0.991 - the tightest the set has recorded, and the first with eight of nine verticals at 1.000. Per-vertical from run 3, the run whose lowest vertical is lowest. CONJUNCTION ADDED, and it needed a body. It is the first vertical whose gold is mixed-type, and the shared preamble has no way to say that BOTH halves of a join must be right: precedence rule 3 says extra correct detail never lowers the outcome, and the judge extended that to detail which was not correct. Given '3 times, with Marlow Carriage' against a gold of 3 with a different courier it returned CORRECT in every baseline run. The body says a count is a count OF something, that a right number on the wrong entity is wrong rather than correct-with-extra, and that resolving the fact without performing the operation is a commitment rather than an abstention. Conjunction 24/24 in all three runs, from a baseline of 22/24. THE FIX THAT MATTERED WAS IN THE CORPUS, NOT THE PROMPT. cal-cnj-023 - right count, superseded entity - kept returning correct even WITH the body, and the judge was right: it sees only question, gold and answer, and the gold said '3 times.' with no courier in it. There was no contradiction to find. A prompt rule could have forced agreement, at the cost of teaching the judge to punish appended detail in general and breaking the four controls that exist to stop exactly that. Gold now reads '3 times, with Oakhurst Transit.' The general rule, which applies to anything composed after this: IF A QUESTION REQUIRES TWO THINGS TO BE RIGHT, GOLD MUST STATE BOTH, OR THE SECOND IS UNJUDGEABLE. TWO OF MY OWN LABELS WERE WRONG AGAIN, both caught by the baseline rather than by review. cal-cnj-005 and cal-cnj-024 are the same construction on two shapes - resolve the fact, never perform the operation - and I labelled them abstained; the preamble reserves abstained for declining to commit to ANY value, and both commit confidently to something the question did not ask. I also relabelled only one of the two at first, which the judge caught by marking both wrong in every run. Across Semantic and Conjunction my authored labels have needed correction at roughly one case in ten, which is the whole argument for measuring a baseline before writing a body: every one of those would otherwise have been fossilised into a template that made the number look perfect. cal-for-006 remains the only every-run disagreement in the family. It, cal-for-012 and cal-sem-020 all sit on the shared preamble's abstained/missed/wrong seam, which stays parked for its own controlled change across all nine verticals."
+  "note": "Three runs: 0.983 / 0.983 / 0.983. THE FINGERPRINT IS UNCHANGED - no prompt edit ships from this work. The re-measurement was forced by SCOPE alone: six calibration controls were added, 224 -> 230. THIS TASK PRODUCED THREE NESTED NEGATIVE RESULTS, and shipping almost nothing is the correct outcome. It was undertaken because the shared preamble states the abstained/missed line as uncertainty-versus-denial and then illustrates ABSTAINED with 'I have no record of that', which is a denial. I argued to the consuming project that this was the family's largest remaining judge defect and that it should be sequenced ahead of their own corpus work. They adopted that ordering on my argument. The argument was wrong. (1) THE SEAM IS NOT A FAMILY-WIDE DEFECT. Eight negative controls were authored first and a BEFORE state measured across all nine verticals: six of eight passed unchanged. (2) MY REPAIR WAS A REGRESSION. Making the preamble self-consistent - folding record-absence into missed - dropped agreement from 0.983/0.987 to 0.974/0.966/0.974 and converted the family's canonical genuine-refusal-abstains cases to Missed in FOUR verticals (cal-epi-013, cal-wm-003, cal-wm-022, cal-bit-024, cal-tem-023). Reverted. The preamble ships untouched. (3) HALF MY CONTROLS WERE NOT MEASURING THE SEAM. Four were placed in Forgetting's still-valid shape, where ForgettingBody states that an answer claiming a still-valid fact is no longer known is WRONG. Under that rule abstained is essentially unreachable in that shape - even a bare 'I don't know' grades wrong - so those controls measured the vertical's over-forgetting rule instead. Two of them (cal-for-025, cal-for-027) then flapped BOTH WAYS across six runs: labelled Abstained they graded Wrong, labelled Wrong they graded Abstained. A case the judge answers both ways with equal frequency has no correct label and cannot discriminate anything, so both were removed - cases I added this session, removed for failing their design purpose rather than for being inconvenient, and the removal is recorded in cal-for-026's note rather than left to a diff. WHAT SHIPS IS ONE RULE AND SIX CONTROLS. The rule is that A VERTICAL BODY SUPERSEDES THE SHARED PREAMBLE, which was true, load-bearing and written down nowhere before. cal-for-026 and cal-for-028 document it: the same sentence shape is WRONG in Forgetting (over-forgetting) and MISSED in Semantic (cal-sem-026), decided by the vertical, and both are stable. THE CORRECT SCOPING, narrower than what I claimed: the preamble's ambiguity reaches whichever vertical LACKS a body to settle it. Semantic is the only one, and it is where the residue lives - cal-sem-007 and cal-sem-013 flip between Missed and Abstained on exactly this boundary. The remedy is therefore a Semantic body or a deliberate acceptance there, NOT a preamble edit, which is measurably worse. cal-for-006 and cal-for-012 remain the only every-run disagreements. Forgetting at 0.885 is its floor with the two surviving seam controls in it, above the 0.80 per-vertical floor."
 }

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
@@ -2896,5 +2896,71 @@
     "expected": "Wrong",
     "rule": "conj-restates-resolution-never-counts",
     "note": "Performs the co-reference and stops, committing to no number. RELABELLED abstained -> wrong alongside cal-cnj-005, which is the identical construction on the other shape and which I relabelled first while leaving this one behind - my inconsistency, caught by the judge marking both wrong in every run. Abstained requires declining to commit to any value; this commits to a true statement that answers a different question. cal-cnj-006 and cal-cnj-013 are the genuine abstentions."
+  },
+  {
+    "id": "cal-for-026",
+    "vertical": "Forgetting",
+    "shape": "still-valid",
+    "question": "Who is my dentist?",
+    "gold": "Ashcroft Dental - that is still your dentist.",
+    "answer": "I have no record of a dentist for you.",
+    "expected": "Wrong",
+    "rule": "seam-record-absence-is-over-forgetting",
+    "note": "RELABELLED missed -> wrong after the BEFORE measurement, and the label was mine to fix. Gold here is STILL-VALID, and ForgettingBody says in as many words: 'Gold says the fact is still valid: an answer claiming it is no longer known is wrong - the system is forgetting something it should still hold.' The vertical's own template supersedes the shared preamble's abstained/missed line, and the judge applied it correctly in both runs. I authored the label from the preamble alone without reading the body that governs the case. See also cal-for-025 and cal-for-027, relabelled for the same reason. The case still earns its place: it is almost verbatim the preamble's ABSTAINED illustration and it is not abstained under any reading, which is the point. In Forgetting it is wrong (over-forgetting a still-valid fact); in a vertical with no body of its own it would be missed (see cal-sem-026, which is the same sentence shape and IS missed). One phrase, two correct answers, decided by the vertical - that is the discipline working, not an ambiguity. Two sibling controls (cal-for-025 'I don't know', cal-for-027 'I am not sure what I have on file') were authored alongside this one and REMOVED: with an Abstained label they graded Wrong, with a Wrong label they graded Abstained, flapping both ways across six runs. A case the judge answers both ways with equal frequency cannot discriminate anything and only adds noise to a vertical that already carries the family's last every-run disagreement. They were mine, added this session, and removed for failing their design purpose - not for being inconvenient. This case and cal-for-028 are stable at Wrong and carry the finding they were all authored to look for."
+  },
+  {
+    "id": "cal-for-028",
+    "vertical": "Forgetting",
+    "shape": "still-valid",
+    "question": "Who is my dentist?",
+    "gold": "Ashcroft Dental - that is still your dentist.",
+    "answer": "There is nothing on file about a dentist.",
+    "expected": "Wrong",
+    "rule": "seam-store-asserted-empty-is-over-forgetting",
+    "note": "RELABELLED missed -> wrong after the BEFORE measurement, and the label was mine to fix. Gold here is STILL-VALID, and ForgettingBody says in as many words: 'Gold says the fact is still valid: an answer claiming it is no longer known is wrong - the system is forgetting something it should still hold.' The vertical's own template supersedes the shared preamble's abstained/missed line, and the judge applied it correctly in both runs. I authored the label from the preamble alone without reading the body that governs the case. Third-person form of cal-for-026. Same reading, same correction."
+  },
+  {
+    "id": "cal-sem-025",
+    "vertical": "Semantic",
+    "shape": "current-value",
+    "question": "Who is my usual courier now?",
+    "gold": "Oakhurst Transit.",
+    "answer": "I could not tell you who that is now.",
+    "expected": "Abstained",
+    "rule": "seam-declines-without-absence-claim",
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Declines and asserts nothing about the record. Abstained on any reading."
+  },
+  {
+    "id": "cal-sem-026",
+    "vertical": "Semantic",
+    "shape": "current-value",
+    "question": "Who is my usual courier now?",
+    "gold": "Oakhurst Transit.",
+    "answer": "Nothing is recorded for your courier.",
+    "expected": "Missed",
+    "rule": "seam-nothing-recorded",
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Asserts the record is empty when gold says it is not. The sibling of cal-sem-007, which is the case that first exposed this seam by matching the abstained illustration while carrying the missed label."
+  },
+  {
+    "id": "cal-wm-025",
+    "vertical": "WorkingMemory",
+    "shape": "distance-8",
+    "question": "Which gym did I say I go to?",
+    "gold": "Brightwater.",
+    "answer": "I don't recall.",
+    "expected": "Abstained",
+    "rule": "seam-recall-failure-is-uncertainty",
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Reports the system's own failure to retrieve without claiming the fact is absent. Abstained - and this one matters because 'I do not recall' is easily read as a denial."
+  },
+  {
+    "id": "cal-wm-026",
+    "vertical": "WorkingMemory",
+    "shape": "distance-8",
+    "question": "Which gym did I say I go to?",
+    "gold": "Brightwater.",
+    "answer": "You never mentioned a gym.",
+    "expected": "Missed",
+    "rule": "seam-denies-being-told",
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Verbatim the preamble's MISSED illustration, kept as the anchor at that end so the edit cannot drift missed toward abstained either."
   }
 ]


### PR DESCRIPTION
Three nested negative results. **The preamble ships unchanged** and the fingerprint does not move — the re-measurement was forced by scope alone, 224 → 230 cases.

I argued to the consuming project that the shared preamble's `abstained`/`missed` seam was the family's largest remaining judge defect and should be sequenced **ahead of their own corpus work**. They adopted that ordering on my argument. The argument was wrong.

## 1. The seam is not a family-wide defect

Eight negative controls authored **first**, BEFORE state measured across all nine verticals: **six of eight passed unchanged.**

The two failures were in Forgetting and graded `Wrong`, not `Abstained` — because `ForgettingBody` says so explicitly:

> *"Gold says the fact is still valid: an answer claiming it is no longer known is 'wrong' — the system is forgetting something it should still hold."*

My labels were authored from the preamble without reading the body that governs the case.

## 2. My repair was a regression

Folding record-absence into `missed` — which makes the preamble self-consistent — measured:

```
BEFORE  0.983 / 0.987
AFTER   0.974 / 0.966 / 0.974
```

It converted the family's canonical `genuine-refusal-abstains` cases to `Missed` across **four verticals**: `cal-epi-013`, `cal-wm-003`, `cal-wm-022`, `cal-bit-024`, `cal-tem-023`.

**My over-correction guard did not catch it.** I built `cal-for-027` against the failure I imagined; the regression landed on the *existing* refusal cases I never enumerated before editing. Reverted.

## 3. Half my controls were not measuring the seam

Four sat in Forgetting's `still-valid` shape, where `abstained` is essentially unreachable — even a bare *"I don't know"* grades `wrong`. They measured over-forgetting instead.

Two then **flapped both ways** across six runs: labelled `Abstained` they graded `Wrong`; labelled `Wrong` they graded `Abstained`. A case the judge answers both ways with equal frequency has no correct label, so `cal-for-025` and `cal-for-027` are removed — cases I added this session, removed for failing their design purpose rather than for being inconvenient. **The removal and its reasoning are written into `cal-for-026`'s note**, not left to a diff nobody re-reads.

## What ships: one rule and six controls

**A vertical body supersedes the shared preamble.** True, load-bearing, written down nowhere before. `cal-for-026` and `cal-for-028` document it: the same sentence shape is `Wrong` in Forgetting (over-forgetting) and `Missed` in Semantic (`cal-sem-026`), decided by the vertical, and all three are stable.

## And a narrower scoping than I claimed

The preamble's ambiguity reaches **whichever vertical lacks a body to settle it**. Semantic is the only one, and that is where the residue lives — `cal-sem-007` and `cal-sem-013` flip on exactly this boundary. The remedy is a Semantic body or a deliberate acceptance there, **not** a preamble edit, which is measurably worse.

Three runs `0.983 / 0.983 / 0.983`, matching the pre-task baseline. 1031/1031 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ