### PR TITLE
Gate the corpus bytes consumers actually download, at both ends of the chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,102 @@ jobs:
         }
         Write-Host "All packed AgentEval assemblies report $expected."
 
+    - name: Verify the packed corpora are the corpora in this repository
+      shell: pwsh
+      run: |
+        # The step above proves the packed assemblies carry the right VERSION. It does not prove they
+        # carry the right CORPUS, and those are different failures: a glob that stops matching, a
+        # stale obj/ artifact surviving an incremental build, or a corpus regenerated after the last
+        # rebuild all ship a correct version number wrapped around the wrong bytes. Until this step
+        # existed, the link between "the sidecar says 31d26e60" and "the bytes a consumer downloads
+        # are 31d26e60" was held by the build being correct, not by anything checking.
+        #
+        # ALL FRAMEWORKS, NOT ONE. The package ships net8.0/net9.0/net10.0, each with its own
+        # AgentEval.Memory.dll and its own embedded copy of every corpus. This repo has a recorded
+        # multi-TFM stale-binary trap, and a per-TFM divergence is that trap wearing a corpus: a
+        # consumer on net8 would probe different bytes than one on net10 while every published sha
+        # names only one of them.
+        $repoCorpora = Join-Path $env:GITHUB_WORKSPACE 'src/AgentEval.Memory/Data/typedmemeval'
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        function Get-NormalisedHash([string] $text) {
+          # Exactly the sidecar convention: CRLF -> LF, UTF-8, SHA256. A check that normalised
+          # differently would measure normalisation rather than content.
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes(($text -replace "`r`n", "`n"))
+          return ((($sha.ComputeHash($bytes)) | ForEach-Object { $_.ToString('x2') }) -join '')
+        }
+
+        $expectedCorpora = @{}
+        foreach ($f in Get-ChildItem $repoCorpora -Recurse -Filter '*.json') {
+          if ($f.Name -like '*.meta.json') { continue }
+          $expectedCorpora[$f.Name] = Get-NormalisedHash ([System.IO.File]::ReadAllText($f.FullName))
+        }
+        if ($expectedCorpora.Count -eq 0) {
+          Write-Host "::error::No corpora found under $repoCorpora. Refusing to pass a check with nothing in it."
+          exit 1
+        }
+        Write-Host "Reference corpora in the working tree: $($expectedCorpora.Count)"
+
+        $failures = @()
+        $mvids = @()
+        $assertions = 0
+        foreach ($pkg in Get-ChildItem ./nupkgs/*.nupkg) {
+          $dir = Join-Path $env:RUNNER_TEMP ("c_" + $pkg.BaseName)
+          Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+          [IO.Compression.ZipFile]::ExtractToDirectory($pkg.FullName, $dir)
+          foreach ($dll in Get-ChildItem $dir -Recurse -Filter 'AgentEval.Memory.dll') {
+            $tfm = Split-Path -Leaf (Split-Path -Parent $dll.FullName)
+            $label = "$($pkg.Name)/$tfm"
+            $asm = [Reflection.Assembly]::Load([IO.File]::ReadAllBytes($dll.FullName))
+            # The MVID is unique per compilation. Collecting them lets the step PROVE it opened a
+            # different assembly each time instead of trusting the loader not to hand back a cached
+            # one -- a gate that verified a single framework three times would pass while two were
+            # never read.
+            $mvids += $asm.ManifestModule.ModuleVersionId
+            $seen = @{}
+            foreach ($res in $asm.GetManifestResourceNames()) {
+              if ($res -notmatch 'typedmemeval' -or $res -like '*.meta.json') { continue }
+              $name = ($res -replace '^.*?([^.]+-v[0-9]+)\.json$', '$1') + '.json'
+              $stream = $asm.GetManifestResourceStream($res)
+              $ms = New-Object IO.MemoryStream
+              $stream.CopyTo($ms)
+              $actual = Get-NormalisedHash ([Text.Encoding]::UTF8.GetString($ms.ToArray()))
+              if (-not $expectedCorpora.ContainsKey($name)) {
+                $failures += "$label : embedded '$name' has no counterpart in the repository"
+                continue
+              }
+              $seen[$name] = $true
+              $assertions++
+              if ($actual -ne $expectedCorpora[$name]) {
+                $failures += "$label/$name : packed $($actual.Substring(0,16)) != repo $($expectedCorpora[$name].Substring(0,16))"
+              }
+            }
+            # A framework that embedded nothing must fail loudly rather than contribute zero
+            # comparisons and leave the totals looking healthy.
+            foreach ($missing in ($expectedCorpora.Keys | Where-Object { -not $seen.ContainsKey($_) })) {
+              $failures += "$label : '$missing' is MISSING from the packed assembly"
+            }
+          }
+        }
+
+        if ($mvids.Count -eq 0) {
+          Write-Host "::error::No AgentEval.Memory.dll found in any package. Nothing was verified."
+          exit 1
+        }
+        $distinct = ($mvids | Select-Object -Unique).Count
+        if ($distinct -ne $mvids.Count) {
+          Write-Host "::error::Read $($mvids.Count) assemblies but only $distinct distinct MVIDs -- the same assembly was verified more than once and some framework was never opened."
+          exit 1
+        }
+
+        Write-Host "Frameworks verified: $($mvids.Count) (all distinct assemblies)"
+        Write-Host "Corpus assertions:   $assertions"
+        if ($failures) {
+          Write-Host "::error::Packed corpora do not match the repository. Nothing was pushed."
+          $failures | Select-Object -Unique | ForEach-Object { Write-Host "  $_" }
+          exit 1
+        }
+        Write-Host "All packed corpora are byte-identical to the repository."
+
     - name: Push to NuGet
       run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalPackagedCorpusTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalPackagedCorpusTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Linq;
+using AgentEval.Memory.External.TypedMemEval;
+using Xunit;
+
+namespace AgentEval.Memory.Tests;
+
+/// <summary>
+/// Asserts that the corpus bytes COMPILED INTO the assembly are the corpus bytes in the repository.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This closes a seam that every other check steps over. <c>Metadata_DescribesTheCorpusItShipsWith</c>
+/// compares <see cref="TypedMemEvalCorpus.Sha256"/> against the sidecar's <c>corpus_sha256</c> — and
+/// BOTH of those are read out of the same assembly's embedded resources. An assembly that embedded a
+/// stale corpus together with its matching stale sidecar agrees with itself and passes. Until this
+/// file existed, no test in the suite read a corpus from disk at all, so nothing anywhere compared
+/// what ships against what is committed.
+/// </para>
+/// <para>
+/// That is the gate self-examination rule in its plainest form: the artifact under test was supplying
+/// both sides of its own comparison. The repository file is the one input to this decision that the
+/// build cannot influence, which is exactly why the assertion is written against it.
+/// </para>
+/// <para>
+/// What it catches: a glob that stops matching, a moved or renamed data file, a stale obj/ artifact
+/// surviving an incremental build, a regenerated corpus that never made it into a rebuild. Every one
+/// of those ships silently today and every sha we publish still reads as correct, because every sha
+/// we publish is computed from the same stale bytes.
+/// </para>
+/// <para>
+/// The packaging half of the chain — that the pushed .nupkg carries these bytes for EVERY target
+/// framework — is verified in the release workflow before the push, because only there does the
+/// artifact a consumer downloads exist. See "Verify the packed corpora" in release.yml.
+/// </para>
+/// </remarks>
+public class TypedMemEvalPackagedCorpusTests
+{
+    public static TheoryData<TypedMemEvalVertical> AllVerticals()
+    {
+        var data = new TheoryData<TypedMemEvalVertical>();
+        foreach (var vertical in Enum.GetValues<TypedMemEvalVertical>())
+        {
+            data.Add(vertical);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void EmbeddedCorpus_IsTheCorpusCommittedToTheRepository(TypedMemEvalVertical vertical)
+    {
+        var corpusId = TypedMemEvalVerticals.For(vertical).CorpusId;
+        var onDisk = ReadRepositoryFile($"{corpusId}.json");
+
+        // Same normalisation the shipped hash uses, deliberately reusing the production helper: a
+        // check that normalised differently would measure normalisation rather than content.
+        Assert.Equal(
+            TypedMemEvalCorpus.ComputeSha256(onDisk),            // DevSkim: ignore DS197836
+            TypedMemEvalCorpus.Sha256(vertical));                // DevSkim: ignore DS197836
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void EmbeddedSidecar_IsTheSidecarCommittedToTheRepository(TypedMemEvalVertical vertical)
+    {
+        // The sidecar carries the probe records consumers read — arm pass counts, coverage, the
+        // reference deployment. A stale one ships numbers describing a corpus nobody has, and it is
+        // deliberately outside the corpus hash, so nothing else would notice.
+        var corpusId = TypedMemEvalVerticals.For(vertical).CorpusId;
+        var onDisk = ReadRepositoryFile($"{corpusId}.meta.json");
+
+        Assert.Equal(
+            TypedMemEvalCorpus.ComputeSha256(onDisk),            // DevSkim: ignore DS197836
+            TypedMemEvalCorpus.ComputeSha256(                    // DevSkim: ignore DS197836
+                TypedMemEvalCorpus.ReadMetadataJson(vertical)));
+    }
+
+    /// <summary>Reads a data file from the working tree, located by file name rather than by folder.</summary>
+    /// <remarks>
+    /// Searching for the name instead of rebuilding <c>Data/typedmemeval/{vertical}/…</c> keeps the
+    /// folder convention written down in exactly one place — the csproj glob. A test that restated it
+    /// would keep passing after a reorganisation that the glob had already stopped matching.
+    /// </remarks>
+    private static string ReadRepositoryFile(string fileName)
+    {
+        var root = LocateRepositoryRoot();
+        var data = Path.Combine(root, "src", "AgentEval.Memory", "Data", "typedmemeval");
+        Assert.True(Directory.Exists(data), $"TypedMemEval data directory not found at {data}.");
+
+        var matches = Directory.GetFiles(data, fileName, SearchOption.AllDirectories);
+        Assert.True(
+            matches.Length == 1,
+            $"Expected exactly one '{fileName}' under {data}, found {matches.Length}: "
+            + string.Join(", ", matches.Select(Path.GetFileName)));
+
+        return File.ReadAllText(matches[0]);
+    }
+
+    private static string LocateRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null
+               && !File.Exists(Path.Combine(directory.FullName, "AgentEval.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("AgentEval.sln not located above the test binary.");
+    }
+}


### PR DESCRIPTION
Nothing verified that a published package carries the corpora this repository holds. CI checked corpus shas in the **repo**; `release.yml` checked that packed assemblies carry the right **version**. Neither checked **content** — so the link between *"the sidecar says `31d26e60`"* and *"the bytes a consumer downloads are `31d26e60`"* was held together by the build being correct rather than by anything checking.

It **was** correct — verified by hand twice, by us and independently by the consuming project. That is exactly why it needed a gate: verified-correct-twice is not a gate.

## The existing check was self-referential

`Metadata_DescribesTheCorpusItShipsWith` compares `TypedMemEvalCorpus.Sha256()` against the sidecar's `corpus_sha256` — and **both are read from the same assembly's embedded resources**. An assembly embedding a stale corpus together with its matching stale sidecar agrees with itself and passes.

No test in the suite read a corpus from disk at all, so nothing anywhere compared what ships against what is committed. The artifact under test was supplying both sides of its own comparison.

## Two layers, because the chain has two links that fail differently

**1. `TypedMemEvalPackagedCorpusTests` — every PR.** The embedded corpus and sidecar must equal the files on disk. Files are located by **name**, not by rebuilding the `Data/typedmemeval/{vertical}/…` convention, so a reorganisation the csproj glob had already stopped matching cannot be restated as correct by the test. Catches a dead glob, a moved file, a stale `obj/` artifact, a corpus regenerated after the last build.

**2. `release.yml` → "Verify the packed corpora" — before the push.** Extracts each `.nupkg` and checks **all nine corpora in every framework: 27 assertions, not 9.** This repo has a recorded multi-TFM stale-binary trap, and a per-TFM divergence is that trap wearing a corpus — a consumer on net8 would probe different bytes than one on net10 while every published sha names only one of them.

## Independence is asserted, not assumed

Loading three assemblies that share an identity into one process and trusting the runtime to keep them distinct is how a gate becomes a rubber stamp: if the loader returned the first assembly three times, the step would "verify" one framework thrice and pass while two were never opened.

The step collects each assembly's **MVID** (unique per compilation) and fails if the distinct count is below the number of assemblies read. Measured: **3 of 3 distinct**. A framework embedding *nothing* also fails loudly rather than contributing zero comparisons and leaving the totals looking healthy.

Hashing reuses the production helper and the sidecar convention exactly (CRLF→LF, UTF-8, SHA256) — a check that normalised differently would measure normalisation rather than content.

## Red-first, both layers

A gate that has never failed has never been tested.

| layer | sabotage | result |
|---|---|---|
| 1 | one byte changed in the temporal corpus, run **without rebuilding** — the real stale-binary case | exactly 1 failure (Temporal), other 17 pass; restored → 18/18 |
| 2 | 0.31 package checked against **v0.30.0-beta** corpora — a real historical divergence, not a synthetic tamper | exactly **6** failures: prospective + temporal × 3 frameworks; other 21 pass |

Layer 2's red is the better fixture: it uses two corpora that genuinely moved this release, so it exercises the comparison against real divergent bytes.

## Green against the real published artifact

Pulled `agenteval/0.31.0-beta` from `api.nuget.org` and ran the gate logic against it: **9 corpora × 3 frameworks = 27 assertions, 0 mismatches, 3 distinct MVIDs.**

Suite: **1049/1049** on net10.0 (was 1031; +18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ