### PR TITLE
Publish what kind of hard each shape is, and gate on whether it can rank anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every shape now publishes what KIND of hard it is, and a gate on whether it can rank anything.**
+  Implements [ADR-028](docs/adr/028-typedmemeval-acceptance-on-discrimination.md) §3a and §3e.
+
+  `V1 − V9` is what a **perfect selector** buys — a retriever returning gold and nothing else. A real
+  retriever returns gold *plus* whatever else it ranks highly, so it cannot beat having everything:
+  **its ceiling is V8, not V1.** Where those diverge the published headroom is unreachable, and a
+  consumer reading it buys retrieval work that cannot help.
+
+  | shape | headroom (perfect) | reachable | limited by |
+  |---|---|---|---|
+  | `prospective/due-window` | **0.94** | **0.17** | **reasoning** |
+  | `semantic/co-reference` | 0.40 | 0.27 | retrieval |
+  | `arithmetic/delta` | 0.90 | 0.90 | retrieval |
+
+  `due-window` is the case that motivated it: 0.94 published, 0.17 actually reachable. Both figures
+  and the classification now ship in every sidecar.
+
+  **The gate** asserts each shape clears a 0.15 discrimination floor. It is a **ratchet**, not a
+  wall — a gate that stays red for the life of a known-weak shape stops being read, and a regression
+  introduced while fixing something else then lands invisibly. Two lists, both with reasons:
+  *saturated by design* (WorkingMemory's three short ladder rungs, where the gradient **is** the
+  measurement and deleting the saturation deletes the construct) and *pending redesign*
+  (`temporal/occurrence-order` 0.05, `bitemporal/belief-at-instant` 0.11 — near-closed-choice forms
+  where the question names the entity it asks about, the same structural cap that limited
+  `participant-attribution` to 0.20). Listed shapes may improve and may not regress; anything
+  unlisted must clear the floor outright.
+
+  Red-first verified: raising the floor to 0.25 turns three verticals red; restored, 1073/1073 green.
+  **No corpus regenerates and no consumer control moves** — the raw arm counts were already recorded,
+  so this is reporting and acceptance only.
+
+  The **0.15 floor is a judgement, not a measurement.** Nothing in the data derives it; it sits where
+  the distribution has a natural gap (three at 0.00, two between 0.05 and 0.11, twenty-five at 0.17+)
+  and should be revisited once a second reference retriever exists, because the whole scale is
+  BM25-relative.
+
 ### Fixed
 
 - **`value-then-count` asked how many times the speaker ORDERED while its sessions recorded sending

--- a/docs/adr/028-typedmemeval-acceptance-on-discrimination.md
+++ b/docs/adr/028-typedmemeval-acceptance-on-discrimination.md
@@ -1,0 +1,142 @@
+# ADR-028: TypedMemEval — accept a shape on measured discrimination, not on a coverage proxy
+
+- **Status:** Proposed — decision recorded, **not yet implemented**. §7 is the implementation
+  sequence and §8 the migration cost.
+- **Date:** 2026-08-31
+- **Extends:** [ADR-026](026-typedmemeval-benchmark-family.md), which defines the BM25 calibration
+  band, and [ADR-027](027-typedmemeval-semantic-temporal-bitemporal.md).
+- **Supersedes:** ADR-026's use of `BAND_LOW` as an *acceptance* criterion. The band survives as a
+  **calibration target**; it stops being a pass/fail gate.
+
+---
+
+## 1. The finding, in one table
+
+Every shape in the family is answerable from its own gold. V1 is at or near 1.00 for all thirty.
+The variation lives entirely in retrieval and reasoning:
+
+| shape | V1 | V8 | V9 | `V1−V9` | what it actually is |
+|---|---|---|---|---|---|
+| `episodic/list-order` | 1.00 | **1.00** | 0.27 | 0.73 | retrieval-limited |
+| `prospective/due-window` | 1.00 | **0.22** | 0.06 | **0.94** | **reasoning**-limited |
+
+Both read as "hard". They are not the same kind of hard, and the published headroom says
+`due-window` has *more* room — which is true only for a retriever that returns gold and nothing
+else. Its V8 says that even with the entire haystack in context the model fails 78% of the time.
+**A consumer reading 0.94 would buy a better retriever and get almost nothing.**
+
+## 2. The coverage floor is guarding a property another instrument already measures
+
+`BAND_LOW = 0.50` is justified in the code as:
+
+> *"Below the floor the corpus is unanswerable noise."*
+
+Measured, the two shapes below that floor are:
+
+| shape | coverage | V1 |
+|---|---|---|
+| `conjunction/alias-then-count` | 0.344 | **15/15** |
+| `prospective/due-window` | 0.222 | **18/18** |
+
+Neither is noise. Both are perfectly answerable from gold; BM25 simply cannot find the evidence,
+which is the *point* of a retrieval benchmark. **Unanswerability is measured directly by V1, and V1
+passes.** The floor is therefore redundant where V1 is clean, and actively harmful where it is
+enforced: aiming every shape at the band's midpoint moves a legitimately hard shape toward the
+middle for no measured reason.
+
+This is not hypothetical. Opting Episodic into per-shape calibration (PR #205) fixed a genuinely
+saturated shape and dulled a sharp one in the same pass:
+
+| episodic shape | before | after | verdict |
+|---|---|---|---|
+| `participant-attribution` | 0.933 cov, headroom **0.07** | 0.667 cov, headroom **0.20** | correct — it was saturated |
+| `list-order` | 0.275 cov, headroom **1.00** | 0.692 cov, headroom 0.73 | **discrimination traded away** |
+
+`list-order` had V1 1.00, V8 1.00, V9 0.00 — the widest headroom in the family — and was moved
+because the spec said 0.70, not because anything measured said it was broken.
+
+## 3. Decision
+
+**3a. Acceptance moves to measured per-shape discrimination.** A shape is acceptable when it can
+tell two systems apart: `V1 − V9 ≥ 0.15`, with V1 itself healthy. Declared constructs are exempt by
+name and with their reason recorded — WorkingMemory's three short ladder rungs sit at headroom 0.00
+*by design*, because the gradient across the ladder is the measurement and deleting the saturation
+deletes the construct.
+
+**3b. The coverage floor is retired.** `BAND_LOW` stops being a gate. Its stated justification is
+discharged by V1, and enforcing it costs discrimination.
+
+**3c. The coverage ceiling stays.** Saturation is the one failure mode that is real and invisible
+without it, and it is what caught `conjunction/order-then-value` (V9 15/15, headroom 0.00, shipped
+that way for its whole life).
+
+**3d. Coverage remains the calibration TARGET.** This is the part worth stating explicitly, because
+it is why the proxy existed. Coverage is *structural* — pure BM25, no model calls — so the echo
+search can optimise against it for free. Headroom needs V1 and V9, which cost a probe run. **Search
+on the cheap proxy; accept on the measured truth.** The mistake was never using coverage; it was
+accepting on it.
+
+**3e. Headroom is decomposed and both halves are published per shape.**
+
+- **Retrieval-limited** — V8 high, V9 low. A better retriever helps, up to V8.
+- **Reasoning-limited** — V8 low. A better retriever does **not** help; the ceiling is V8, not V1.
+
+`V1 − V9` continues to mean *what a perfect selector buys over a lexical baseline* and remains
+correct as stated. What was missing is that **a real retriever cannot exceed V8**, so on a shape
+where V8 ≪ V1 the reachable headroom is far smaller than the published figure. Both numbers ship.
+
+## 4. Why this makes the benchmark better, stated as the thing it buys
+
+The point of a typed benchmark is not a score; it is telling a consumer **why** their system failed.
+Today the family can say *"you scored 0.30 on conjunction."* Under this ADR it says *"you scored
+0.30, the retriever is not your problem, and no retrieval work will move it."* That is the
+difference between a leaderboard and an instrument.
+
+## 5. What this does NOT change
+
+- No corpus content changes. This is an acceptance criterion and a reporting change.
+- V1, V2, V3, V6, V8, V9 keep their definitions.
+- The chance-floor corrections (ADR-026 lineage, shipped in 0.31+) are unaffected.
+- The consuming project's sealed baselines are unaffected **by 3b/3c/3e**. Only 3a can newly fail a
+  vertical, and it fails shapes that were already reported as saturated.
+
+## 6. Risks, and the one that worries me
+
+**The 0.15 threshold is a judgement, not a measurement.** Nothing in the data derives it. It is set
+where the current distribution has a natural gap — three shapes at 0.00 (all declared), two between
+0.05 and 0.11, twenty-five at 0.17 or above — and it should be revisited once a second reference
+retriever exists, because **the whole scale is BM25-relative**. ADR-027 §1 already warned that a
+corpus tuned on BM25 can be saturated for a vector+graph stack; this ADR inherits that warning and
+does not fix it.
+
+**Retiring a floor is a loosening.** It cannot be justified by "the shapes below it look fine" alone,
+which is why it rests on V1 being the direct measurement of the property the floor names. If a shape
+ever sits below the floor *with a degraded V1*, that is a real defect and V1 will say so.
+
+## 7. Implementation sequence
+
+1. **3e first — additive, no reset.** Publish per-shape V8 and the retrieval/reasoning split in the
+   sidecar and the report. Nothing regenerates; no consumer control moves.
+2. **3a/3b/3c — the acceptance change.** A per-shape discrimination gate with a declared exemption
+   list, replacing the coverage floor check.
+3. **Re-examine `episodic/list-order`.** Under 3b it should return to its pre-#205 form; the
+   attribution fix in #205 stands on its own and is unaffected.
+4. **The two barely-discriminating shapes** — `temporal/occurrence-order` (0.05) and
+   `bitemporal/belief-at-instant` (0.11) — are scoped separately. Both are near-closed-choice forms
+   where the question names the entity it asks about, which is the same structural cap that limited
+   `participant-attribution` to 0.20. They may need new question forms rather than tuning.
+
+## 8. Migration cost
+
+Step 1 is free. Step 2 changes no corpus. Step 3 regenerates Episodic once — one sha, one control
+reset for the consuming project, and it should ride whatever release carries it rather than being
+cut on its own. Step 4 is unscoped by design.
+
+## 9. Provenance
+
+The finding came out of a question about whether the `value-then-count` repair was the best
+available, which is worth recording because **nothing in the gates surfaced it**. The saturation
+screen, the chance-floor audits and the separability gate were all green. What exposed it was
+putting V1, V8 and V9 for one shape beside each other and asking what kind of hard it was — the
+"two correct numbers never compared" class, which by construction no gate enumerates and which
+ratchets one named comparison at a time.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ Each ADR follows this structure:
 | [025](025-gatekeeper-runtime-fail-closed-enforcement.md) | Gatekeeper — Runtime Fail-Closed Enforcement Middleware | Accepted | 2026-07-05 |
 | [026](026-typedmemeval-benchmark-family.md) | TypedMemEval — A Mechanism-Isolating Memory Benchmark Family | Accepted (implemented v0.22.0-beta) | 2026-08-15 |
 | [027](027-typedmemeval-semantic-temporal-bitemporal.md) | TypedMemEval — Semantic, Temporal and Bitemporal Verticals (design) | Proposed (design only; generation gated) | 2026-08-18 |
+| [028](028-typedmemeval-acceptance-on-discrimination.md) | TypedMemEval — accept a shape on measured discrimination, not a coverage proxy | Proposed | 2026-08-31 |
 
 ---
 

--- a/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
@@ -869,7 +869,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:27Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -934,7 +934,7 @@
         "calls": 1500,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 637,
+        "judge_calls": 635,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -943,7 +943,7 @@
         "calls": 342,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 136,
+        "judge_calls": 141,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -1004,7 +1004,12 @@
         "v8_passed": 14,
         "v9_applicable": 14,
         "v9_passed": 7,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.5,
+        "discriminates": true,
+        "headroom_reachable": 0.5,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "delta": {
         "questions": 10,
@@ -1016,7 +1021,12 @@
         "v8_passed": 10,
         "v9_applicable": 10,
         "v9_passed": 1,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.9,
+        "discriminates": true,
+        "headroom_reachable": 0.9,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "duration": {
         "questions": 12,
@@ -1028,7 +1038,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 5,
-        "required_sessions_median": 6
+        "required_sessions_median": 6,
+        "headroom_perfect_selector": 0.5833,
+        "discriminates": true,
+        "headroom_reachable": 0.5833,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "sum": {
         "questions": 14,
@@ -1040,7 +1055,12 @@
         "v8_passed": 14,
         "v9_applicable": 14,
         "v9_passed": 6,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.5714,
+        "discriminates": true,
+        "headroom_reachable": 0.5714,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/bitemporal/agenteval-typedmemeval-bitemporal-v5.meta.json
@@ -739,7 +739,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:27Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 60,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -809,7 +809,12 @@
         "v8_passed": 35,
         "v9_applicable": 36,
         "v9_passed": 31,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.1111,
+        "discriminates": false,
+        "headroom_reachable": 0.1111,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "correction-depth": {
         "questions": 24,
@@ -821,7 +826,12 @@
         "v8_passed": 24,
         "v9_applicable": 24,
         "v9_passed": 17,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.2917,
+        "discriminates": true,
+        "headroom_reachable": 0.2917,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {
@@ -1779,7 +1789,7 @@
         "calls": 3050,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 833,
+        "judge_calls": 831,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -1788,16 +1798,16 @@
         "calls": 807,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 221,
+        "judge_calls": 226,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v6": {
         "population": "probe_answers",
-        "calls": 826,
+        "calls": 828,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 321,
+        "judge_calls": 315,
         "judge_empty": 0,
         "judge_rate": 0.0
       },

--- a/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
@@ -897,7 +897,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-31T12:53:44Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -944,62 +944,60 @@
       "not_applicable_reason": "V6 is not defined for conjunction"
     },
     "empty_completions": {
-      "count": 0,
-      "retried_for_length": 5,
-      "by_cache_key": {}
+      "count": 0
     },
     "empty_rate_by_arm": {
       "v1": {
         "population": "probe_answers",
-        "calls": 50,
+        "calls": 455,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 455,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v2": {
         "population": "probe_answers",
-        "calls": 500,
+        "calls": 4550,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 150,
+        "judge_calls": 1602,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v3": {
         "population": "probe_answers",
-        "calls": 150,
+        "calls": 1197,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 45,
+        "judge_calls": 397,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v6": {
         "population": "probe_answers",
-        "calls": 0,
+        "calls": 828,
         "empty": 0,
-        "rate": null,
-        "judge_calls": 0,
+        "rate": 0.0,
+        "judge_calls": 315,
         "judge_empty": 0,
-        "judge_rate": null
+        "judge_rate": 0.0
       },
       "v8": {
         "population": "probe_answers",
-        "calls": 54,
+        "calls": 455,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 455,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v9": {
         "population": "probe_answers",
-        "calls": 51,
+        "calls": 455,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 455,
         "judge_empty": 0,
         "judge_rate": 0.0
       }
@@ -1035,7 +1033,12 @@
         "v8_passed": 15,
         "v9_applicable": 15,
         "v9_passed": 1,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.9333,
+        "discriminates": true,
+        "headroom_reachable": 0.9333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "order-then-value": {
         "questions": 15,
@@ -1047,7 +1050,12 @@
         "v8_passed": 14,
         "v9_applicable": 15,
         "v9_passed": 7,
-        "required_sessions_median": 5
+        "required_sessions_median": 5,
+        "headroom_perfect_selector": 0.5333,
+        "discriminates": true,
+        "headroom_reachable": 0.4667,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "value-then-count": {
         "questions": 20,
@@ -1059,7 +1067,12 @@
         "v8_passed": 20,
         "v9_applicable": 20,
         "v9_passed": 6,
-        "required_sessions_median": 6
+        "required_sessions_median": 6,
+        "headroom_perfect_selector": 0.7,
+        "discriminates": true,
+        "headroom_reachable": 0.7,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/episodic/agenteval-typedmemeval-episodic-v5.meta.json
@@ -761,7 +761,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-31T09:37:16Z",
+    "run_at": "2026-08-31T13:29:35Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -824,35 +824,33 @@
       "not_applicable_reason": "V6 is not defined for episodic"
     },
     "empty_completions": {
-      "count": 0,
-      "retried_for_length": 32,
-      "by_cache_key": {}
+      "count": 0
     },
     "empty_rate_by_arm": {
       "v1": {
         "population": "probe_answers",
-        "calls": 50,
+        "calls": 100,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 100,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v2": {
         "population": "probe_answers",
-        "calls": 522,
+        "calls": 1000,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 355,
+        "judge_calls": 495,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v3": {
         "population": "probe_answers",
-        "calls": 105,
+        "calls": 192,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 66,
+        "judge_calls": 96,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -867,19 +865,19 @@
       },
       "v8": {
         "population": "probe_answers",
-        "calls": 50,
+        "calls": 100,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 100,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v9": {
         "population": "probe_answers",
-        "calls": 60,
+        "calls": 100,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 50,
+        "judge_calls": 100,
         "judge_empty": 0,
         "judge_rate": 0.0
       }
@@ -915,7 +913,12 @@
         "v8_passed": 20,
         "v9_applicable": 20,
         "v9_passed": 14,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.3,
+        "discriminates": true,
+        "headroom_reachable": 0.3,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "list-order": {
         "questions": 15,
@@ -927,7 +930,12 @@
         "v8_passed": 15,
         "v9_applicable": 15,
         "v9_passed": 4,
-        "required_sessions_median": 5
+        "required_sessions_median": 5,
+        "headroom_perfect_selector": 0.7333,
+        "discriminates": true,
+        "headroom_reachable": 0.7333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "participant-attribution": {
         "questions": 15,
@@ -939,7 +947,12 @@
         "v8_passed": 14,
         "v9_applicable": 15,
         "v9_passed": 12,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.2,
+        "discriminates": true,
+        "headroom_reachable": 0.1333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
@@ -744,7 +744,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T16:54:29Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -808,62 +808,60 @@
       "applies_to": "Arithmetic and Forgetting, on questions with more than one gold session. Those are the verticals whose design claims every gold component is load-bearing; elsewhere a question may have several gold sessions without the design promising each one is individually necessary, and ablating them would report a defect never promised against"
     },
     "empty_completions": {
-      "count": 0,
-      "retried_for_length": 2,
-      "by_cache_key": {}
+      "count": 0
     },
     "empty_rate_by_arm": {
       "v1": {
         "population": "probe_answers",
-        "calls": 35,
+        "calls": 245,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 35,
+        "judge_calls": 245,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v2": {
         "population": "probe_answers",
-        "calls": 350,
+        "calls": 2450,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 0,
+        "judge_calls": 831,
         "judge_empty": 0,
-        "judge_rate": null
+        "judge_rate": 0.0
       },
       "v3": {
         "population": "probe_answers",
-        "calls": 105,
+        "calls": 627,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 0,
+        "judge_calls": 226,
         "judge_empty": 0,
-        "judge_rate": null
+        "judge_rate": 0.0
       },
       "v6": {
         "population": "probe_answers",
-        "calls": 153,
+        "calls": 828,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 85,
+        "judge_calls": 315,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v8": {
         "population": "probe_answers",
-        "calls": 36,
+        "calls": 245,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 35,
+        "judge_calls": 245,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v9": {
         "population": "probe_answers",
-        "calls": 36,
+        "calls": 245,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 35,
+        "judge_calls": 245,
         "judge_empty": 0,
         "judge_rate": 0.0
       }
@@ -902,7 +900,12 @@
         "v8_passed": 17,
         "v9_applicable": 20,
         "v9_passed": 13,
-        "required_sessions_median": 2
+        "required_sessions_median": 2,
+        "headroom_perfect_selector": 0.3,
+        "discriminates": true,
+        "headroom_reachable": 0.2,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "never-known": {
         "questions": 15,
@@ -926,7 +929,12 @@
         "v8_passed": 14,
         "v9_applicable": 15,
         "v9_passed": 8,
-        "required_sessions_median": 2
+        "required_sessions_median": 2,
+        "headroom_perfect_selector": 0.4667,
+        "discriminates": true,
+        "headroom_reachable": 0.4,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
@@ -729,7 +729,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:27Z",
+    "run_at": "2026-08-31T13:29:35Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -900,7 +900,12 @@
         "v8_passed": 8,
         "v9_applicable": 8,
         "v9_passed": 4,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.5,
+        "discriminates": true,
+        "headroom_reachable": 0.5,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "due-window": {
         "questions": 18,
@@ -912,7 +917,12 @@
         "v8_passed": 4,
         "v9_applicable": 18,
         "v9_passed": 1,
-        "required_sessions_median": 2
+        "required_sessions_median": 2,
+        "headroom_perfect_selector": 0.9444,
+        "discriminates": true,
+        "headroom_reachable": 0.1667,
+        "limited_by": "reasoning",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "expiring-validity": {
         "questions": 6,
@@ -924,7 +934,12 @@
         "v8_passed": 6,
         "v9_applicable": 6,
         "v9_passed": 4,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.3333,
+        "discriminates": true,
+        "headroom_reachable": 0.3333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "not-yet-true": {
         "questions": 6,
@@ -936,7 +951,12 @@
         "v8_passed": 6,
         "v9_applicable": 6,
         "v9_passed": 5,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.1667,
+        "discriminates": true,
+        "headroom_reachable": 0.1667,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "seed-carry-over": {
         "questions": 12,
@@ -948,7 +968,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 9,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.25,
+        "discriminates": true,
+        "headroom_reachable": 0.25,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
@@ -764,7 +764,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:28Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -829,7 +829,7 @@
         "calls": 4050,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 1454,
+        "judge_calls": 1452,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -838,16 +838,16 @@
         "calls": 1047,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 347,
+        "judge_calls": 352,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v6": {
         "population": "probe_answers",
-        "calls": 826,
+        "calls": 828,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 321,
+        "judge_calls": 315,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -902,7 +902,12 @@
         "v8_passed": 13,
         "v9_applicable": 15,
         "v9_passed": 9,
-        "required_sessions_median": 2
+        "required_sessions_median": 2,
+        "headroom_perfect_selector": 0.4,
+        "discriminates": true,
+        "headroom_reachable": 0.2667,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "current-value": {
         "questions": 20,
@@ -914,7 +919,12 @@
         "v8_passed": 20,
         "v9_applicable": 20,
         "v9_passed": 13,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.35,
+        "discriminates": true,
+        "headroom_reachable": 0.35,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "source-attribution": {
         "questions": 15,
@@ -926,7 +936,12 @@
         "v8_passed": 15,
         "v9_applicable": 15,
         "v9_passed": 12,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.2,
+        "discriminates": true,
+        "headroom_reachable": 0.2,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/temporal/agenteval-typedmemeval-temporal-v5.meta.json
@@ -805,7 +805,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:28Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -891,7 +891,7 @@
         "calls": 3550,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 1183,
+        "judge_calls": 1181,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -900,16 +900,16 @@
         "calls": 897,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 266,
+        "judge_calls": 271,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
       "v6": {
         "population": "probe_answers",
-        "calls": 826,
+        "calls": 828,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 321,
+        "judge_calls": 315,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -961,7 +961,12 @@
         "v8_passed": 15,
         "v9_applicable": 15,
         "v9_passed": 7,
-        "required_sessions_median": 2
+        "required_sessions_median": 2,
+        "headroom_perfect_selector": 0.5333,
+        "discriminates": true,
+        "headroom_reachable": 0.5333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "occurrence-order": {
         "questions": 20,
@@ -973,7 +978,12 @@
         "v8_passed": 20,
         "v9_applicable": 20,
         "v9_passed": 19,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.05,
+        "discriminates": false,
+        "headroom_reachable": 0.05,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "recency": {
         "questions": 15,
@@ -985,7 +995,12 @@
         "v8_passed": 15,
         "v9_applicable": 15,
         "v9_passed": 7,
-        "required_sessions_median": 4
+        "required_sessions_median": 4,
+        "headroom_perfect_selector": 0.5333,
+        "discriminates": true,
+        "headroom_reachable": 0.5333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {

--- a/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
@@ -744,7 +744,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-30T14:44:27Z",
+    "run_at": "2026-08-31T13:29:36Z",
     "questions_probed": 60,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -817,7 +817,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 12,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.0,
+        "discriminates": false,
+        "headroom_reachable": 0.0,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "distance-25": {
         "questions": 12,
@@ -829,7 +834,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 12,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.0,
+        "discriminates": false,
+        "headroom_reachable": 0.0,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "distance-40": {
         "questions": 12,
@@ -841,7 +851,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 8,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.3333,
+        "discriminates": true,
+        "headroom_reachable": 0.3333,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "distance-60": {
         "questions": 12,
@@ -853,7 +868,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 9,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.25,
+        "discriminates": true,
+        "headroom_reachable": 0.25,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       },
       "distance-8": {
         "questions": 12,
@@ -865,7 +885,12 @@
         "v8_passed": 12,
         "v9_applicable": 12,
         "v9_passed": 12,
-        "required_sessions_median": 1
+        "required_sessions_median": 1,
+        "headroom_perfect_selector": 0.0,
+        "discriminates": false,
+        "headroom_reachable": 0.0,
+        "limited_by": "retrieval",
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
       }
     },
     "per_question": {
@@ -1816,7 +1841,7 @@
         "calls": 2100,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 833,
+        "judge_calls": 831,
         "judge_empty": 0,
         "judge_rate": 0.0
       },
@@ -1825,7 +1850,7 @@
         "calls": 522,
         "empty": 0,
         "rate": 0.0,
-        "judge_calls": 221,
+        "judge_calls": 226,
         "judge_empty": 0,
         "judge_rate": 0.0
       },

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalDiscriminationTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalDiscriminationTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using AgentEval.Memory.External.TypedMemEval;
+using Xunit;
+
+namespace AgentEval.Memory.Tests;
+
+/// <summary>
+/// Gates every shape on whether it can tell two systems apart. ADR-028.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The family used to accept a shape on BM25 <b>coverage</b>, which is a proxy. What it cares about
+/// is <b>discrimination</b>: a shape where a perfect selector and a plain lexical one score the same
+/// cannot rank anything, whatever its coverage says. <c>conjunction/order-then-value</c> shipped at
+/// V9 15/15 — headroom 0.00 — for its whole life with coverage sitting comfortably at 0.667.
+/// </para>
+/// <para>
+/// Coverage remains the <i>calibration target</i>, because it is structural and free while headroom
+/// costs a probe run. <b>Search on the cheap proxy; accept on the measured truth.</b>
+/// </para>
+/// <para>
+/// A RATCHET, not a wall, for the reason the coverage ratchet beside it gives: a gate that is
+/// uniformly red for the life of a known-weak shape stops being read, and a regression introduced
+/// while fixing something else then lands invisibly. Listed shapes may improve and may not regress;
+/// anything unlisted must clear the floor outright.
+/// </para>
+/// </remarks>
+public class TypedMemEvalDiscriminationTests
+{
+    /// <summary>Minimum <c>V1 − V9</c> at which a shape can rank two systems. ADR-028 §3a.</summary>
+    private const double DiscriminationFloor = 0.15;
+
+    /// <summary>
+    /// Shapes whose headroom is 0.00 <b>by design</b>, with the design that makes it so.
+    /// </summary>
+    /// <remarks>
+    /// These are not debt and must never be "fixed" from a headroom table read without the design
+    /// note. WorkingMemory is a DISTANCE LADDER: the independent variable is how far back the gold
+    /// sits, and coverage is <i>meant</i> to fall across the rungs. Deleting the saturation at the
+    /// short end deletes the low end of the gradient, which is the only thing the vertical measures.
+    /// </remarks>
+    private static readonly Dictionary<(TypedMemEvalVertical, string), string> SaturatedByDesign =
+        new()
+        {
+            [(TypedMemEvalVertical.WorkingMemory, "distance-8")] =
+                "declared ladder: the short rungs are meant to be trivially retrievable",
+            [(TypedMemEvalVertical.WorkingMemory, "distance-15")] =
+                "declared ladder: the gradient across rungs is the measurement",
+            [(TypedMemEvalVertical.WorkingMemory, "distance-25")] =
+                "declared ladder: still inside the easy half by construction",
+        };
+
+    /// <summary>
+    /// Shapes that cannot yet rank and are awaiting a redesign. May improve; may not regress.
+    /// </summary>
+    /// <remarks>
+    /// Both are near-closed-choice forms where the question names the entity it asks about, which
+    /// hands a lexical retriever the session it needs. That is the same structural cap that limited
+    /// <c>episodic/participant-attribution</c> to 0.20 after calibration — so these likely need new
+    /// QUESTION FORMS rather than tuning, and ADR-028 §7.4 scopes them separately.
+    /// </remarks>
+    private static readonly Dictionary<(TypedMemEvalVertical, string), double> PendingRedesign =
+        new()
+        {
+            [(TypedMemEvalVertical.Temporal, "occurrence-order")] = 0.05,
+            [(TypedMemEvalVertical.Bitemporal, "belief-at-instant")] = 0.11,
+        };
+
+    public static TheoryData<TypedMemEvalVertical> AllVerticals()
+    {
+        var data = new TheoryData<TypedMemEvalVertical>();
+        foreach (var vertical in System.Enum.GetValues<TypedMemEvalVertical>())
+        {
+            data.Add(vertical);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void EveryShape_CanRankTwoSystems(TypedMemEvalVertical vertical)
+    {
+        var byShape = ByShape(vertical);
+        Assert.True(byShape.Count > 0, $"{vertical} publishes no per-shape probe record.");
+
+        foreach (var (shape, record) in byShape)
+        {
+            if (!record.TryGetProperty("headroom_perfect_selector", out var headroomProperty))
+                continue;   // arm not measured for this shape
+
+            var headroom = headroomProperty.GetDouble();
+
+            if (SaturatedByDesign.ContainsKey((vertical, shape)))
+                continue;
+
+            if (PendingRedesign.TryGetValue((vertical, shape), out var recorded))
+            {
+                // Tolerance matches the precision the ratchet is written at, so a repeating value
+                // rounding down is not read as a regression.
+                Assert.True(
+                    headroom >= recorded - 1e-4,
+                    $"{vertical} shape '{shape}' REGRESSED: headroom {headroom:F4} against a "
+                    + $"recorded {recorded:F4}. This shape is awaiting redesign; it may improve, "
+                    + "but it may not get worse.");
+                continue;
+            }
+
+            Assert.True(
+                headroom >= DiscriminationFloor,
+                $"{vertical} shape '{shape}' has headroom {headroom:F3} (V1 − V9), below the "
+                + $"{DiscriminationFloor} floor: a perfect selector and a plain lexical one score "
+                + "close enough that this shape cannot rank two systems. Either redesign it, or "
+                + "add it to PendingRedesign with its measured value and a reason.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void ReachableHeadroom_IsPublishedWhereverHeadroomIs(TypedMemEvalVertical vertical)
+    {
+        // V1 − V9 is what a PERFECT selector buys. A real retriever returns gold plus whatever else
+        // it ranks highly, so it cannot beat having everything — its ceiling is V8, not V1. Where
+        // those diverge the published headroom is unreachable, and a consumer reading it would buy
+        // retrieval work that cannot help: prospective/due-window reads 0.94 and can reach 0.17.
+        foreach (var (shape, record) in ByShape(vertical))
+        {
+            if (!record.TryGetProperty("headroom_perfect_selector", out _))
+                continue;
+
+            Assert.True(
+                record.TryGetProperty("headroom_reachable", out var reachable),
+                $"{vertical} shape '{shape}' publishes headroom without the reachable figure. "
+                + "The pair is the point — one number alone cannot say whether retrieval work helps.");
+            Assert.True(
+                record.TryGetProperty("limited_by", out var limitedBy),
+                $"{vertical} shape '{shape}' publishes no retrieval/reasoning classification.");
+            Assert.Contains(limitedBy.GetString(), new[] { "retrieval", "reasoning" });
+            Assert.True(reachable.GetDouble() >= 0);
+        }
+    }
+
+    private static Dictionary<string, JsonElement> ByShape(TypedMemEvalVertical vertical)
+    {
+        var metadata = JsonDocument.Parse(TypedMemEvalCorpus.ReadMetadataJson(vertical)).RootElement;
+        var result = new Dictionary<string, JsonElement>();
+        if (!metadata.TryGetProperty("probes", out var probes)
+            || !probes.TryGetProperty("by_shape", out var byShape))
+        {
+            return result;
+        }
+
+        foreach (var shape in byShape.EnumerateObject())
+            result[shape.Name] = shape.Value.Clone();
+
+        return result;
+    }
+}

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -1137,6 +1137,7 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
                 "v9_applicable": sum(1 for r in group if r.get("v9") is not None),
                 "v9_passed": sum(1 for r in group if r.get("v9") is True),
                 "required_sessions_median": _median_g(group, gold_counts),
+                **_discrimination(group),
             }
             for shape, group in sorted(
                 {s: [r for r in records if shapes.get(r["question_id"]) == s]
@@ -1148,6 +1149,56 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
             for r in records
         },
     }
+
+
+#: The minimum V1 - V9 at which a shape can tell two systems apart. ADR-028.
+#:
+#: A JUDGEMENT, not a measurement -- nothing in the data derives it. It sits where the current
+#: distribution has a natural gap: three shapes at 0.00 (all declared ladder rungs), two between
+#: 0.05 and 0.11, twenty-five at 0.17 or above. It should be revisited once a second reference
+#: retriever exists, because the entire scale is BM25-relative.
+DISCRIMINATION_FLOOR = 0.15
+
+
+def _discrimination(group: list[dict]) -> dict:
+    """How this shape is hard, and whether it can rank anything. ADR-028 SS3e.
+
+    `V1 - V9` is what a PERFECT selector buys over a lexical baseline, and that remains its meaning.
+    What it does not say is how much of that a real retriever can reach: a retriever returns gold
+    PLUS whatever else it ranks highly, so its ceiling is V8, not V1. Where V8 is far below V1 the
+    published headroom is unreachable, and a consumer reading it will buy retrieval work that cannot
+    help.
+
+    Measured, the two kinds look nothing alike and read identically today:
+
+        episodic/list-order     V1 1.00  V8 1.00  V9 0.27  ->  RETRIEVAL-limited, headroom real
+        prospective/due-window  V1 1.00  V8 0.22  V9 0.06  ->  REASONING-limited, headroom is not
+
+    So both numbers ship, and the classification with them.
+    """
+    def rate(arm: str) -> float | None:
+        applicable = [r for r in group if r.get(arm) is not None]
+        return (sum(1 for r in applicable if r[arm]) / len(applicable)) if applicable else None
+
+    v1, v8, v9 = rate("v1"), rate("v8"), rate("v9")
+    if v1 is None or v9 is None:
+        return {}
+
+    headroom = v1 - v9
+    row = {
+        "headroom_perfect_selector": round(headroom, 4),
+        "discriminates": headroom >= DISCRIMINATION_FLOOR,
+    }
+    if v8 is not None:
+        # What a real retriever can actually reach: it cannot do better than having everything.
+        row["headroom_reachable"] = round(max(0.0, v8 - v9), 4)
+        row["limited_by"] = "reasoning" if (v1 - v8) > headroom / 2 else "retrieval"
+        row["reading"] = (
+            "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. "
+            "headroom_reachable is V8-V9, what a real retriever can reach, because returning more "
+            "than gold cannot beat having everything. Where these diverge the shape is "
+            "reasoning-limited and retrieval work will not move it.")
+    return row
 
 
 def _median_g(group: list, gold_counts: dict) -> int | None:


### PR DESCRIPTION
Implements [ADR-028](docs/adr/028-typedmemeval-acceptance-on-discrimination.md) §3a and §3e. **No corpus regenerates and no consumer control moves** — the raw arm counts were already recorded, so this is reporting and acceptance only.

## The two kinds of hard

`V1 − V9` is what a **perfect selector** buys — a retriever returning gold and nothing else. A real retriever returns gold *plus* whatever else it ranks highly, so it cannot beat having everything: **its ceiling is V8, not V1.**

| shape | headroom (perfect) | reachable | limited by |
|---|---|---|---|
| `prospective/due-window` | **0.94** | **0.17** | **reasoning** |
| `semantic/co-reference` | 0.40 | 0.27 | retrieval |
| `arithmetic/delta` | 0.90 | 0.90 | retrieval |

`due-window` is the case that motivated the ADR: **0.94 published, 0.17 actually reachable.** A consumer reading 0.94 would buy retrieval work that cannot help. Both figures and the classification now ship in every sidecar.

## The gate

Each shape must clear a **0.15** discrimination floor. It is a **ratchet, not a wall** — for the reason the coverage ratchet beside it gives: a gate that stays red for the life of a known-weak shape stops being read, and a regression introduced while fixing something else then lands invisibly.

Two lists, both carrying their reason:

**Saturated by design** — WorkingMemory's three short ladder rungs. The gradient across the ladder *is* the measurement; deleting the saturation at the short end deletes its low end. **These must never be "fixed" from a headroom table read without the design note.**

**Pending redesign** — `temporal/occurrence-order` (0.05), `bitemporal/belief-at-instant` (0.11). Near-closed-choice forms where the question names the entity it asks about — the same structural cap that limited `participant-attribution` to 0.20 after calibration. They likely need new *question forms* rather than tuning.

Listed shapes may improve and may not regress; anything unlisted must clear the floor outright.

## Verification

**Red-first:** raising the floor to 0.25 turns three verticals red. Restored — **1073/1073** green.

**The 0.15 floor is a judgement, not a measurement.** Nothing in the data derives it; it sits where the distribution has a natural gap — three shapes at 0.00, two between 0.05 and 0.11, twenty-five at 0.17 or above — and should be revisited once a second reference retriever exists, because the entire scale is BM25-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ