### PR TITLE
release: 0.31.0-beta — the Semantic body, the Prospective reshape, and a negative result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Semantic gained a judge body, and it was built under REACH ENUMERATION.** Semantic shipped
+  without one deliberately — it measured 0.958 on the shared preamble alone and nothing failed
+  consistently — but that left it as the **only** vertical with nothing to settle the preamble's
+  `abstained`/`missed` line, which states the distinction as *uncertainty versus denial* and then
+  illustrates `abstained` with *"I have no record of that"* — a denial. `cal-sem-007` and
+  `cal-sem-013` alternated across runs as a result. **Semantic is now 26/26 in all three runs**;
+  family agreement 0.991 / 0.987 / 0.996.
+
+  All 26 Semantic cases were enumerated *before* a line of the body was written, and **19 carry a
+  declared route** rather than only the four the body targets — `absence` (4), `uncertainty` (4),
+  `value` (11). The two that matter are `cal-sem-005` and `cal-sem-020`: both *look* like refusals
+  and both **commit**, so a body sweeping them into `abstained` would have repeated the preamble
+  regression at vertical scale. Both held. The route is asserted independently of the outcome, so a
+  template reaching the right label by the wrong reasoning fails rather than passing quietly.
+
+- **Prospective is reshaped: firing semantics are now required, not optional.** The consuming
+  project ran the corpus with `ProspectiveFiring` **and** `ValidTime=Current` both dark and scored
+  **49/50**. The mechanism was that every shape **named the thing** — which hands a similarity
+  retriever the words of the session it needs, while the harness supplies "today" and the corpus
+  supplies the due date, making the comparison in-context arithmetic no memory feature is needed for.
+
+  The new `due-window` shape names **nothing**: several reminders whose only distinguishing property
+  is *when* each falls due, and an answer that is a **set** whose membership changes with the as-of
+  instant. Result — **the family's first real interference cost, 0.00 → 0.28**, and `due-window`'s V8
+  is **4/18**: the entire haystack in context and fourteen still fail. Headroom 0.32 → 0.54.
+
+  Per-shape calibration, opted in here for the first time, also revealed `not-yet-true` has been
+  **saturated at 1.000** for its whole shipped life, hidden by the vertical mean. Ratcheted.
+
+- **The shared preamble's `abstained`/`missed` seam was investigated and the preamble ships
+  UNCHANGED.** Eight negative controls showed six of eight pass with no edit at all, and the repair
+  that makes the preamble self-consistent turned out to be a **measured regression** — it converted
+  the family's canonical `genuine-refusal-abstains` cases to `Missed` across four verticals and
+  dropped agreement 0.983 → 0.966.
+
+  What holds instead is narrower and was written down nowhere: **a vertical body supersedes the
+  shared preamble**, so the same sentence is correctly `wrong` in Forgetting (over-forgetting) and
+  correctly `missed` in Semantic. The ambiguity reaches only a vertical that *lacks* a body — which
+  is why the remedy was the Semantic body above, not a preamble edit.
+
+  The lesson the consuming project adopted from it: **controls-first is necessary and not
+  sufficient — enumerate what a change can REACH, not only what it targets.** The guard written for
+  that edit was built against the imagined failure; the regression landed on existing cases never
+  enumerated.
+
+## [0.30.0-beta] - 2026-08-29
+
+
+### Fixed
+
 - **A family-wide judge floor is satisfiable by averaging — added a per-vertical one.** Bitemporal
   sat at **0.750** behind a green family **0.946** because six verticals near 0.98 averaged it away,
   and the gate only ever read the mean. This is the same defect the corpus calibration had, where

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
          whose assemblies reported 0.16.0.0 — and `AgentEvalVersion` in result provenance reads
          Assembly.GetName().Version, so every result that release produced was stamped with a
          version that had not been current since 0.16. The consuming project caught it. -->
-    <Version>0.30.0-beta</Version>
+    <Version>0.31.0-beta</Version>
 
     <!-- Package icon for NuGet -->
     <PackageIcon>AgentEvalNugetLogoAE.png</PackageIcon>

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
@@ -774,6 +774,22 @@ public sealed class TypedMemEvalCorpusTests
     private static readonly Dictionary<(TypedMemEvalVertical Vertical, string Shape), double>
         PendingPerShapeRecalibration = new()
         {
+            // WHAT THIS RATCHET ACTUALLY REPRESENTS, measured 2026-08-30 rather than assumed.
+            // Out-of-band COVERAGE is not the same as an unfailable question: coverage measures
+            // what a BM25 budget retrieves, and the reasoning half still discriminates. Checked
+            // shape by shape against V9:
+            //
+            //   temporal/recency                cov 1.000  V9 15/15  <- THE ONLY UNFAILABLE SHAPE
+            //   episodic/list-order             cov 0.275  V9  0/15  <- the opposite extreme
+            //   episodic/participant-attribution cov 0.933 V9 14/15  discriminates
+            //   forgetting/still-valid          cov 0.467  V9  9/15  discriminates
+            //   temporal/occurrence-order       cov 0.950  V9 19/20  discriminates
+            //
+            // So the family carries ONE shape that cannot fail and one that nothing passes, not
+            // the eleven-shape debt an earlier audit of mine reported. Fixing temporal/recency
+            // means regenerating that corpus, invalidating its probe record and resetting the
+            // consuming project's controls on it — worth proposing to them with these numbers,
+            // not worth doing unilaterally while nothing is blocked on it.
             [(TypedMemEvalVertical.Episodic, "list-order")] = 0.2746,
             [(TypedMemEvalVertical.Episodic, "participant-attribution")] = 0.9333,
             [(TypedMemEvalVertical.Forgetting, "still-valid")] = 0.4667,

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalCorpusTests.cs
@@ -720,6 +720,31 @@ public sealed class TypedMemEvalCorpusTests
             // knob that raises it: raising it would mean naming the thing in the question, which is
             // exactly the construction that let the consuming project score 49/50 with firing and
             // valid-time both dark.
+            // WORKINGMEMORY'S EASY RUNGS ARE NOT DEBT, and moving them out of the ratchet is the
+            // point of this entry. They sat there at 1.0000 / 1.0000 / 0.9167 as "known bad, may
+            // only improve" — but the vertical is a declared LADDER. Its own generator says the
+            // result surface reports the outcome-by-distance CURVE rather than one number, because
+            // "an aggregate over a distance ladder is exactly the summary this family exists to
+            // refuse", and its structure spec sets h_is_independent_variable.
+            //
+            // A ladder needs rungs the system PASSES. distance-8 at 12/12 against distance-40 at
+            // 8/12 IS the finding; the band was designed for single-difficulty verticals and does
+            // not apply to a ladder's easy end. Calibrating distance-8 into [0.5, 0.9] would mean
+            // making a fact stated eight sessions ago hard to retrieve, which destroys the baseline
+            // the curve is measured against.
+            //
+            // Declared rather than ratcheted so a future session reads "the band does not apply"
+            // instead of "fix this". I nearly regenerated this corpus on the opposite reading.
+            [(TypedMemEvalVertical.WorkingMemory, "distance-8")] =
+                "Easy rung of a declared distance ladder (h_is_independent_variable). A ladder " +
+                "needs rungs the system passes; calibrating this into band would mean making an " +
+                "eight-session-old fact hard to retrieve and would destroy the curve's baseline.",
+            [(TypedMemEvalVertical.WorkingMemory, "distance-15")] =
+                "Easy rung of a declared distance ladder — see distance-8.",
+            [(TypedMemEvalVertical.WorkingMemory, "distance-25")] =
+                "Middle rung of a declared distance ladder, 0.917 and falling as distance grows " +
+                "(40 -> 8/12, 60 -> 9/12). The descent IS the measurement.",
+
             [(TypedMemEvalVertical.Prospective, "due-window")] =
                 "Names no entity by construction, so BM25 has nothing to match on and coverage " +
                 "cannot be raised without reintroducing the entity - which is the saturation the " +
@@ -765,9 +790,6 @@ public sealed class TypedMemEvalCorpusTests
             [(TypedMemEvalVertical.Prospective, "not-yet-true")] = 1.0000,
             [(TypedMemEvalVertical.Temporal, "occurrence-order")] = 0.9500,
             [(TypedMemEvalVertical.Temporal, "recency")] = 1.0000,
-            [(TypedMemEvalVertical.WorkingMemory, "distance-8")] = 1.0000,
-            [(TypedMemEvalVertical.WorkingMemory, "distance-15")] = 1.0000,
-            [(TypedMemEvalVertical.WorkingMemory, "distance-25")] = 0.9167,
         };
 
     /// <summary>How far a shape's realised coverage sits outside the band; zero when inside.</summary>


### PR DESCRIPTION
Cuts `0.31.0-beta` for #188–#190. **Not tagged** — the consuming project probes `main` *before* the tag under the restored standing arrangement, and the T-0 notice with predictions goes to them first.

## Fixes the same changelog defect twice over

**`0.30.0-beta` was tagged and published with no version heading** — exactly as `0.29.0-beta` had been. I fixed the `0.29` instance one release ago **and then reproduced it**, because the script that split the section created the heading for the *old* version and left the new entries under `[Unreleased]` with nothing to promote them at tag time.

The pattern, not just the instance: **a release cut has to end by naming the version it just shipped, not the one before it.**

## What the cut contains

| | |
|---|---|
| **Semantic judge body** | 26/26 across three runs; built under **reach enumeration** — 19 of 26 cases carry a declared route, not just the 4 targeted |
| **Prospective reshape** | `due-window` gives the family its **first real interference cost, 0.00 → 0.28**; V8 **4/18** with the entire haystack in context |
| **Preamble seam** | documented **negative result** — the preamble ships unchanged, because the repair was a measured regression across four verticals |

Nine verticals, 470 questions. Family judge agreement **0.987**, eight of nine verticals at 1.000. 1031/1031 on net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ