### PR TITLE
V2 ships the caveat that makes its number readable; the threshold is deliberately unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **V2 now ships the caveat that makes its own number readable — and the threshold was deliberately
+  NOT "fixed".** The arm asks each question with no haystack and rejects at 2 hits in 10. On an
+  **open** question chance is ~0, so any hit is signal and the arm does exactly what it claims. On a
+  **closed-choice** question the model can pick from the candidates the question itself names, so it
+  reaches gold at `1/k` without evidence — and the reject line of 0.20 sits **below that floor**
+  (0.50 at k=2, 0.33 at k=3). **71 questions** are in that position: temporal 35, prospective 21,
+  episodic 15.
+
+  Measured across **7,540 cached V2 answers, 97.9% are explicit declines** — *"I have no way of
+  knowing"* — under a prompt that ends *"If you have no way of knowing, say so plainly."* So a pass
+  records that the model **did not volunteer an answer**, which is real and useful, and is not the
+  guessability question.
+
+  **The obvious repair was tested and rejected on evidence.** Raising the bar to the statistically
+  correct value — 9-of-10 at k=2, 7-of-10 at k=3 — keeps `tme-tem-013` (10/10) and **misses
+  `tme-tem-046`** (5/10), a question we know was leaking: the model was reasoning from real-world
+  knowledge about Yarrow Shipbuilders and landing right about half the time. Its 5 hits are
+  statistically indistinguishable from guessing (p=0.213) and were not guessing. **Calibrating the
+  bar would trade a real detection for a tidier statistic** — the naive threshold is *more*
+  sensitive precisely because the model declines, so against a decliner any hit means it
+  volunteered.
+
+  So the number stays and **the claim narrows**. Every sidecar now carries a `closed_choice` block
+  with the per-question candidate count and how many passes are **not evidence of
+  non-inferability**. Compare with V3, where the identical arithmetic produced the *opposite*
+  disposition: there the budget was 3 samples, no threshold could clear the floor, and *not
+  decidable* was the honest verdict. Same rule, different budgets, different answers — which is why
+  it had to be derived per arm rather than applied as a policy.
+
+  **No corpus sha moves, no verdict changes, zero model calls** — the hit counts were already
+  recorded, because V2 never short-circuited.
+
 - **V3's leak threshold is now read against the chance floor, and 24 of its passes were never
   earned.** The arm draws 3 ablation samples and condemned a question on a **single** hit. On a
   closed-choice question that is not a measurement: the question hands the model its candidates, so

--- a/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
@@ -869,7 +869,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:47Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -889,7 +889,14 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 50,

--- a/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
@@ -739,7 +739,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:48Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 60,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -763,7 +763,14 @@
       "temperature": "provider default",
       "applicable": 60,
       "passed": 60,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 60,

--- a/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
@@ -897,7 +897,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:32:38Z",
+    "run_at": "2026-08-30T14:44:28Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -917,7 +917,14 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 50,

--- a/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
@@ -770,7 +770,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:47Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -790,7 +790,16 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 15,
+        "by_candidates": {
+          "2": 15
+        },
+        "chance_floor_exceeds_reject_line": true,
+        "passes_not_evidence_of_non_inferability": 15,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 35,
@@ -1395,6 +1404,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1407,6 +1417,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1419,6 +1430,7 @@
         "v9_answer": "You said the prompt about the print shop, but **I** was the one who said: “it wants files flattened before upload.”",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1431,6 +1443,7 @@
         "v9_answer": "That was you.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1443,6 +1456,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1455,6 +1469,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1467,6 +1482,7 @@
         "v9_answer": "It was me — the assistant said: “Worth remembering about the canal gate: it gets locked from the far side.”",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1479,6 +1495,7 @@
         "v9_answer": "That was me — the assistant said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1491,6 +1508,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1503,6 +1521,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1515,6 +1534,7 @@
         "v9_answer": "That was me. I said: “One thing about the Marrow Lane depot, it only takes card after six.”",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1527,6 +1547,7 @@
         "v9_answer": "You said the topic came up, but **I** was the one who said: “the wheelie bin round … skips the first week of every month.”",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1539,6 +1560,7 @@
         "v9_answer": "You said it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1551,6 +1573,7 @@
         "v9_answer": "You said it — in Session 5, your message included: “hall, input, side, faster, us, wakes.”",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1563,6 +1586,7 @@
         "v9_answer": "That was me — the assistant said: “The thing with the bulk-buy account is that it needs two signatures before anything changes.”",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null

--- a/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
@@ -706,7 +706,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:48Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -733,7 +733,14 @@
       "temperature": "provider default",
       "applicable": 35,
       "passed": 35,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 35,

--- a/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
@@ -729,7 +729,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:47Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -749,7 +749,16 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 21,
+        "by_candidates": {
+          "2": 21
+        },
+        "chance_floor_exceeds_reject_line": true,
+        "passes_not_evidence_of_non_inferability": 21,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 29,
@@ -1011,6 +1020,7 @@
         "v9_answer": "No. You started the 30-day Lumen trial on 2026/04/28, so it would have ended around 2026/05/28. Today is 2026/06/03.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1023,6 +1033,7 @@
         "v9_answer": "Yes. You said on 2026/02/16 that you start at Halcyon Systems on the first Monday of the next month, which was 2026/03/02. Current date is 2026/04/20, so you should have started already.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1050,6 +1061,7 @@
         "v9_answer": "I don’t have enough information from those conversations to tell whether your car service is due yet. They mention “service, car, yet” being on someone’s mind, but no actual due date is given.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1062,6 +1074,7 @@
         "v9_answer": "No. You said Meridian Health starts on the first Monday of next month, which is June 1, 2026. Today is May 27, 2026.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1074,6 +1087,7 @@
         "v9_answer": "No. The visa application went in on 2026/04/14, and they said to allow eight weeks for a decision. As of 2026/05/26, it has been six weeks, so you would not necessarily expect to have heard back yet. Eight weeks would be around 2026/06/09.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1086,6 +1100,7 @@
         "v9_answer": "No. The flat inspection was booked for a fortnight from 2026/03/06, i.e. around 2026/03/20, so by 2026/04/02 it has already passed.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1098,6 +1113,7 @@
         "v9_answer": "No. You joined the rowing club on 2026/02/24, and the members’ rate only kicks in after six months, so it would be available around 2026/08/24.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1110,6 +1126,7 @@
         "v9_answer": "No. The allotment lease renewal reminder has not come due yet.\n\nIt is due on **2026/05/30 (Sat)**.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1122,6 +1139,7 @@
         "v9_answer": "Yes. The allotment lease renewal reminder was due on **2026/05/30 (Sat)**, so it has already come due.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1134,6 +1152,7 @@
         "v9_answer": "The earlier conversations mention “booking, boiler, service, due,” but they do not give a due date for it.\n\nSo I can’t tell from the record whether it has come due yet, or what date it is/was due.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1146,6 +1165,7 @@
         "v9_answer": "The conversations mention a reminder/concern: “booking, boiler, service, due,” but they never give a due date for it.\n\nSo I can’t tell whether it has come due yet, or what date it is/was due.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1158,6 +1178,7 @@
         "v9_answer": "No. It has not come due yet.\n\nThe reminder to send the quarterly figures to Priya was set on 2026/04/17 for seven weeks later, so it is due on 2026/06/05.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1170,6 +1191,7 @@
         "v9_answer": "Yes. The reminder about sending the quarterly figures to Priya was due on **2026/06/05 (Fri)**, so it has already come due.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1182,6 +1204,7 @@
         "v9_answer": "The conversations mention “bike, come, reminder, chain” repeatedly, but they do **not** state any due date for a bike-chain reminder.\n\nSo I can’t tell whether it has come due yet, or what date it is/was due, from the record provided.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1194,6 +1217,7 @@
         "v9_answer": "The conversations mention “bike, come, reminder, chain,” but they do **not** state any due date for a bike-chain reminder.\n\nSo I can’t tell whether it has come due yet, and no due date is available from the record.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1206,6 +1230,7 @@
         "v9_answer": "Yes. The climbing-wall pass is still valid on 2026/07/25.\n\nIt was picked up on 2026/03/27 and was valid for eighteen weeks, so it runs out on 2026/07/31.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1218,6 +1243,7 @@
         "v9_answer": "No. The climbing-wall pass is no longer valid. It was picked up on 2026/03/27 and was valid for 18 weeks, so it ran out on 2026/07/31.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1230,6 +1256,7 @@
         "v9_answer": "Yes. The ferry multi-trip ticket is still valid on 2026/06/08.\n\nIt was picked up on 2026/03/22 and was valid for twelve weeks, so it runs out on 2026/06/14.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1242,6 +1269,7 @@
         "v9_answer": "No. The ferry multi-trip ticket is no longer valid.\n\nIt was bought on **2026/03/22** and was valid for **twelve weeks**, so it ran out on **2026/06/14**.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1254,6 +1282,7 @@
         "v9_answer": "The conversations do not say when the museum membership runs or ran out. They only contain the repeated note “out, museum, membership, valid,” so I can’t determine whether it is still valid on 2026/06/01.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1266,6 +1295,7 @@
         "v9_answer": "The conversations only mention: “out, museum, membership, valid.”\n\nThey do not say when the museum membership runs out, or whether it is still valid on 2026/06/13.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null

--- a/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
@@ -764,7 +764,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:32:27Z",
+    "run_at": "2026-08-30T14:44:28Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -784,7 +784,14 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 50,

--- a/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
@@ -805,7 +805,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:31:59Z",
+    "run_at": "2026-08-30T14:44:28Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -825,7 +825,17 @@
       "temperature": "provider default",
       "applicable": 50,
       "passed": 50,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 35,
+        "by_candidates": {
+          "2": 20,
+          "3": 15
+        },
+        "chance_floor_exceeds_reject_line": true,
+        "passes_not_evidence_of_non_inferability": 35,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 30,
@@ -987,6 +997,7 @@
         "v9_answer": "The Quorlory rewiring came first; the Vreskade survey happened after it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -999,6 +1010,7 @@
         "v9_answer": "The Traymoor fit-out came first, before the Plennell move.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1011,6 +1023,7 @@
         "v9_answer": "The Zethisk handover came first; the Ondrey audit came after it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1023,6 +1036,7 @@
         "v9_answer": "The Traymoor fit-out came first — it was done well ahead of the Wrenfield sign-off.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1035,6 +1049,7 @@
         "v9_answer": "The Janduisk commissioning came first.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1047,6 +1062,7 @@
         "v9_answer": "The Ovridory retrofit came first, before the Traymoor fit-out.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1059,6 +1075,7 @@
         "v9_answer": "The Draimune inspection came first.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1071,6 +1088,7 @@
         "v9_answer": "The Janduisk commissioning came first, followed by the Plennell move.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1083,6 +1101,7 @@
         "v9_answer": "The Draimune inspection came first.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1095,6 +1114,7 @@
         "v9_answer": "The Janduisk commissioning came first, before the Ovridory retrofit.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1107,6 +1127,7 @@
         "v9_answer": "The Zethisk handover came first, then the Draimune inspection.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1119,6 +1140,7 @@
         "v9_answer": "The Vreskade survey came first. The Janduisk commissioning came after it.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1131,6 +1153,7 @@
         "v9_answer": "The Skarvarn relining came first.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1143,6 +1166,7 @@
         "v9_answer": "The Draimune inspection came first, before the Zethisk handover.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1155,6 +1179,7 @@
         "v9_answer": "The Ondrey audit came first, well ahead of the Ovridory retrofit.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1167,6 +1192,7 @@
         "v9_answer": "The Trevuade changeover came first; the Skarvarn relining happened after it was out of the way.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1179,6 +1205,7 @@
         "v9_answer": "The Wrenfield sign-off came first.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1191,6 +1218,7 @@
         "v9_answer": "The Skarvarn relining came first.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1203,6 +1231,7 @@
         "v9_answer": "The Wrenfield sign-off came first, well ahead of the Plennell move.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1215,6 +1244,7 @@
         "v9_answer": "The Ovridory retrofit came first; the Plennell move came later.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 2,
         "v2": true,
         "v3": null,
         "v6": null
@@ -1452,6 +1482,7 @@
         "v9_answer": "The Plennell move happened most recently.",
         "v9_gold_in_context": 3,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1468,6 +1499,7 @@
         "v9_answer": "The **Ovridory retrofit** happened most recently.",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 1,
         "v3_required_hits": 3,
@@ -1484,6 +1516,7 @@
         "v9_answer": "The Plennell move happened most recently.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1500,6 +1533,7 @@
         "v9_answer": "The Quorlory rewiring happened most recently.",
         "v9_gold_in_context": 0,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1516,6 +1550,7 @@
         "v9_answer": "The Vreskade survey happened most recently.",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 1,
         "v3_required_hits": 3,
@@ -1532,6 +1567,7 @@
         "v9_answer": "The conversations do not plainly say which of the Janduisk commissioning, the Zethisk handover, and the Plennell move happened most recently.",
         "v9_gold_in_context": 1,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1548,6 +1584,7 @@
         "v9_answer": "The Ondrey audit happened most recently.",
         "v9_gold_in_context": 3,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1564,6 +1601,7 @@
         "v9_answer": "The Trevuade changeover happened most recently.",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 1,
         "v3_required_hits": 3,
@@ -1580,6 +1618,7 @@
         "v9_answer": "The conversations don’t contain enough information to say.\n\nThey do establish:\n\n- Vreskade survey happened before the Quorlory rewiring.\n- Quorlory rewiring happened before the Plennell move.\n\nSo the Plennell move was later than the Vreskade survey.\n\nBut they do not place the Zethisk handover relati",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1596,6 +1635,7 @@
         "v9_answer": "The Plennell move happened most recently.",
         "v9_gold_in_context": 3,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 1,
         "v3_required_hits": 3,
@@ -1612,6 +1652,7 @@
         "v9_answer": "The Trevuade changeover happened most recently.",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1628,6 +1669,7 @@
         "v9_answer": "The conversations do not determine that plainly.\n\nThey do say:\n\n- The Plennell move happened after the Vreskade survey.\n- The Vreskade survey happened after the Draimune inspection.\n\nSo the Plennell move was more recent than the Draimune inspection. But there is no stated ordering between the Traymo",
         "v9_gold_in_context": 3,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1644,6 +1686,7 @@
         "v9_answer": "The conversations do not say enough to determine that.\n\nThey establish that the Trevuade changeover happened before the Ondrey audit, but they do not place the Skarvarn relining relative to either of those.",
         "v9_gold_in_context": 2,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1660,6 +1703,7 @@
         "v9_answer": "The conversations establish that:\n\n- Skarvarn relining happened before Janduisk commissioning.\n- Trevuade changeover happened after Janduisk commissioning.\n\nSo Trevuade changeover happened after Skarvarn relining.\n\nBut there is no timing information given for the Zethisk handover relative to either ",
         "v9_gold_in_context": 2,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,
@@ -1676,6 +1720,7 @@
         "v9_answer": "The conversations don’t contain enough information to determine that.\n\nThey do say the **Quorlory rewiring** happened after the **Zethisk handover**. But they don’t give any timing for the **Plennell move**, so we can’t say which of the three happened most recently.",
         "v9_gold_in_context": 4,
         "v2_hits": 0,
+        "v2_candidates": 3,
         "v2": true,
         "v3_hits": 0,
         "v3_required_hits": 3,

--- a/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
@@ -744,7 +744,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T12:30:47Z",
+    "run_at": "2026-08-30T14:44:27Z",
     "questions_probed": 60,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -764,7 +764,14 @@
       "temperature": "provider default",
       "applicable": 60,
       "passed": 60,
-      "failed": []
+      "failed": [],
+      "closed_choice": {
+        "questions": 0,
+        "by_candidates": {},
+        "chance_floor_exceeds_reject_line": false,
+        "passes_not_evidence_of_non_inferability": 0,
+        "reading": "These questions name their own candidates, so a no-evidence model reaches gold at 1/k -- above the 2-in-10 reject line. A PASS here records that the model did not volunteer the answer, not that the question is non-inferable. The threshold is deliberately NOT chance-corrected: the correct bar would have missed a known leak whose hits were statistically indistinguishable from guessing. Read alongside tools/validate_v2_chance_floor.py."
+      }
     },
     "v3_gold_ablated": {
       "applicable": 60,

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -574,6 +574,52 @@ def closed_choice_k(question: str) -> int | None:
     return None
 
 
+def _v2_closed_choice_disclosure(records: list[dict]) -> dict:
+    """What V2's verdict does and does not establish on questions that name their own candidates.
+
+    THE ARM IS SOUND AND ITS CLAIM IS TOO BROAD. V2 asks the model each question with no haystack
+    and counts how often it lands gold. On an OPEN question chance is ~0, so any hit is signal and
+    the arm does exactly what it says. On a CLOSED-CHOICE question the model can pick from the
+    candidates the question itself names, so it reaches gold at 1/k without evidence -- and the
+    reject line of 2-in-10 sits BELOW that floor (0.50 at k=2, 0.33 at k=3).
+
+    So a pass here is not evidence of non-inferability. Measured across 7540 cached V2 answers,
+    97.9% are explicit declines -- "I have no way of knowing" -- under a prompt that ends "If you
+    have no way of knowing, say so plainly." The arm is recording that the model DID NOT VOLUNTEER
+    AN ANSWER, which is a real and useful property (it is what caught a milestone name colliding
+    with Yarrow Shipbuilders), but it is not the guessability question.
+
+    THE THRESHOLD WAS NOT MADE CHANCE-AWARE, AND THAT IS DELIBERATE. Raising the bar to the
+    statistically correct value (9-of-10 at k=2, 7-of-10 at k=3) was tested against the leaks
+    actually on record: it keeps tme-tem-013 at 10/10 and MISSES tme-tem-046 at 5/10, whose 5 hits
+    are consistent with guessing (p=0.213) but were not guessing -- the model was reasoning from
+    real-world knowledge and landing right about half the time. Calibrating the bar would trade a
+    real detection for a tidier statistic. The naive threshold is more sensitive precisely BECAUSE
+    the model declines: against a decliner, any hit at all means it volunteered.
+
+    So the number stays and the CLAIM narrows, which is what this block records. Compare with V3,
+    where the same arithmetic produced the opposite disposition -- there the sample budget was 3,
+    no threshold could clear the floor, and "not decidable" was the honest verdict.
+    """
+    closed = [r for r in records
+              if r.get("v2") is not None and r.get("v2_candidates") is not None]
+    passes = [r for r in closed if r.get("v2") is True]
+    return {
+        "questions": len(closed),
+        "by_candidates": {str(k): sum(1 for r in closed if r["v2_candidates"] == k)
+                          for k in sorted({r["v2_candidates"] for r in closed})},
+        "chance_floor_exceeds_reject_line": bool(closed),
+        "passes_not_evidence_of_non_inferability": len(passes),
+        "reading": (
+            "These questions name their own candidates, so a no-evidence model reaches gold at "
+            "1/k -- above the 2-in-10 reject line. A PASS here records that the model did not "
+            "volunteer the answer, not that the question is non-inferable. The threshold is "
+            "deliberately NOT chance-corrected: the correct bar would have missed a known leak "
+            "whose hits were statistically indistinguishable from guessing. Read alongside "
+            "tools/validate_v2_chance_floor.py."),
+    }
+
+
 def _v3_decidable(gold: str, already_known: str) -> bool:
     """Whether an ablation probe can tell "reached the answer" from "said nothing" for this gold.
 
@@ -738,6 +784,11 @@ def probe_question(entry: dict, vertical: str) -> dict:
                          already_known=f"{question} {date}"):
                 hits += 1
         record["v2_hits"] = hits
+        # WHAT A V2 VERDICT IS WORTH depends on whether the question hands the model its
+        # candidates, so the reader gets k rather than having to infer it from the wording.
+        v2_k = closed_choice_k(question)
+        if v2_k is not None:
+            record["v2_candidates"] = v2_k
         # Silence is only disqualifying where it could CHANGE the verdict. V2 draws ten samples and
         # fails on V2_REJECT_AT hits, so a silent draw matters only if the hits already seen plus
         # the silent ones could have reached that threshold; below it the verdict stands on the
@@ -1005,6 +1056,7 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
             "reject_at_hits": V2_REJECT_AT,
             "temperature": "provider default",
             **tally("v2"),
+            "closed_choice": _v2_closed_choice_disclosure(records),
         },
         "v3_gold_ablated": {
             **tally("v3"),


### PR DESCRIPTION
V2 rejects at 2 hits in 10. On an **open** question chance is ~0, so any hit is signal and the arm does exactly what it claims. On a **closed-choice** question the model picks from candidates the question itself names, reaching gold at `1/k` without evidence — and the reject line of 0.20 sits **below that floor** (0.50 at k=2, 0.33 at k=3).

**71 questions** are in that position: temporal 35, prospective 21, episodic 15.

Across **7,540 cached V2 answers, 97.9% are explicit declines** — *"I have no way of knowing"* — under a prompt that ends *"If you have no way of knowing, say so plainly."* A pass records that the model **did not volunteer an answer**. Real and useful; not the guessability question.

## The obvious repair was tested and rejected on evidence

Raising the bar to the statistically correct value:

| question | hits | k | new bar | outcome |
|---|---|---|---|---|
| `tme-tem-013` | 10/10 | 2 | 9 | **kept** |
| `tme-tem-046` | 5/10 | 3 | 7 | **MISSED** |

`tme-tem-046` is a question we *know* was leaking — the model reasoned from real-world knowledge about Yarrow Shipbuilders and landed right about half the time. Its 5 hits are statistically indistinguishable from guessing (**p=0.213**) and were not guessing.

**Calibrating the bar would trade a real detection for a tidier statistic.** The naive threshold is *more* sensitive precisely because the model declines: against a decliner, any hit at all means it volunteered.

So the number stays and **the claim narrows**. Every sidecar now carries a `closed_choice` block with the per-question candidate count and how many passes are not evidence of non-inferability.

## Same arithmetic, opposite disposition to V3

In V3 the budget was 3 samples, no threshold could clear the floor, and *not decidable* was the honest verdict. Here the budget is 10, a threshold exists, and taking it would lose a real detection. **Same rule, different budgets, different answers** — which is why it had to be derived per arm rather than applied as a policy.

**No corpus sha moves, no verdict changes, zero model calls** — the hit counts were already recorded, because V2 never short-circuited.

Protocol: `--self-test` → two-question real run → full family. Suite **1052/1052**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ