### PR TITLE
TypedMemEval: withdraw ADR-028 §10's convergence claim; four verticals move

### DIFF
--- a/docs/adr/028-typedmemeval-acceptance-on-discrimination.md
+++ b/docs/adr/028-typedmemeval-acceptance-on-discrimination.md
@@ -187,6 +187,69 @@ the instrument and re-baselining on it are separate decisions, and only the firs
 This is what the structural dry run is for: it answered a question that would otherwise have been
 settled by spending.
 
+## 11. Correction to §10, same day — the convergence claim was wrong, and so was the decision
+
+§10 concluded that the corrected search picks the same echoes as the bisection it replaced, and
+therefore that **"the code fix ships and the re-baseline does not."** Both halves are withdrawn.
+
+| §10 published | Corrected |
+|---|---|
+| "The two searches converge to the same answer, including on both non-monotone shapes." | Holds for `episodic` and `semantic`. **Fails for `arithmetic` and `conjunction`.** |
+| "The old bisection landed correctly by luck rather than by construction." | It landed correctly *on the two verticals that were measured*. |
+| "Correcting the instrument and re-baselining on it are separate decisions, and only the first is justified here." | The separation is still the right principle. The conclusion drawn from it was wrong. |
+| `episodic/assistant-stated` 0.75 → 0.625; `participant-attribution` 0.625 → 0.617 | **Spurious.** Both are stable. |
+
+Measured through the real calibration entry points, with no model calls:
+
+| vertical | shipped → corrected | vertical mean |
+|---|---|---|
+| `arithmetic` | `delta` 0.3125 → **1.0** | 0.758 → 0.609 |
+| `conjunction` | all three shapes move | 0.581 → **0.632** |
+| `prospective` | `due-window` 0.125 → 0.0, `expiring-validity` 0.625 → 0.875, `not-yet-true` 0.75 → 0.625 | 0.617 → 0.592 |
+| `workingmemory` | 0.75 → 0.875 | **0.867 → 0.683** |
+| `forgetting` | 0.25 → 0.125 | 0.629 → 0.629 |
+| `episodic`, `semantic` | unchanged | unchanged |
+
+Conjunction's mean moves **toward** the 0.70 target, not away: the shipped calibration was not
+merely different, it was further from the band the search aims at.
+
+**Two questions, not one, and they have different answers.** A moved echo means the recorded
+sidecar is inaccurate; it does not by itself mean the corpus changed. `forgetting` is the case that
+separates them -- its echo moves and its corpus regenerates BYTE-IDENTICALLY, so its published
+measurements stand and it is owed no probe run. The re-probe list therefore comes from
+`tools/check_corpus_reproducibility.py`, which compares corpus bytes, and not from the echo diff.
+
+**A consequence for §3a's exemption list.** WorkingMemory's three ladder rungs are exempted at
+headroom 0.00 as declared design. That vertical's coverage falls 0.867 → 0.683 under the corrected
+search, so part of the saturation the exemption describes may be a search artefact rather than the
+ladder. The exemption is re-examined against the re-baselined numbers rather than carried forward on
+its original reasoning.
+
+### Two causes, and the second is the one worth keeping
+
+**Scope.** Six shapes across two verticals were measured and a conclusion was written about nine.
+
+**Method — and this is §5b's own lesson, repeated inside the measurement meant to settle §5b.** The
+convergence table called the search per shape directly instead of going through
+`calibrate_per_shape`, which pins each shape's knob as it advances. Off-pipeline it invented
+movement in `episodic` and never touched the two verticals that actually move. §5b already records:
+*"When measuring a pipeline, go through the pipeline."* It was written after the first monotone
+measurement was invalid for the same reason, and then not applied to the second.
+
+**The instrument that settles it is `tools/compare_calibration_search.py`,** which recomputes every
+vertical through the real calibration entry point and diffs against the shipped sidecar. It costs
+nothing to run because calibration is structural. It exists so this question is answered by a
+command rather than by an argument, and so a shape whose echo does NOT move is never regenerated for
+tidiness.
+
+### Consequence
+
+The re-baseline proceeds as its own arc, which is also what the consuming project's coordinator
+independently asked for on cost grounds — their reasoning (the controls a reset would destroy are
+already lapsed or unheld, so now is the cheap moment) and this measurement (the echoes genuinely
+move) are independent arguments reaching the same place. Cheap and warranted are different claims;
+this section supplies the second.
+
 ## 9. Provenance
 
 The finding came out of a question about whether the `value-then-count` repair was the best

--- a/tools/compare_calibration_search.py
+++ b/tools/compare_calibration_search.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Recomputes every vertical's calibration under the CURRENT search and diffs it against what shipped.
+
+WHY THIS EXISTS. `search_echo` used to bisect on a monotone it asserted and never measured, and
+2 of 3 shapes tested are not monotone (ADR-028 s10). Bisection on a non-monotone function returns
+wherever the bracket started, so every shipped echo was potentially an artefact of the search path
+rather than a property of the corpus. The search is fixed; the question this answers is whether the
+fix CHANGES ANYTHING, which is a different question and has to be measured separately.
+
+IT COSTS NOTHING TO RUN. Calibration is structural -- BM25 over generated text, no model calls -- so
+what the new search picks is knowable before committing to a re-probe. A shape whose echo does not
+move needs no new probe run: same echo, same seed, same generator means the same corpus bytes.
+That is the whole point. Re-baselining is priced in probe calls; this tells you which shapes are
+actually owed one.
+
+Read the output as a WORK LIST, not a verdict: `moved` shapes need regeneration and a re-probe,
+`stable` shapes are already correct and must not be regenerated for tidiness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import pathlib
+import inspect
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+import typedmemeval_common as tmc  # noqa: E402
+
+DATA = pathlib.Path(__file__).resolve().parents[1] / "src/AgentEval.Memory/Data/typedmemeval"
+
+#: Verticals opting into per-shape calibration, mirroring each generator's `shape_of` argument.
+#: Listed rather than introspected because the generators only pass it inside `__main__`, which
+#: does not run on import -- reading it back would mean executing a full generation to learn it.
+PER_SHAPE = {"arithmetic", "conjunction", "episodic", "prospective", "semantic"}
+
+
+def shipped(vertical: str) -> dict:
+    path = next((DATA / vertical).glob("*.meta.json"))
+    return json.loads(path.read_text(encoding="utf-8"))["coverage"]
+
+
+def recompute(vertical: str) -> tuple[dict[str, float], float, float]:
+    """Returns (echo_by_shape, overall echo, mean) under the search as it stands today."""
+    module = importlib.import_module(f"gen_typedmemeval_{vertical}")
+    # Read from the signature rather than a positional index into __defaults__, so adding a
+    # keyword to finalise cannot silently re-point this at the wrong value.
+    seed = inspect.signature(tmc.finalise).parameters["seed"].default
+    if vertical in PER_SHAPE:
+        _, cal = tmc.calibrate_per_shape(
+            module.build, seed, lambda q: (q.extension or {}).get("shape"))
+        return cal.echo_by_shape, cal.echo, cal.mean
+    _, cal = tmc.calibrate(module.build, seed)
+    return {}, cal.echo, cal.mean
+
+
+def compare(vertical: str) -> dict:
+    was = shipped(vertical)
+    by_shape, echo, mean = recompute(vertical)
+    rows = []
+    if by_shape:
+        old = was.get("echo_by_shape") or {}
+        for shape in sorted(set(by_shape) | set(old)):
+            a, b = old.get(shape), by_shape.get(shape)
+            rows.append({"shape": shape, "shipped": a, "recomputed": b,
+                         "moved": a is None or b is None or abs(a - b) > 1e-9})
+    else:
+        a, b = was.get("echo"), echo
+        rows.append({"shape": "(single knob)", "shipped": a, "recomputed": b,
+                     "moved": abs(a - b) > 1e-9})
+    return {"vertical": vertical, "shipped_mean": was.get("mean_realised"),
+            "recomputed_mean": round(mean, 4), "rows": rows,
+            "moved": any(r["moved"] for r in rows)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("verticals", nargs="*", default=sorted(tmc.VERTICALS))
+    parser.add_argument("--json", type=pathlib.Path)
+    args = parser.parse_args()
+
+    results = []
+    for vertical in args.verticals:
+        result = compare(vertical)
+        results.append(result)
+        flag = "MOVED" if result["moved"] else "stable"
+        print(f"\n== {vertical}  [{flag}]  mean {result['shipped_mean']} -> {result['recomputed_mean']}")
+        for row in result["rows"]:
+            mark = "  <-- MOVED" if row["moved"] else ""
+            print(f"   {row['shape']:26} shipped {str(row['shipped']):8} -> {str(row['recomputed']):8}{mark}")
+        sys.stdout.flush()
+
+    moved = [r["vertical"] for r in results if r["moved"]]
+    print(f"\n{'=' * 60}\nverticals whose calibration MOVES: {moved or 'none'}")
+    print("shapes owed a re-probe:",
+          sum(1 for r in results for row in r["rows"] if row["moved"]))
+    if args.json:
+        args.json.write_text(json.dumps(results, indent=1), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -983,6 +983,9 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
     by_id = {r["question_id"]: r for r in records}
     shapes = {e["question_id"]: (e.get("typedmemeval") or {}).get("shape") for e in entries}
     gold_counts = {e["question_id"]: len(e.get("answer_session_ids") or []) for e in entries}
+    # Paired arms, for the shapes that have them. See _pair_discrimination.
+    arms = {e["question_id"]: ((e.get("typedmemeval") or {}).get("pair_id"),
+                               (e.get("typedmemeval") or {}).get("arm")) for e in entries}
 
     # Pair flip (V1p). Both arms must be answerable AND their answers must differ, which is what
     # makes the before/after design capable of showing anything at all.
@@ -1138,6 +1141,7 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
                 "v9_passed": sum(1 for r in group if r.get("v9") is True),
                 "required_sessions_median": _median_g(group, gold_counts),
                 **_discrimination(group),
+                **_pair_discrimination(group, arms),
             }
             for shape, group in sorted(
                 {s: [r for r in records if shapes.get(r["question_id"]) == s]
@@ -1198,6 +1202,69 @@ def _discrimination(group: list[dict]) -> dict:
             "headroom_reachable is V8-V9, what a real retriever can reach, because returning more "
             "than gold cannot beat having everything. Where these diverge the shape is "
             "reasoning-limited and retrieval work will not move it.")
+    return row
+
+
+def _pair_discrimination(group: list[dict], arms: dict) -> dict:
+    """For a shape built as PAIRED ARMS, score the pair rather than the arm. ADR-028 SS7.4.
+
+    Bitemporal asks one haystack on two clocks: valid time (what is true) and transaction time
+    (what the record said at a named earlier instant). Measured on the shipped corpus, all 30 pairs
+    have DIFFERENT correct answers and DISJOINT gold, so answering one arm tells you nothing about
+    the other -- and a system that answers valid-time whatever it is asked scores 1.0 on one arm and
+    0.0 on the other. Per-question `V1 - V9` averages those two into a middling number and cannot
+    see the difference. The unit of capability here is the PAIR, so the pair is the unit of
+    measurement, and this is the number a consumer should read for this vertical.
+
+    THE CAVEAT IS PART OF THE NUMBER, and it is why this ships alongside `headroom_perfect_selector`
+    rather than replacing it. A conjunction of two measurements is harder than either, so pair
+    headroom is WIDER than per-question headroom by construction -- for independent arms it scales
+    by roughly (V1_arm + V9_arm), about 1.7x at these rates. Reading 0.17 here as comparable to 0.17
+    on an unpaired shape would be reading an artefact of the conjunction. `pair_floor_scaled` is the
+    discrimination floor multiplied by that same factor, so the comparison is like for like; on the
+    shipped corpus belief-at-instant cleared the raw floor and MISSED the scaled one, which is the
+    honest reading and the one that kept it on the redesign list.
+    """
+    paired = [(r, arms.get(r["question_id"], (None, None))) for r in group]
+    pairs: dict[str, dict[str, dict]] = {}
+    for record, (pair_id, arm) in paired:
+        if pair_id and arm:
+            pairs.setdefault(pair_id, {})[arm] = record
+    complete = [a for a in pairs.values() if len(a) == 2]
+    if not complete:
+        return {}
+
+    def both(key: str) -> tuple[int, int]:
+        usable = [a for a in complete if all(r.get(key) is not None for r in a.values())]
+        return sum(1 for a in usable if all(r[key] for r in a.values())), len(usable)
+
+    v1_hits, v1_n = both("v1")
+    v9_hits, v9_n = both("v9")
+    if not v1_n or not v9_n:
+        return {}
+
+    def arm_rate(key: str) -> float:
+        usable = [r for r in group if r.get(key) is not None]
+        return (sum(1 for r in usable if r[key]) / len(usable)) if usable else 0.0
+
+    pair_headroom = v1_hits / v1_n - v9_hits / v9_n
+    amplification = arm_rate("v1") + arm_rate("v9")
+    row = {
+        "pairs": len(complete),
+        "pair_v1_both_arms": f"{v1_hits}/{v1_n}",
+        "pair_v9_both_arms": f"{v9_hits}/{v9_n}",
+        "pair_headroom": round(pair_headroom, 4),
+        "pair_floor_scaled": round(DISCRIMINATION_FLOOR * amplification, 4),
+        "pair_discriminates": pair_headroom >= DISCRIMINATION_FLOOR * amplification,
+    }
+    v8_hits, v8_n = both("v8")
+    if v8_n:
+        row["pair_v8_both_arms"] = f"{v8_hits}/{v8_n}"
+    row["pair_reading"] = (
+        "Both arms of one pair scored together, because a system that answers only the valid-time "
+        "arm has not shown it can represent two clocks. Compare pair_headroom against "
+        "pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens "
+        "headroom mechanically, and the scaled floor removes that gain rather than banking it.")
     return row
 
 
@@ -1328,11 +1395,66 @@ def self_test() -> None:
     check("silence is named on every arm it blocked",
           sorted(set(rec.get("silent_arms") or [])), ["v1", "v2", "v3", "v6", "v8", "v9"])
 
+    # ---- the paired-arm instrument -------------------------------------------------------
+    #
+    # A conjunction of two measurements is HARDER than either, so pair headroom is wider than
+    # per-question headroom by construction. That makes it a tempting way to talk a weak shape over
+    # the bar, and these cases exist to stop that: the scaled floor must reject the very shape whose
+    # raw pair headroom clears the unscaled one.
+    def paired(spec: list[tuple[dict, dict]]) -> tuple[list[dict], dict]:
+        """`spec` is one (valid_arm, transaction_arm) outcome dict per pair."""
+        records, arms = [], {}
+        for index, (valid, txn) in enumerate(spec):
+            for arm, outcome in (("valid-time", valid), ("transaction-time", txn)):
+                qid = f"q{index}-{arm}"
+                records.append({"question_id": qid, **outcome})
+                arms[qid] = (f"p{index}", arm)
+        return records, arms
+
+    hit = {"v1": True, "v8": True, "v9": True}
+    # Reproduces the shipped belief-at-instant distribution exactly: valid V1 18/18 V9 17/18,
+    # transaction V1 17/18 V9 14/18, both-arms V1 17/18 V9 14/18.
+    spec = [({**hit, "v9": False}, {**hit, "v1": False, "v9": False})]    # both arms fail V9
+    spec += [({**hit}, {**hit, "v9": False}) for _ in range(3)]           # transaction fails V9
+    spec += [({**hit}, {**hit}) for _ in range(14)]
+    records, arms = paired(spec)
+    row = _pair_discrimination(records, arms)
+    check("pair count", row["pairs"], 18)
+    check("both arms at V1", row["pair_v1_both_arms"], "17/18")
+    check("both arms at V9", row["pair_v9_both_arms"], "14/18")
+    check("pair headroom", row["pair_headroom"], 0.1667)
+    # 0.15 * (35/36 + 31/36). The raw floor is 0.15 and this shape's pair headroom is 0.1667, so an
+    # unscaled comparison would PASS it -- the conjunction's mechanical gain banked as discrimination.
+    check("floor is scaled by the amplification", row["pair_floor_scaled"], 0.275)
+    check("a shape that clears the RAW floor still fails the SCALED one",
+          row["pair_discriminates"], False)
+
+    # The other direction: a genuinely separating shape must still pass, or the scaled floor is
+    # merely a way of failing everything.
+    strong = [({**hit}, {**hit}) for _ in range(12)]
+    for index in range(5):
+        strong[index] = ({**hit, "v9": False}, {**hit, "v9": False})
+    records, arms = paired(strong)
+    row = _pair_discrimination(records, arms)
+    check("a separating shape passes", row["pair_discriminates"], True)
+    check("its pair headroom", row["pair_headroom"], round(1.0 - 7 / 12, 4))
+
+    # Unpaired shapes must emit NOTHING rather than a degenerate row -- eight of the nine verticals
+    # have no arms, and a zero-filled block there would read as a measured result.
+    unpaired = [{"question_id": "solo", **hit}]
+    check("unpaired shapes publish no pair block",
+          _pair_discrimination(unpaired, {"solo": (None, None)}), {})
+    # A half-collected pair is not a pair: one arm missing means the conjunction is undefined.
+    half, half_arms = paired([({**hit}, {**hit})])
+    half, half_arms = half[:1], {half[0]["question_id"]: half_arms[half[0]["question_id"]]}
+    check("a pair missing an arm is skipped", _pair_discrimination(half, half_arms), {})
+
     if failures:
         for f in failures:
             print(f"self-test FAIL  {f}")
         raise SystemExit(1)
-    print("self-test OK  (10 evidence-screen cases, 6 arm-attribution cases, 7 silence cases)")
+    print("self-test OK  (10 evidence-screen cases, 6 arm-attribution cases, 7 silence cases, "
+          "8 paired-arm cases)")
 
 
 def restamp_empty_rates_from_cache(verticals: list[str]) -> None:

--- a/tools/typedmemeval_common.py
+++ b/tools/typedmemeval_common.py
@@ -2185,6 +2185,39 @@ def finalise(
 
     out_dir = DATA_ROOT / vertical
     out_dir.mkdir(parents=True, exist_ok=True)
+    # MEASUREMENTS SURVIVE A REGENERATION THAT CHANGED NOTHING.
+    #
+    # This used to reset `probes` to "not_run" unconditionally, so rebuilding a corpus to CHECK
+    # something destroyed the probe records even when the rebuild produced identical bytes -- 1141
+    # lines of reference-model results and `gold_item_types` wiped by a verification step that found
+    # nothing wrong. The records were recoverable from git, but only because the sha happened to be
+    # unchanged, and that is exactly the condition worth deciding on rather than relying on.
+    #
+    # THE CONDITION IS THE CORPUS HASH, and it is the same binding the probe records already carry:
+    # a probe result describes the bytes it was measured against, so it stays valid for those bytes
+    # and for no others. Where the hash matches, carrying the records forward is not a convenience,
+    # it is the correct reading. Where it differs, "not_run" remains the only honest state, and
+    # restoring the old block from version control would be a DEFECT -- stale measurements attached
+    # to a corpus that never produced them.
+    existing = out_dir / f"{corpus_id}.meta.json"
+    if existing.exists():
+        try:
+            previous = json.loads(existing.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            previous = {}
+        if previous.get("corpus_sha256") == corpus_sha:
+            for carried in ("probes", "gold_item_types"):
+                if carried in previous:
+                    metadata[carried] = previous[carried]
+            # V7 is the one probe the generator owns and has just recomputed from the questions in
+            # hand, so it is put back on top of the restored block rather than carried.
+            metadata["probes"]["v7_separability"] = {
+                **separability_report(questions, structure.separability_exempt),
+                "status": "run",
+                "measured_by": "generator",
+                "probed_corpus_sha256": corpus_sha,
+            }
+
     (out_dir / f"{corpus_id}.json").write_text(corpus_json, encoding="utf-8", newline="\n")
     (out_dir / f"{corpus_id}.meta.json").write_text(_dump(metadata), encoding="utf-8", newline="\n")
 


### PR DESCRIPTION
## What this corrects

[#210](https://github.com/joslat/AgentEval/pull/210) fixed the calibration search — bisection over a monotone that 2 of 3 shapes violate, replaced with a sweep plus local refinement. ADR-028 §10 then measured whether the fix *changes* anything, concluded it does not, and decided the re-baseline was unnecessary. **That conclusion is withdrawn.**

| §10 published | Corrected |
|---|---|
| "Both searches converge to the same echoes, including on both non-monotone shapes." | Holds for `episodic` and `semantic`. Fails for `arithmetic`, `conjunction`, `prospective`, `workingmemory`, `forgetting`. |
| "The code fix ships and the re-baseline does not." | Withdrawn — the re-baseline is warranted. |
| `episodic` echoes 0.75→0.625, 0.625→0.617 | Spurious. Both stable. |

**Direction of error: flattering** — it claimed less work was needed and that shipped corpora were unaffected.

Two causes. Scope: six shapes in two verticals, generalised to nine. Method: the convergence table called the search per shape instead of going through `calibrate_per_shape`, which pins each knob as it advances — so it invented movement in `episodic` and never touched the verticals that move. §5b already records *"when measuring a pipeline, go through the pipeline"*, written after the same mistake.

No published arm result changes: echo is a difficulty knob, not a correctness property. What changes is that `arithmetic`'s and `conjunction`'s published *difficulty* is partly a search-path artefact.

## The movement map (structural, zero model calls)

| vertical | shipped → corrected | mean |
|---|---|---|
| `arithmetic` | `delta` 0.3125 → **1.0** | 0.758 → 0.609 |
| `conjunction` | all three shapes | 0.581 → **0.632** (toward target) |
| `prospective` | three of five shapes | 0.617 → 0.592 |
| `workingmemory` | 0.75 → 0.875 | **0.867 → 0.683** |
| `forgetting` | 0.25 → 0.125 | unchanged |
| `episodic`, `semantic` | unchanged | unchanged |

`tools/compare_calibration_search.py` is the instrument. It costs nothing to run, which is the point: a shape whose echo does not move is never regenerated for tidiness.

**A moved echo is not a changed corpus.** `forgetting`'s echo moves and its corpus regenerates byte-identically — its sidecar is inaccurate, its measurements stand, and it is owed no probe run.

## Score the pair, not the arm

Bitemporal asks one haystack on two clocks. All 30 pairs have **different correct answers and disjoint gold**, so a system that answers valid-time whatever it is asked scores 1.0 on one arm and 0.0 on the other — and per-question `V1 − V9` averages that into a number that cannot see it.

The caveat ships as part of the number. Conjunction widens headroom mechanically (~1.7×), so `pair_floor_scaled` scales the floor by the same factor:

| shape | per-question | pair | scaled floor | verdict |
|---|---|---|---|---|
| `belief-at-instant` | 0.111 | 0.167 | 0.275 | still fails |
| `correction-depth` | 0.292 | 0.417 | 0.256 | clears |

`belief-at-instant` clears the raw 0.15 floor and misses the scaled one. Banking the conjunction's mechanical gain would have been the artifact supplying its own pass. Eight self-test cases pin both directions.

## A no-op regeneration no longer destroys measurements

`finalise()` reset `probes` to `not_run` unconditionally, so rebuilding a corpus to *check* something wiped 1141 lines of reference-model results for a byte-identical rebuild. The condition is the corpus hash — the binding the probe records already carry. Where it matches, carrying them forward is correct; where it differs, `not_run` is the only honest state.

## Not in this PR

The regenerated corpora, the two corpus fixes (`temporal/occurrence-order`, `bitemporal/belief-at-instant`), and the CI reproducibility gate land with the re-baseline arc — the gate would be red until the corpora are regenerated, and a gate that lands red is one people learn to skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ