### PR TITLE
release: give 0.31.0-beta its own changelog heading before the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0-beta] - 2026-08-30
+
 ### Fixed
 
 - **Temporal's `recency` shape could not rank anything, and now it is the hardest shape in the


### PR DESCRIPTION
The 0.31.0-beta release content sits under `## [Unreleased]` with **no version heading**. That is the same defect I fixed for `0.29.0-beta` and then reproduced on `0.30.0-beta` — tagging without this makes it three. A released version whose notes are filed under "unreleased" is a version whose notes nobody can find from the tag.

**No content changes.** Everything already under `[Unreleased]` becomes `## [0.31.0-beta] - 2026-08-30`; `[Unreleased]` is left empty for the next cycle. `Directory.Build.props` is already `0.31.0-beta`, so tag and assembly version agree.

## What 0.31.0-beta ships

- Semantic judge body, built under reach enumeration
- Prospective reshape (`due-window`) — the family's first real interference cost, 0.28
- Temporal `recency` fix — V9 15/15 → 6/15, headroom 0.16 → 0.40
- Five zero-model-call instruments
- **Five declared defects that ride WITH the tag**: V2's reject line below the chance floor (69 unearned passes), the chance-corrected arm counts, Forgetting's diluted coverage (0.670 published vs 0.529 measured), two out-of-band shapes, and the 85.7% padding register

## Cleared by the consuming project's pre-tag probe

Read-only against `5d158044`: all nine corpus shas verified (prospective and temporal moved as declared, seven byte-identical), all nine `probes.status=run` with `probed_corpus_sha256 == shipped sha`, judge fingerprint present, and the declared defects verified as present in the changelog itself. Their ruling on all five: **non-blocking**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ