### PR TITLE
Commission the Semantic judge body, built under reach enumeration

### DIFF
--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudge.cs
@@ -206,6 +206,7 @@ public sealed class TypedMemEvalJudge
             TypedMemEvalVertical.Forgetting => TypedMemEvalVerdict.Kind.Forgetting,
             TypedMemEvalVertical.Bitemporal => TypedMemEvalVerdict.Kind.Bitemporal,
             TypedMemEvalVertical.Temporal => TypedMemEvalVerdict.Kind.Temporal,
+            TypedMemEvalVertical.Semantic => TypedMemEvalVerdict.Kind.Semantic,
             TypedMemEvalVertical.Episodic when extension.Shape == "list-order"
                 => TypedMemEvalVerdict.Kind.ListOrder,
             _ => TypedMemEvalVerdict.Kind.Base
@@ -229,6 +230,9 @@ public sealed class TypedMemEvalJudge
 
             TypedMemEvalVertical.Temporal =>
                 TypedMemEvalJudgePrompts.Temporal(question, goldAnswer, agentResponse),
+
+            TypedMemEvalVertical.Semantic =>
+                TypedMemEvalJudgePrompts.Semantic(question, goldAnswer, agentResponse),
 
             TypedMemEvalVertical.Conjunction =>
                 TypedMemEvalJudgePrompts.Conjunction(question, goldAnswer, agentResponse),

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalJudgePrompts.cs
@@ -198,6 +198,45 @@ internal static class TypedMemEvalJudgePrompts
           resolved entity alongside a correct count is correct, and so is naming the
           designation the events were recorded under. Only a contradiction demotes.
         """;
+    /// <remarks>
+    /// Semantic shipped without a body deliberately - it measured 0.958 on the shared preamble
+    /// alone and no case failed consistently, so a template would have been ceremony. What the
+    /// preamble cannot settle is its own abstained/missed line: it states the distinction as
+    /// uncertainty versus denial and then illustrates ABSTAINED with "I have no record of that",
+    /// which is a denial. Every other vertical with a stake carries a body that settles it;
+    /// Semantic was the only one that did not, and cal-sem-007 and cal-sem-013 flip between
+    /// Missed and Abstained across runs as a result.
+    ///
+    /// Editing the shared preamble was tried and measured: it converted the family's canonical
+    /// genuine-refusal cases to Missed in four verticals and dropped agreement 0.983 to 0.966.
+    /// The remedy is per-vertical, which is what this is.
+    /// </remarks>
+    private const string SemanticBody = """
+
+        This question asks you to RESOLVE something, not merely to recall it: the current value
+        after a chain of replacements, a fact stated under a different designation, or which
+        conversation a belief came from.
+
+        THE DISTINCTION THIS VERTICAL NEEDS SETTLED. An answer that fails to give the value can
+        fail in three different ways, and they are three different outcomes:
+
+        - It ASSERTS THE RECORD HOLDS NOTHING - "I have no record of that", "nothing is
+          recorded", "I do not have one on file" - when gold says the record does hold it. That
+          is "missed". It is a claim about the store, and gold says the claim is false.
+
+        - It DECLINES WITHOUT CLAIMING ABSENCE - "I could not say which", "I am not sure which
+          one you mean". That is "abstained". Uncertainty about what is there differs from
+          asserting nothing is.
+
+        - It COMMITS TO SOMETHING THAT IS NOT THE ANSWER. That is "wrong", not abstained, and
+          it includes two cases that look like refusals and are not: listing every value the
+          record has held without saying which is current, and restating a related fact instead
+          of answering the question asked. Both commit; neither declines.
+
+        Nothing above changes the preamble's precedence rules. A hedged answer is still graded
+        on the value it states, and extra detail that agrees with gold still never lowers the
+        outcome.
+        """;
     private const string ArithmeticBody = """
 
         This question has a derived numeric answer. Grade the ARITHMETIC, not the phrasing.
@@ -278,6 +317,9 @@ internal static class TypedMemEvalJudgePrompts
     internal static string Conjunction(string question, string gold, string answer)
         => string.Format(Preamble + ConjunctionBody + Closing, question, gold, answer);
 
+    internal static string Semantic(string question, string gold, string answer)
+        => string.Format(Preamble + SemanticBody + Closing, question, gold, answer);
+
     internal static string ListOrder(string question, string gold, string answer)
         => string.Format(Preamble + ListOrderBody + Closing, question, gold, answer);
 
@@ -313,6 +355,18 @@ internal static class TypedMemEvalJudgePrompts
              "reasoning": "<one or two sentences>",
              "ordered_pairs_correct": <integer>,
              "ordered_pairs_total": <integer>}
+            """,
+        TypedMemEvalVerdict.Kind.Semantic => """
+
+            Reply with a single JSON object and nothing else:
+            {"outcome": "correct" | "wrong" | "abstained" | "missed" | "premature",
+             "reasoning": "<one or two sentences>",
+             "question_asks": "value" | "absence" | "uncertainty"}
+
+            question_asks is what THE ANSWER commits to, and it is the branch you took above:
+            "value" if it commits to some value (right or wrong), "absence" if it asserts the
+            record holds nothing, "uncertainty" if it declines without claiming absence. Report
+            what you actually decided, not what would justify the outcome.
             """,
         TypedMemEvalVerdict.Kind.Bitemporal => """
 
@@ -362,6 +416,7 @@ internal static class TypedMemEvalJudgePrompts
             .Append(BitemporalBody).Append('\u001e')
             .Append(TemporalBody).Append('\u001e')
             .Append(ConjunctionBody).Append('\u001e')
+            .Append(SemanticBody).Append('\u001e')
             .Append(ArithmeticBody).Append('\u001e')
             .Append(ListOrderBody).Append('\u001e')
             .Append(ForgettingBody).Append('\u001e')

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalVerdict.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalVerdict.cs
@@ -59,7 +59,14 @@ internal static class TypedMemEvalVerdict
         Bitemporal,
 
         /// <summary>Adds which branch of the ordering-versus-presence discriminator was taken (Temporal).</summary>
-        Temporal
+        Temporal,
+
+        /// <summary>
+        /// Adds what the answer commits to when it does not give the value (Semantic): a value, an
+        /// assertion of absence, or uncertainty. That three-way is the distinction the shared
+        /// preamble states but does not settle.
+        /// </summary>
+        Semantic
     }
 
     private const string OutcomeProperty = """
@@ -155,6 +162,22 @@ internal static class TypedMemEvalVerdict
         }
         """);
 
+    private static readonly JsonElement s_semantic = ParseSchema($$"""
+        {
+          "type": "object",
+          "properties": {
+        {{OutcomeProperty}},
+            "question_asks": {
+              "type": "string",
+              "enum": ["value", "absence", "uncertainty"],
+              "description": "What the answer commits to: a VALUE (right or wrong), an assertion of ABSENCE (the record holds nothing), or UNCERTAINTY (declines without claiming absence). Report the branch you actually took."
+            }
+          },
+          "required": ["outcome", "reasoning", "question_asks"],
+          "additionalProperties": false
+        }
+        """);
+
     private static JsonElement ParseSchema(string json) => JsonDocument.Parse(json).RootElement.Clone();
 
     internal static JsonElement Schema(Kind kind) => kind switch
@@ -163,6 +186,7 @@ internal static class TypedMemEvalVerdict
         Kind.ListOrder => s_listOrder,
         Kind.Bitemporal => s_bitemporal,
         Kind.Temporal => s_temporal,
+        Kind.Semantic => s_semantic,
         _ => s_base
     };
 

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration-result.json
@@ -1,8 +1,8 @@
 {
-  "judge_prompt_fingerprint": "2fe921a6528c10fb29423ebe3100dc135634211c3bc60f4623fca7b8d91373e3",
+  "judge_prompt_fingerprint": "b1d3f7216032ba27232fe4f0824f84226ffc39db6b226a66fa286b756b44e123",
   "measured_at": "2026-08-29",
   "model": "gpt-5.5",
-  "agreement": 0.983,
+  "agreement": 0.987,
   "status": "measured",
   "cases": 230,
   "runs": 3,
@@ -11,41 +11,38 @@
     "Episodic": 1.0,
     "Arithmetic": 1.0,
     "WorkingMemory": 1.0,
-    "Forgetting": 0.885,
+    "Forgetting": 0.923,
     "Bitemporal": 1.0,
     "Temporal": 1.0,
-    "Semantic": 0.962,
-    "Conjunction": 1.0
+    "Semantic": 1.0,
+    "Conjunction": 0.958
   },
   "disagreements": {
     "every_run": [
-      "cal-for-006",
-      "cal-for-012"
+      "cal-for-006"
     ],
     "run_varying": [
-      "cal-for-013",
-      "cal-sem-007",
-      "cal-sem-013",
-      "cal-sem-020"
+      "cal-cnj-011",
+      "cal-for-012"
     ]
   },
   "superseded": {
     "judge_prompt_fingerprint": "2fe921a6528c10fb29423ebe3100dc135634211c3bc60f4623fca7b8d91373e3",
     "measured_at": "2026-08-29",
     "model": "gpt-5.5",
-    "agreement": 0.991,
-    "cases": 224,
+    "agreement": 0.983,
+    "cases": 230,
     "per_vertical": {
       "Prospective": 1.0,
       "Episodic": 1.0,
       "Arithmetic": 1.0,
       "WorkingMemory": 1.0,
-      "Forgetting": 0.917,
+      "Forgetting": 0.885,
       "Bitemporal": 1.0,
       "Temporal": 1.0,
-      "Semantic": 1.0,
+      "Semantic": 0.962,
       "Conjunction": 1.0
     }
   },
-  "note": "Three runs: 0.983 / 0.983 / 0.983. THE FINGERPRINT IS UNCHANGED - no prompt edit ships from this work. The re-measurement was forced by SCOPE alone: six calibration controls were added, 224 -> 230. THIS TASK PRODUCED THREE NESTED NEGATIVE RESULTS, and shipping almost nothing is the correct outcome. It was undertaken because the shared preamble states the abstained/missed line as uncertainty-versus-denial and then illustrates ABSTAINED with 'I have no record of that', which is a denial. I argued to the consuming project that this was the family's largest remaining judge defect and that it should be sequenced ahead of their own corpus work. They adopted that ordering on my argument. The argument was wrong. (1) THE SEAM IS NOT A FAMILY-WIDE DEFECT. Eight negative controls were authored first and a BEFORE state measured across all nine verticals: six of eight passed unchanged. (2) MY REPAIR WAS A REGRESSION. Making the preamble self-consistent - folding record-absence into missed - dropped agreement from 0.983/0.987 to 0.974/0.966/0.974 and converted the family's canonical genuine-refusal-abstains cases to Missed in FOUR verticals (cal-epi-013, cal-wm-003, cal-wm-022, cal-bit-024, cal-tem-023). Reverted. The preamble ships untouched. (3) HALF MY CONTROLS WERE NOT MEASURING THE SEAM. Four were placed in Forgetting's still-valid shape, where ForgettingBody states that an answer claiming a still-valid fact is no longer known is WRONG. Under that rule abstained is essentially unreachable in that shape - even a bare 'I don't know' grades wrong - so those controls measured the vertical's over-forgetting rule instead. Two of them (cal-for-025, cal-for-027) then flapped BOTH WAYS across six runs: labelled Abstained they graded Wrong, labelled Wrong they graded Abstained. A case the judge answers both ways with equal frequency has no correct label and cannot discriminate anything, so both were removed - cases I added this session, removed for failing their design purpose rather than for being inconvenient, and the removal is recorded in cal-for-026's note rather than left to a diff. WHAT SHIPS IS ONE RULE AND SIX CONTROLS. The rule is that A VERTICAL BODY SUPERSEDES THE SHARED PREAMBLE, which was true, load-bearing and written down nowhere before. cal-for-026 and cal-for-028 document it: the same sentence shape is WRONG in Forgetting (over-forgetting) and MISSED in Semantic (cal-sem-026), decided by the vertical, and both are stable. THE CORRECT SCOPING, narrower than what I claimed: the preamble's ambiguity reaches whichever vertical LACKS a body to settle it. Semantic is the only one, and it is where the residue lives - cal-sem-007 and cal-sem-013 flip between Missed and Abstained on exactly this boundary. The remedy is therefore a Semantic body or a deliberate acceptance there, NOT a preamble edit, which is measurably worse. cal-for-006 and cal-for-012 remain the only every-run disagreements. Forgetting at 0.885 is its floor with the two surviving seam controls in it, above the 0.80 per-vertical floor."
+  "note": "Three runs: 0.991 / 0.987 / 0.996. Lowest recorded, per-vertical from that run. Run 3's 0.996 is the highest this set has measured, with cal-for-006 its only disagreement. SEMANTIC GAINED A JUDGE BODY, commissioned by the consuming project after it shipped without one. That was the right call at the time - it measured 0.958 on the shared preamble alone and nothing failed consistently - but it left Semantic as the ONLY vertical with no body to settle the preamble's abstained/missed line, which the preamble states as uncertainty-versus-denial and then illustrates with a denial. cal-sem-007 and cal-sem-013 alternated between Missed and Abstained across runs as a result. Semantic is now 26/26 in ALL THREE RUNS. THE SHARED PREAMBLE WAS NOT TOUCHED, and that is deliberate: editing it was tried, measured, and reverted - it converted the family's canonical genuine-refusal cases to Missed across four verticals and dropped agreement 0.983 to 0.966. Per-vertical is the remedy, and the family rule it confirms is that A VERTICAL BODY SUPERSEDES THE SHARED PREAMBLE. BUILT UNDER REACH ENUMERATION, a requirement the consuming project adopted from our own failure on that preamble edit: controls-first is necessary and not sufficient, because the guard there was built against the failure imagined rather than the surfaces the change could touch. So all 26 Semantic cases were enumerated first and 19 carry a DECLARED ROUTE, not just the four the body targets. The two that matter are cal-sem-005 (lists every value the record has held) and cal-sem-020 (restates a related fact): both LOOK like refusals and both COMMIT, so a body that swept them into abstained would repeat the preamble regression at vertical scale. Both held at 'value'. The route is asserted INDEPENDENTLY of the outcome via question_asks - value | absence | uncertainty - so a template reaching the right label by the wrong reasoning fails rather than passing quietly. No case reached its outcome by the wrong route in any run. cal-for-006 remains the family's only every-run disagreement: an answer replaces a cancelled gym membership with an invented move to a different gym, the judge reads the no-longer as satisfied, the label treats the fabricated replacement as a committed value gold does not carry."
 }

--- a/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
+++ b/tests/AgentEval.Memory.Tests/Data/typedmemeval-judge-calibration.json
@@ -2378,7 +2378,8 @@
     "answer": "Oakhurst Transit.",
     "expected": "Correct",
     "rule": "semantic-current-correct",
-    "note": "The current value, plainly."
+    "note": "The current value, plainly.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-002",
@@ -2400,7 +2401,8 @@
     "answer": "Marlow Carriage.",
     "expected": "Wrong",
     "rule": "semantic-current-superseded-value",
-    "note": "THE CORE FAILURE OF THIS SHAPE. Marlow Carriage was genuinely the courier once, so this is not a fabrication - it is a resolution failure, the chain retrieved but not ordered. Still wrong, because the question asks what it is NOW."
+    "note": "THE CORE FAILURE OF THIS SHAPE. Marlow Carriage was genuinely the courier once, so this is not a fabrication - it is a resolution failure, the chain retrieved but not ordered. Still wrong, because the question asks what it is NOW.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-004",
@@ -2422,7 +2424,8 @@
     "answer": "You have used Pellham Freight, Marlow Carriage and Oakhurst Transit.",
     "expected": "Wrong",
     "rule": "semantic-current-lists-without-resolving",
-    "note": "Retrieval succeeded and resolution did not. Listing every value refuses the discrimination the question asks for. Not an abstention: it commits to a set whose members are mostly superseded. This is the shape's whole point - retrieving is necessary and NOT sufficient."
+    "note": "Retrieval succeeded and resolution did not. Listing every value refuses the discrimination the question asks for. Not an abstention: it commits to a set whose members are mostly superseded. This is the shape's whole point - retrieving is necessary and NOT sufficient.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-006",
@@ -2433,7 +2436,8 @@
     "answer": "I am not sure, but probably Oakhurst Transit.",
     "expected": "Correct",
     "rule": "semantic-current-hedged-states-value",
-    "note": "Precedence rule 1: a stated value outranks hedging, and the value is right."
+    "note": "Precedence rule 1: a stated value outranks hedging, and the value is right.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-007",
@@ -2444,7 +2448,8 @@
     "answer": "I do not have a current courier on file for you.",
     "expected": "Missed",
     "rule": "semantic-current-denies-any-value",
-    "note": "Confidently asserts nothing is there when gold says something is."
+    "note": "Confidently asserts nothing is there when gold says something is.",
+    "question_asks": "absence"
   },
   {
     "id": "cal-sem-008",
@@ -2455,7 +2460,8 @@
     "answer": "I could not say which of them is current.",
     "expected": "Abstained",
     "rule": "semantic-current-declines",
-    "note": "Declines to commit to any value. Distinct from cal-sem-005, which commits to a set."
+    "note": "Declines to commit to any value. Distinct from cal-sem-005, which commits to a set.",
+    "question_asks": "uncertainty"
   },
   {
     "id": "cal-sem-009",
@@ -2477,7 +2483,8 @@
     "answer": "In the spring.",
     "expected": "Correct",
     "rule": "semantic-coref-correct",
-    "note": "The fact, asked under the far designation and answered."
+    "note": "The fact, asked under the far designation and answered.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-011",
@@ -2499,7 +2506,8 @@
     "answer": "In the autumn.",
     "expected": "Wrong",
     "rule": "semantic-coref-wrong-value",
-    "note": "A committed value that does not match gold."
+    "note": "A committed value that does not match gold.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-013",
@@ -2510,7 +2518,8 @@
     "answer": "I have nothing recorded about a new flat.",
     "expected": "Missed",
     "rule": "semantic-coref-denies-entity",
-    "note": "Denies an entity the record holds. The resolution failed and the answer reports absence rather than uncertainty."
+    "note": "Denies an entity the record holds. The resolution failed and the answer reports absence rather than uncertainty.",
+    "question_asks": "absence"
   },
   {
     "id": "cal-sem-014",
@@ -2521,7 +2530,8 @@
     "answer": "I am not sure which place you mean by the new flat.",
     "expected": "Abstained",
     "rule": "semantic-coref-declines-on-designation",
-    "note": "Declines because the designation did not resolve. Uncertainty rather than denial - the line the preamble draws between abstained and missed."
+    "note": "Declines because the designation did not resolve. Uncertainty rather than denial - the line the preamble draws between abstained and missed.",
+    "question_asks": "uncertainty"
   },
   {
     "id": "cal-sem-015",
@@ -2532,7 +2542,8 @@
     "answer": "The boiler at the workshop was replaced last year.",
     "expected": "Wrong",
     "rule": "semantic-coref-resolves-to-wrong-entity",
-    "note": "Resolved the designation to the WRONG entity and answered confidently about it. The characteristic co-reference failure, and it commits to a value."
+    "note": "Resolved the designation to the WRONG entity and answered confidently about it. The characteristic co-reference failure, and it commits to a value.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-016",
@@ -2554,7 +2565,8 @@
     "answer": "In the conversation about the roof repair.",
     "expected": "Correct",
     "rule": "semantic-source-correct",
-    "note": "Names the right conversation."
+    "note": "Names the right conversation.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-018",
@@ -2576,7 +2588,8 @@
     "answer": "In the conversation about the gutter clearing.",
     "expected": "Wrong",
     "rule": "semantic-source-wrong-conversation",
-    "note": "Cites a decoy - a plausible neighbouring topic that did not carry the belief."
+    "note": "Cites a decoy - a plausible neighbouring topic that did not carry the belief.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-020",
@@ -2587,7 +2600,8 @@
     "answer": "You told me the guttering has to be done at the same time.",
     "expected": "Wrong",
     "rule": "semantic-source-restates-belief-cites-nothing",
-    "note": "Restates the belief and cites no conversation. KNOWN-UNSTABLE, and recorded as such rather than tuned away. Pooled across eight runs today the judge split exactly 4-4 between wrong and abstained, so neither label is 'right' and the case cannot discriminate anything. I first labelled it abstained, relabelled it wrong on the strength of one run plus my own reading, and the fuller evidence says that was overconfident in the other direction; the label stays at wrong on the preamble's own wording - it asserts rather than declines - but the honest status is that this sits on the shared preamble's abstained/missed/wrong boundary. That boundary is a FAMILY-WIDE defect parked for its own controlled change: the preamble gives 'I have no record of that' as its ABSTAINED example and 'you never told me about that' as its MISSED example, and they are near-synonyms. cal-for-006, cal-for-012, cal-for-013, cal-wm-012 and cal-sem-007 flap on the same seam across four verticals. Do not read a failure here as evidence about Semantic's construct."
+    "note": "Restates the belief and cites no conversation. KNOWN-UNSTABLE, and recorded as such rather than tuned away. Pooled across eight runs today the judge split exactly 4-4 between wrong and abstained, so neither label is 'right' and the case cannot discriminate anything. I first labelled it abstained, relabelled it wrong on the strength of one run plus my own reading, and the fuller evidence says that was overconfident in the other direction; the label stays at wrong on the preamble's own wording - it asserts rather than declines - but the honest status is that this sits on the shared preamble's abstained/missed/wrong boundary. That boundary is a FAMILY-WIDE defect parked for its own controlled change: the preamble gives 'I have no record of that' as its ABSTAINED example and 'you never told me about that' as its MISSED example, and they are near-synonyms. cal-for-006, cal-for-012, cal-for-013, cal-wm-012 and cal-sem-007 flap on the same seam across four verticals. Do not read a failure here as evidence about Semantic's construct.",
+    "question_asks": "value"
   },
   {
     "id": "cal-sem-021",
@@ -2598,7 +2612,8 @@
     "answer": "You never told me that.",
     "expected": "Missed",
     "rule": "semantic-source-denies-being-told",
-    "note": "Confidently denies a belief the record holds."
+    "note": "Confidently denies a belief the record holds.",
+    "question_asks": "absence"
   },
   {
     "id": "cal-sem-022",
@@ -2609,7 +2624,8 @@
     "answer": "I could not say which conversation that came from.",
     "expected": "Abstained",
     "rule": "semantic-source-declines",
-    "note": "Declines outright. The same outcome as cal-sem-020 by a different route, which is why both are here: one declines openly, the other declines by answering a different question."
+    "note": "Declines outright. The same outcome as cal-sem-020 by a different route, which is why both are here: one declines openly, the other declines by answering a different question.",
+    "question_asks": "uncertainty"
   },
   {
     "id": "cal-sem-023",
@@ -2631,7 +2647,8 @@
     "answer": "The roof repair conversation -- that is where the guttering came up.",
     "expected": "Correct",
     "rule": "semantic-source-correct-with-belief",
-    "note": "Names the right source AND restates the belief. The restatement is extra detail rather than a substitute, so it stays correct - the mirror of cal-sem-020."
+    "note": "Names the right source AND restates the belief. The restatement is extra detail rather than a substitute, so it stays correct - the mirror of cal-sem-020.",
+    "question_asks": "value"
   },
   {
     "id": "cal-cnj-001",
@@ -2928,7 +2945,8 @@
     "answer": "I could not tell you who that is now.",
     "expected": "Abstained",
     "rule": "seam-declines-without-absence-claim",
-    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Declines and asserts nothing about the record. Abstained on any reading."
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Declines and asserts nothing about the record. Abstained on any reading.",
+    "question_asks": "uncertainty"
   },
   {
     "id": "cal-sem-026",
@@ -2939,7 +2957,8 @@
     "answer": "Nothing is recorded for your courier.",
     "expected": "Missed",
     "rule": "seam-nothing-recorded",
-    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Asserts the record is empty when gold says it is not. The sibling of cal-sem-007, which is the case that first exposed this seam by matching the abstained illustration while carrying the missed label."
+    "note": "SEAM CONTROL for the shared preamble's abstained/missed boundary. The preamble states the line as UNCERTAINTY versus DENIAL, then lists 'I have no record of that' as an ABSTAINED example - a phrase that denies the record holds anything, which is what MISSED's own example says. The rule and its illustrations disagree, and six cases across four verticals flap on it. These eight fix the reading in both directions before any preamble edit. Asserts the record is empty when gold says it is not. The sibling of cal-sem-007, which is the case that first exposed this seam by matching the abstained illustration while carrying the missed label.",
+    "question_asks": "absence"
   },
   {
     "id": "cal-wm-025",


### PR DESCRIPTION
Commissioned by the consuming project after Semantic shipped without a body. That was right at the time — it measured **0.958** on the shared preamble alone and no case failed consistently — but it left Semantic as the **only** vertical with nothing to settle the preamble's `abstained`/`missed` line, which states the distinction as *uncertainty versus denial* and then illustrates `abstained` with *"I have no record of that"* — a denial. `cal-sem-007` and `cal-sem-013` alternated across runs as a result.

## Semantic is now 26/26 in all three runs

```
family: 0.991 / 0.987 / 0.996
```

Run 3's **0.996** is the highest this set has measured, with `cal-for-006` its only disagreement.

## The shared preamble is untouched, deliberately

Editing it was **tried, measured and reverted** (#188): it converted the family's canonical `genuine-refusal-abstains` cases to `Missed` across four verticals and dropped agreement 0.983 → 0.966. Per-vertical is the remedy, and this confirms the rule that attempt produced — **a vertical body supersedes the shared preamble.**

## Built under reach enumeration

The consuming project adopted this as a requirement from my own failure on that preamble edit: **controls-first is necessary and not sufficient**, because the guard there was built against the failure I *imagined* rather than the surfaces the change could *touch*.

So all 26 Semantic cases were enumerated before a line of the body was written, and **19 carry a declared route** — not just the four the body targets:

| route | n | meaning |
|---|---|---|
| `absence` | 4 | asserts the record holds nothing → `missed` |
| `uncertainty` | 4 | declines without claiming absence → `abstained` |
| **`value`** | **11** | commits to something → `correct`/`wrong` |

The two that matter are **`cal-sem-005`** (lists every value the record has held) and **`cal-sem-020`** (restates a related fact instead of answering). Both *look* like refusals and both **commit** — a body that swept them into `abstained` would repeat the preamble regression at vertical scale. **Both held at `value`.**

The route is asserted **independently of the outcome** through `question_asks`, so a template that reaches the right label by the wrong reasoning fails rather than passing quietly. **No case reached its outcome by the wrong route in any run.**

1031/1031 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ