### PR TITLE
The judge's default budget could void it on the deployment its claim was measured on

### DIFF
--- a/.github/workflows/llm-integration-tests.yml
+++ b/.github/workflows/llm-integration-tests.yml
@@ -16,11 +16,22 @@ on:
         default: 'Category=Integration'
         type: string
       model:
-        description: 'Model to use for testing'
+        # THE DEFAULT IS THE CALIBRATED DEPLOYMENT, and that is the whole point of it. The judge's
+        # shipped validity claim -- agreement 0.987 over 230 cases, prompt fingerprint
+        # b1d3f721... -- was measured on gpt-5.5. A gate exercising a different model certifies
+        # nothing about that claim: its green is decoration, and a regression on the deployment the
+        # number describes would not turn it red.
+        #
+        # The schedule is weekly rather than daily for cost. If it ever needs to be cheaper, run the
+        # calibrated judge LESS OFTEN rather than a different judge more often -- an honest weekly
+        # beats a misleading daily. The cheaper models stay selectable for manual runs where the
+        # question is "does the plumbing work", not "is the judge still valid".
+        description: 'Deployment to test against. Default is the CALIBRATED judge deployment.'
         required: false
-        default: 'gpt-4o-mini'
+        default: 'gpt-5.5'
         type: choice
         options:
+          - gpt-5.5
           - gpt-4o-mini
           - gpt-4o
           - gpt-4.1
@@ -112,7 +123,7 @@ jobs:
       env:
         AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
         AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-        AZURE_OPENAI_DEPLOYMENT: ${{ inputs.model || 'gpt-4o-mini' }}
+        AZURE_OPENAI_DEPLOYMENT: ${{ inputs.model || 'gpt-5.5' }}
         # Secondary model for comparison tests
         AZURE_OPENAI_DEPLOYMENT_2: ${{ inputs.model == 'gpt-4o' && 'gpt-4o-mini' || 'gpt-4o' }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The judge's default completion budget could silently void it on the deployments its own claim
+  was measured on, and CI was certifying a different judge.** Two coupled defects, fixed together
+  because fixing either alone makes things worse.
+
+  **The budget.** `TypedMemEvalOptions.JudgeMaxOutputTokens` defaulted to **512**. That is ample for
+  a non-reasoning model and dangerous on a reasoning one, where the budget covers reasoning tokens
+  too: the model can spend the whole allowance thinking and return an **empty completion**. This
+  family has already paid for that once — empty completions scored as answers until the silence
+  accounting was built — and any consumer pointing the judge at a `gpt-5.x` deployment on defaults
+  would have hit it silently.
+
+  Now **1500**, which is not a guess: it is the value the calibration test floors at, and therefore
+  the configuration the published agreement number (**0.987** over 230 cases) was actually measured
+  under. **A default that differs from the configuration the claim came from means the out-of-box
+  judge is not the judge the claim describes.**
+
+  **The deployment.** The integration workflow defaulted to `gpt-4o-mini` while the judge's validity
+  claim is measured on `gpt-5.5`. A gate exercising a different model **certifies nothing about that
+  claim** — its green is decoration, and a regression on the calibrated deployment would not turn it
+  red. The default is now the calibrated deployment; the cheaper models stay selectable for manual
+  runs where the question is *"does the plumbing work"* rather than *"is the judge still valid"*.
+  If cost ever bites, run the calibrated judge **less often** rather than a different judge more
+  often.
+
+  **Behaviour-affecting, and recorded as such.** Raising a cap can flip a formerly-truncated
+  verdict, so the effective value is now stamped per run in
+  `BenchmarkRunProvenance.JudgeMaxOutputTokens`. Two runs differing only in this number are not
+  comparable, and that has to be visible rather than inferred.
+
+  Pinned by tests rather than left to a comment — and the first draft of that test **failed**,
+  correctly: `ExternalBenchmarkOptions` carries the same setting at a default of 256 and serves
+  LongMemEval, whose own calibration was measured there. The guarantee is not "the base default is
+  1500" but that the TypedMemEval facade **overrides it on the way through**. A value corrected in
+  one of two places is the applied-once shape, caught here by its own guard.
+
 - **`conjunction/order-then-value` could not rank any two retrievers, and now it can.** It measured
   **V9 15/15, headroom 0.00** — a perfect retriever and a plain BM25 retriever scored identically —
   while its BM25 coverage was only **0.667**. Those two numbers together are the diagnosis: the

--- a/src/AgentEval.Memory/External/Models/BenchmarkRunProvenance.cs
+++ b/src/AgentEval.Memory/External/Models/BenchmarkRunProvenance.cs
@@ -41,6 +41,19 @@ public sealed class BenchmarkRunProvenance
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyList<string>? JudgePromptTemplateNames { get; init; }
 
+    /// <summary>
+    /// The completion budget the judge actually ran with, in tokens.
+    /// </summary>
+    /// <remarks>
+    /// Stamped because RAISING THIS CAP CAN FLIP A VERDICT. On a reasoning deployment the budget
+    /// covers reasoning tokens too, so a judge that was silently truncated at one cap returns a
+    /// real verdict at a higher one — and two runs that differ only in this value are not
+    /// comparable, which is invisible unless the value travels with the run. The consuming project
+    /// asked for it explicitly when the default was raised from 512.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? JudgeMaxOutputTokens { get; init; }
+
     /// <summary>Informational version of the AgentEval.Memory assembly that produced the run.</summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AgentEvalVersion { get; init; }

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalOptions.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalOptions.cs
@@ -94,9 +94,24 @@ public sealed class TypedMemEvalOptions
     /// <summary>Judge sampling temperature; null uses the provider default.</summary>
     public double? JudgeTemperature { get; init; }
 
-    /// <summary>Judge output-token budget. Raised above the LongMemEval default because the
-    /// five-way verdict carries more fields than a yes/no.</summary>
-    public int JudgeMaxOutputTokens { get; init; } = 512;
+    /// <summary>Judge output-token budget.</summary>
+    /// <remarks>
+    /// 1500 because that is the value the SHIPPED CALIBRATION WAS MEASURED AT — agreement 0.987
+    /// over 230 cases on a reasoning deployment. A default that differs from the configuration the
+    /// published number came from means the out-of-box judge is not the judge the claim describes.
+    ///
+    /// It was 512, which is ample for a non-reasoning model and DANGEROUS on a reasoning one: the
+    /// budget covers reasoning tokens too, so the model can spend the whole allowance thinking and
+    /// return an empty completion. This family has already paid for that once — empty completions
+    /// scored as answers until the silence accounting was built — and a consumer pointing the judge
+    /// at a gpt-5.x deployment on defaults would have hit it silently.
+    ///
+    /// BEHAVIOUR-AFFECTING. Raising a cap can flip a formerly-truncated verdict, so the effective
+    /// value is stamped per run in <c>BenchmarkRunProvenance.JudgeMaxOutputTokens</c>: two runs
+    /// differing only in this number are not comparable, and that has to be visible rather than
+    /// inferred.
+    /// </remarks>
+    public int JudgeMaxOutputTokens { get; init; } = 1500;
 
     /// <summary>Retries after the first judge attempt, 0–3.</summary>
     public int MaxJudgeRetries { get; init; } = 1;

--- a/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalReportBuilder.cs
+++ b/src/AgentEval.Memory/External/TypedMemEval/TypedMemEvalReportBuilder.cs
@@ -122,7 +122,8 @@ internal static class TypedMemEvalReportBuilder
                 options, results.Select(q => q.AnswerSampling).ToList()),
             OracleProjection = oracleProjection,
             TypedOutcomes = typed,
-            Provenance = BuildProvenance(descriptor, results, totalQuestionsInCorpus, corpusSha256),
+            Provenance = BuildProvenance(
+                descriptor, results, totalQuestionsInCorpus, corpusSha256, options),
             JudgeSystemFingerprints = results
                 .Select(q => q.JudgeSystemFingerprint)
                 .Where(f => !string.IsNullOrEmpty(f))
@@ -288,12 +289,14 @@ internal static class TypedMemEvalReportBuilder
         TypedMemEvalVerticalDescriptor descriptor,
         IReadOnlyList<QuestionResult> results,
         int totalQuestionsInCorpus,
-        string corpusSha256)
+        string corpusSha256,
+        ExternalBenchmarkOptions options)
         => new()
         {
             Mode = RunProvenanceMode.Full,
             JudgePromptFingerprint = TypedMemEvalJudge.PromptFingerprint,
             JudgePromptTemplateNames = TemplateNames,
+            JudgeMaxOutputTokens = options.JudgeMaxOutputTokens,
             AgentEvalVersion = LongMemEvalProvenance.TryGetAgentEvalVersion(),
             // No path by design: the family is embedded-only, and the identifier plus hash pin the
             // corpus more precisely than a path ever could.

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeBudgetTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalJudgeBudgetTests.cs
@@ -1,0 +1,72 @@
+using AgentEval.Memory.External.Models;
+using AgentEval.Memory.External.TypedMemEval;
+using Xunit;
+
+namespace AgentEval.Memory.Tests;
+
+/// <summary>
+/// Pins the judge's completion budget to the value its shipped calibration was measured at.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default was 512 — ample for a non-reasoning model and dangerous on a reasoning one, where
+/// the budget covers reasoning tokens too. A model can spend the whole allowance thinking and
+/// return an empty completion, and this family has already paid for that once: empty completions
+/// scored as answers until the silence accounting was built. A consumer pointing the judge at a
+/// reasoning deployment on defaults would have hit it silently.
+/// </para>
+/// <para>
+/// 1500 is not a guess. It is the value <c>TypedMemEvalJudgeCalibrationTests</c> floors at, which
+/// makes it the configuration the published agreement number (0.987 over 230 cases) was actually
+/// measured under. <b>A default that differs from the configuration the claim came from means the
+/// out-of-box judge is not the judge the claim describes.</b>
+/// </para>
+/// <para>
+/// Pinned by a test rather than trusted to a comment, because the whole lesson of the arc that
+/// produced it is that a rule written down is not a rule enforced. Raising a cap can flip a
+/// formerly-truncated verdict, so the effective value also has to travel with the run — asserted
+/// below.
+/// </para>
+/// </remarks>
+public class TypedMemEvalJudgeBudgetTests
+{
+    /// <summary>The budget the shipped calibration was measured at.</summary>
+    private const int CalibratedCompletionBudget = 1500;
+
+    [Fact]
+    public void JudgeCompletionBudget_DefaultsToTheValueTheCalibrationWasMeasuredAt()
+    {
+        Assert.Equal(CalibratedCompletionBudget, new TypedMemEvalOptions().JudgeMaxOutputTokens);
+    }
+
+    [Fact]
+    public void JudgeCompletionBudget_ReachesTheOptionsTheRunnerActuallyUses()
+    {
+        // TWO CLASSES CARRY THIS SETTING and only one of them is TypedMemEval's. The base
+        // ExternalBenchmarkOptions defaults to 256 and serves LongMemEval, whose own calibration
+        // was measured there -- raising it would be changing a different benchmark's judge on the
+        // way past. So the guarantee is not "the base default is 1500"; it is that the TypedMemEval
+        // facade OVERRIDES it on the way through.
+        //
+        // The first draft of this test asserted the base default and failed, which is the
+        // applied-once shape catching its own author: a value corrected in one of two places.
+        var built = new TypedMemEvalOptions()
+            .ToExternalOptions(TypedMemEvalVerticals.For(TypedMemEvalVertical.Temporal));
+        Assert.Equal(CalibratedCompletionBudget, built.JudgeMaxOutputTokens);
+        Assert.NotEqual(new ExternalBenchmarkOptions().JudgeMaxOutputTokens, built.JudgeMaxOutputTokens);
+    }
+
+    [Fact]
+    public void Provenance_CanCarryTheEffectiveBudget()
+    {
+        // Two runs differing only in this number are not comparable, and that has to be visible in
+        // the record rather than inferred from a version. The report builder stamps it; this pins
+        // that the field exists and survives serialisation-shaped use.
+        var provenance = new BenchmarkRunProvenance
+        {
+            Mode = RunProvenanceMode.Full,
+            JudgeMaxOutputTokens = 4096
+        };
+        Assert.Equal(4096, provenance.JudgeMaxOutputTokens);
+    }
+}


### PR DESCRIPTION
Two coupled defects, fixed together because fixing either alone makes things worse.

## The budget

`TypedMemEvalOptions.JudgeMaxOutputTokens` defaulted to **512** — ample for a non-reasoning model, dangerous on a reasoning one where the budget covers reasoning tokens too. The model can spend the whole allowance thinking and return an **empty completion**.

This family has already paid for that once: empty completions scored as answers until the silence accounting was built. Any consumer pointing the judge at a `gpt-5.x` deployment **on defaults** would have hit it silently.

Now **1500** — not a guess. It is the value the calibration test floors at, and therefore the configuration the published agreement number (**0.987** over 230 cases) was measured under.

> **A default that differs from the configuration the claim came from means the out-of-box judge is not the judge the claim describes.**

## The deployment

`llm-integration-tests.yml` defaulted to `gpt-4o-mini` while the judge's validity claim is measured on `gpt-5.5`. A gate exercising a different model **certifies nothing about that claim** — its green is decoration, and a regression on the calibrated deployment would not turn it red.

Default is now the calibrated deployment. Cheaper models stay selectable for manual runs where the question is *"does the plumbing work"* rather than *"is the judge still valid"*. If cost bites, run the calibrated judge **less often** rather than a different judge more often.

## Behaviour-affecting, and recorded as such

Raising a cap can flip a formerly-truncated verdict, so the effective value is stamped per run in `BenchmarkRunProvenance.JudgeMaxOutputTokens`. Two runs differing only in this number are not comparable, and that must be visible rather than inferred.

All three riders the consuming project attached to their approval.

## The test failed first, correctly

Pinned by tests rather than a comment. **The first draft failed** — `ExternalBenchmarkOptions` carries the same setting at a default of **256** and serves LongMemEval, whose own calibration was measured there; raising it would have changed a different benchmark's judge on the way past.

The guarantee is not *"the base default is 1500"* but that the TypedMemEval facade **overrides it on the way through**. A value corrected in one of two places is the applied-once shape, caught here by its own guard.

## Rider (c) was already satisfied — verified, not assumed

An empty completion at the cap classifying as infrastructure rather than a wrong answer: `TypedMemEvalVerdict.Parse` returns a null outcome for `invalid_finish_reason` and `empty_response` alike, and a null outcome **never becomes `Wrong`** — it retries, then fails the run or stays unscored.

Suite **1055/1055**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ