### PR TITLE
TypedMemEval: calibration is an authoring step, not a build step

### DIFF
--- a/.github/workflows/corpus-reproducibility.yml
+++ b/.github/workflows/corpus-reproducibility.yml
@@ -1,0 +1,46 @@
+name: TypedMemEval corpus reproducibility
+
+# Every TypedMemEval sidecar records `generator.tool`, `generator.version` and `generator.seed`,
+# which together assert that the committed corpus is reproducible from the committed generator.
+# Nothing tested that assertion until this job, and it had already stopped being true: PR #210
+# replaced the calibration search (bisection over a monotone that 2 of 3 shapes violate) with a
+# sweep plus local refinement, which is the correct fix and which changes the echo four verticals
+# converge on. The corpora were not regenerated with it, so the generators no longer produced the
+# files beside them and no gate said so.
+#
+# WHY IT IS FAST NOW. Calibration is pinned: a plain rebuild uses the echo the sidecar records
+# instead of searching for one, so this re-derives nine corpora in seconds rather than re-running a
+# sweep per shape. That is also the fix for the underlying problem -- a corpus is now a function of
+# (generator, seed, recorded echo) rather than of whichever search algorithm happened to be checked
+# in. `--recalibrate` is the deliberate act that moves a corpus, and it obliges a re-probe.
+#
+# SCOPED BY PATH, NOT BY SCHEDULE. Reproducibility can only break when a generator or the shared
+# generation code changes, so that is when this runs -- on the change that could break it, while
+# that change is still in review. A nightly job would have reported this days after the PR merged,
+# to nobody in particular.
+on:
+  pull_request:
+    paths:
+      - 'tools/gen_typedmemeval_*.py'
+      - 'tools/typedmemeval_common.py'
+      - 'tools/check_corpus_reproducibility.py'
+      - 'src/AgentEval.Memory/Data/typedmemeval/**'
+
+permissions:
+  contents: read
+
+jobs:
+  reproduce:
+    runs-on: ubuntu-latest
+    # Pinned rebuilds do no searching, so nine verticals take well under a minute. The allowance is
+    # for a runner under load, not for the work.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Regenerate every corpus and compare bytes
+        # The checker restores the tree whatever the outcome, so a failure here leaves nothing
+        # behind to clean up and the diff it reports is the whole story.
+        run: python tools/check_corpus_reproducibility.py

--- a/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/arithmetic/agenteval-typedmemeval-arithmetic-v5.meta.json
@@ -83,8 +83,8 @@
     },
     "per_shape_realised": {
       "count": 0.8274,
-      "delta": 0.7767,
-      "duration": 0.6528,
+      "delta": 0.735,
+      "duration": 0.625,
       "sum": 0.8179
     }
   },
@@ -553,7 +553,7 @@
       "worst_refused_auc": 0.6615,
       "worst_role_sequence": null,
       "role_sequence_auc": 0.5,
-      "worst_gold_marker_ngram": "against the",
+      "worst_gold_marker_ngram": "payment logged against",
       "gold_marker_ngram_auc": 0.6615,
       "worst_boilerplate_ngram": "on the",
       "boilerplate_ngram_auc": 0.572,

--- a/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/conjunction/agenteval-typedmemeval-conjunction-v5.meta.json
@@ -81,7 +81,7 @@
       "value-then-count": 0.25
     },
     "per_shape_realised": {
-      "alias-then-count": 0.3444,
+      "alias-then-count": 0.3356,
       "order-then-value": 0.7067,
       "value-then-count": 0.6708
     }

--- a/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/forgetting/agenteval-typedmemeval-forgetting-v5.meta.json
@@ -428,7 +428,7 @@
       "worst_refused_auc": 0.6521,
       "worst_role_sequence": null,
       "role_sequence_auc": 0.5,
-      "worst_gold_marker_ngram": "or near",
+      "worst_gold_marker_ngram": "or near enough",
       "gold_marker_ngram_auc": 0.6061,
       "worst_boilerplate_ngram": "of",
       "boilerplate_ngram_auc": 0.5754,

--- a/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/semantic/agenteval-typedmemeval-semantic-v5.meta.json
@@ -81,7 +81,7 @@
       "source-attribution": 0.875
     },
     "per_shape_realised": {
-      "co-reference": 0.6889,
+      "co-reference": 0.7222,
       "current-value": 0.6,
       "source-attribution": 0.7333
     }

--- a/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/workingmemory/agenteval-typedmemeval-workingmemory-v5.meta.json
@@ -739,7 +739,7 @@
       "bimodal_features": {},
       "passed": true,
       "status": "run",
-      "measured_at": "2026-08-21T15:10:22Z",
+      "measured_by": "generator",
       "probed_corpus_sha256": "7e04e4cb1717cbbfb1ee0afe3b18c86b9364859bb1442ad2f4419ece301af7a0"
     },
     "reference_deployment": "gpt-5.5",

--- a/tools/compare_calibration_search.py
+++ b/tools/compare_calibration_search.py
@@ -43,8 +43,8 @@ def shipped(vertical: str) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))["coverage"]
 
 
-def recompute(vertical: str) -> tuple[dict[str, float], float, float]:
-    """Returns (echo_by_shape, overall echo, mean) under the search as it stands today."""
+def recompute(vertical: str) -> tuple[dict[str, float], float, float, dict[str, float]]:
+    """Returns (echo_by_shape, overall echo, mean, per_shape_realised) under today's search."""
     module = importlib.import_module(f"gen_typedmemeval_{vertical}")
     # Read from the signature rather than a positional index into __defaults__, so adding a
     # keyword to finalise cannot silently re-point this at the wrong value.
@@ -52,20 +52,33 @@ def recompute(vertical: str) -> tuple[dict[str, float], float, float]:
     if vertical in PER_SHAPE:
         _, cal = tmc.calibrate_per_shape(
             module.build, seed, lambda q: (q.extension or {}).get("shape"))
-        return cal.echo_by_shape, cal.echo, cal.mean
+        return cal.echo_by_shape, cal.echo, cal.mean, cal.per_shape
     _, cal = tmc.calibrate(module.build, seed)
-    return {}, cal.echo, cal.mean
+    return {}, cal.echo, cal.mean, {}
 
 
 def compare(vertical: str) -> dict:
     was = shipped(vertical)
-    by_shape, echo, mean = recompute(vertical)
+    by_shape, echo, mean, realised = recompute(vertical)
     rows = []
     if by_shape:
         old = was.get("echo_by_shape") or {}
         for shape in sorted(set(by_shape) | set(old)):
             a, b = old.get(shape), by_shape.get(shape)
+            # COVERAGE, not just the knob. A moved echo says the search chose differently; only
+            # the realised coverage says whether it chose BETTER, and "better" here means closer to
+            # BAND_TARGET. A shape pinned at echo 1.0 whose coverage is still above the band is not
+            # improved, it is SATURATED and cannot be calibrated at all -- which is a finding about
+            # the corpus rather than a win for the search.
+            was_cov = (was.get("per_shape_realised") or {}).get(shape)
+            now_cov = realised.get(shape)
+            closer = None
+            if was_cov is not None and now_cov is not None:
+                closer = abs(now_cov - tmc.BAND_TARGET) < abs(was_cov - tmc.BAND_TARGET)
             rows.append({"shape": shape, "shipped": a, "recomputed": b,
+                         "coverage_shipped": was_cov, "coverage_now": now_cov,
+                         "closer_to_target": closer,
+                         "saturated": now_cov is not None and now_cov > tmc.BAND_HIGH,
                          "moved": a is None or b is None or abs(a - b) > 1e-9})
     else:
         a, b = was.get("echo"), echo
@@ -90,7 +103,12 @@ def main() -> int:
         print(f"\n== {vertical}  [{flag}]  mean {result['shipped_mean']} -> {result['recomputed_mean']}")
         for row in result["rows"]:
             mark = "  <-- MOVED" if row["moved"] else ""
-            print(f"   {row['shape']:26} shipped {str(row['shipped']):8} -> {str(row['recomputed']):8}{mark}")
+            verdict = ("" if row.get("closer_to_target") is None
+                       else ("  CLOSER to target" if row["closer_to_target"] else "  FURTHER from target"))
+            if row.get("saturated"):
+                verdict += "  SATURATED (above the band at every echo)"
+            print(f"   {row['shape']:26} echo {str(row['shipped']):8} -> {str(row['recomputed']):8}"
+                  f" cov {str(row['coverage_shipped']):8} -> {str(row['coverage_now']):8}{mark}{verdict}")
         sys.stdout.flush()
 
     moved = [r["vertical"] for r in results if r["moved"]]

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -1224,6 +1224,20 @@ def _pair_discrimination(group: list[dict], arms: dict) -> dict:
     discrimination floor multiplied by that same factor, so the comparison is like for like; on the
     shipped corpus belief-at-instant cleared the raw floor and MISSED the scaled one, which is the
     honest reading and the one that kept it on the redesign list.
+
+    THE SCALING IS A HEURISTIC AND ITS ASSUMPTION IS MEASURABLY FALSE. (q^2 - p^2) = (q - p)(q + p)
+    holds when the arms are INDEPENDENT. They are not: both arms read the same haystack, and on the
+    shipped corpus pair-V9 came in at 14/18 = 0.778 against the 0.735 independence predicts, so the
+    arms are positively correlated and the true amplification is SMALLER than (V1 + V9). The scaled
+    floor is therefore conservative -- it can fail a shape that would survive an exact correction,
+    and the verdict on belief-at-instant turns on precisely that margin (0.167 against 0.275, where
+    the unscaled floor would have passed it).
+
+    SO THE FLOOR IS NOT WHAT CARRIES THE belief-at-instant VERDICT, and it should not be quoted as
+    though it were. What carries it is the raw separation: 3 pairs out of 18, against a binomial
+    standard error near 1.75 pairs -- about 1.7 sd, which no reading of the amplification rescues.
+    A shape whose entire discrimination is three pairs on n=18 cannot rank two systems whatever
+    floor it is compared against, and the sample size is itself worth revisiting.
     """
     paired = [(r, arms.get(r["question_id"], (None, None))) for r in group]
     pairs: dict[str, dict[str, dict]] = {}

--- a/tools/typedmemeval_common.py
+++ b/tools/typedmemeval_common.py
@@ -44,6 +44,7 @@ import json
 import math
 import random  # DevSkim: ignore DS148264 - corpus generation must be replayable under a seed; a CSPRNG cannot be seeded to reproduce a draw, and this selects filler text, not secrets.
 import re
+import sys
 import unicodedata
 from collections import Counter
 from dataclasses import dataclass, field
@@ -1963,6 +1964,16 @@ def calibrate_per_shape(build, seed: int, shape_of, max_iterations: int = 24
         iterations += iters
 
     questions = attempt(echo_map)
+    # RE-READ PER-SHAPE COVERAGE FROM THE FINAL CORPUS. `per_shape` used to hold each shape's
+    # `best_mean` -- the value its search saw, taken while every LATER shape's knob was still 0.0.
+    # The final build sets them all, which moves the earlier shapes, so the published number
+    # described a corpus that was never shipped: arithmetic reported delta 0.7767 against an actual
+    # 0.7350, and conjunction alias-then-count 0.3444 against 0.3356. Small, and exactly the class
+    # this family keeps finding -- a published figure measured off the artifact it names.
+    for shape in shapes:
+        values = scored(questions, shape)
+        if values:
+            per_shape[shape] = round(sum(values) / len(values), 4)
     per_q = {q.question_id: realised_coverage(q) for q in questions}
     mean = measurable_coverage_mean(questions)
     return questions, Calibration(
@@ -2036,6 +2047,112 @@ def _dump(payload) -> str:
     return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
 
 
+def calibrate_pinned(build, seed: int, echo, shape_of=None,
+                     iterations: int = 0, trace=None) -> tuple[list[Question], Calibration]:
+    """Rebuilds at a RECORDED echo instead of searching for one.
+
+    CALIBRATION IS AN AUTHORING STEP, NOT A BUILD STEP, and treating it as a build step is what
+    broke reproducibility across the whole family. A corpus used to be a function of (generator,
+    seed, SEARCH ALGORITHM): every regeneration re-ran the search, so #210's correction to that
+    search silently desynchronised nine committed corpora from the generators that are supposed to
+    produce them, and the sidecars went on asserting `generator.tool`/`version`/`seed` as though
+    they still reproduced it. Nothing was wrong with the corpora -- they passed every gate and their
+    probe records honestly describe their bytes -- but their provenance claim had quietly become
+    false.
+
+    Pinning makes a corpus a function of (generator, seed, RECORDED ECHO), which is reproducible by
+    construction and removes the failure mode rather than re-fixing it after each search change.
+    The echo is already published in the sidecar, so nothing new has to be stored.
+
+    The band gate still applies. A pinned rebuild landing outside the band means the GENERATOR
+    changed in a way that moved difficulty, which is exactly the case that should stop the build
+    loudly rather than silently re-tune around itself.
+    """
+    per_shape_mode = shape_of is not None
+    questions = build(echo, random.Random(seed))  # DevSkim: ignore DS148264 - deterministic corpus generation
+    # Mirrors the equalisation each search path uses, INCLUDING the argument they differ on:
+    # calibrate_per_shape neutralises at 0.0 because its knob is per shape, while calibrate passes
+    # the single knob through. Getting this wrong reproduces nothing and looks like a generator bug.
+    equalise_echo(questions, 0.0 if per_shape_mode else echo, random.Random(seed + 1))  # DevSkim: ignore DS148264 - see above
+    equalise_reply(questions, random.Random(seed + 3))  # DevSkim: ignore DS148264 - see above
+    equalise_shape(questions, random.Random(seed + 2))  # DevSkim: ignore DS148264 - see above
+
+    per_q = {q.question_id: realised_coverage(q) for q in questions}
+    mean = measurable_coverage_mean(questions)
+    if not (BAND_LOW <= mean <= BAND_HIGH):
+        raise SystemExit(
+            f"calibration gate: rebuilding at the RECORDED echo {echo} gives mean realised coverage "
+            f"{mean:.3f}, outside the [{BAND_LOW}, {BAND_HIGH}] band. The pinned echo no longer "
+            f"suits this generator, which means the generator's difficulty moved. Re-run with "
+            f"--recalibrate to search for a new echo, and re-probe the corpus that produces.")
+
+    per_shape = None
+    if per_shape_mode:
+        grouped: dict[str, list[float]] = {}
+        for q in questions:
+            if q.g > 0:                       # same exclusion measurable_coverage_mean uses
+                grouped.setdefault(shape_of(q), []).append(realised_coverage(q))
+        per_shape = {k: round(sum(v) / len(v), 4) for k, v in sorted(grouped.items()) if v}
+
+    return questions, Calibration(
+        echo=round(sum(echo.values()) / len(echo), 4) if isinstance(echo, dict) else round(echo, 4),
+        mean=round(mean, 4),
+        # The AUTHORING search's count, carried forward: the field describes how this echo was
+        # found, and it was found once. Recomputing it as 0 would be true of this build and would
+        # also rewrite the sidecar on every rebuild, so a reproducible build would still produce a
+        # diff -- which is the property pinning exists to provide.
+        iterations=iterations,
+        per_question=per_q,
+        # Carried for the same reason as `iterations`: the trace records the authoring search that
+        # chose this echo, and dropping it on every rebuild would both lose the record and rewrite
+        # the sidecar that pinning exists to keep stable.
+        trace=list(trace or []),
+        echo_by_shape=({k: round(v, 4) for k, v in sorted(echo.items())}
+                       if isinstance(echo, dict) else None),
+        per_shape=per_shape,
+    )
+
+
+def recorded_echo(vertical: str, corpus_id: str, per_shape: bool):
+    """The (echo, iterations, trace) the sidecar was built at, or (None, 0, []) if nothing to pin."""
+    sidecar = DATA_ROOT / vertical / f"{corpus_id}.meta.json"
+    if not sidecar.exists():
+        return None, 0, []
+    try:
+        coverage = json.loads(sidecar.read_text(encoding="utf-8")).get("coverage") or {}
+    except json.JSONDecodeError:
+        return None, 0, []
+    iterations = coverage.get("iterations") or 0
+    trace = coverage.get("search_trace") or []
+    if per_shape:
+        by_shape = coverage.get("echo_by_shape")
+        return (dict(by_shape) if by_shape else None), iterations, trace
+    # A per-shape vertical's `echo` is the MEAN of its knobs and is not a usable setting, so it is
+    # only read back for verticals that genuinely calibrate on one.
+    if coverage.get("echo_by_shape") is not None:
+        return None, iterations, trace
+    return coverage.get("echo"), iterations, trace
+
+
+def _carry_measurements(previous: dict, rebuilt: dict) -> None:
+    """Copies anything the previous sidecar holds that this build does not produce, at ANY depth.
+
+    Only ever called when the corpus hash matches, which is what makes it correct: a key present in
+    the old sidecar and absent from the new one is a measurement some later tool stamped against
+    these exact bytes, and those bytes have not changed.
+
+    DEPTH IS THE POINT. A top-level-only version of this still dropped WorkingMemory's
+    `structure.retrieval_ceiling`, because `structure` IS rebuilt and the stamped block lives inside
+    it -- so the parent looked "produced" while its contents were quietly lost. Values the build
+    does compute always win; this only fills gaps.
+    """
+    for key, value in previous.items():
+        if key not in rebuilt:
+            rebuilt[key] = value
+        elif isinstance(value, dict) and isinstance(rebuilt[key], dict):
+            _carry_measurements(value, rebuilt[key])
+
+
 def finalise(
     vertical: str,
     build,
@@ -2057,9 +2174,25 @@ def finalise(
     # `shape_of` opts a vertical into PER-SHAPE calibration. Without it the vertical is calibrated
     # on its mean, which is satisfiable by averaging one shape's collapse against another's
     # saturation; with it, every shape must reach its own band on its own knob.
-    questions, calibration = (
-        calibrate_per_shape(build, seed, shape_of) if shape_of is not None
-        else calibrate(build, seed))
+    # BUILD REPRODUCES; AUTHORING RE-SEARCHES. Plain `python gen_typedmemeval_X.py` rebuilds at the
+    # echo the committed sidecar records, so it reproduces the committed corpus byte for byte and
+    # the provenance the sidecar asserts is true. `--recalibrate` runs the search, and is the
+    # deliberate act that moves a corpus and therefore obliges a re-probe.
+    #
+    # sys.argv rather than a parameter: all nine generators call finalise() directly with no CLI of
+    # their own, and threading a flag through every one of them is nine chances to wire it up
+    # differently.
+    recalibrate = "--recalibrate" in sys.argv[1:]
+    pinned, pinned_iterations, pinned_trace = (
+        (None, 0, []) if recalibrate
+        else recorded_echo(vertical, corpus_id, shape_of is not None))
+    if pinned is not None:
+        questions, calibration = calibrate_pinned(
+            build, seed, pinned, shape_of, pinned_iterations, pinned_trace)
+    elif shape_of is not None:
+        questions, calibration = calibrate_per_shape(build, seed, shape_of)
+    else:
+        questions, calibration = calibrate(build, seed)
 
     if len(questions) != expected_count:
         raise SystemExit(
@@ -2206,9 +2339,14 @@ def finalise(
         except json.JSONDecodeError:
             previous = {}
         if previous.get("corpus_sha256") == corpus_sha:
-            for carried in ("probes", "gold_item_types"):
-                if carried in previous:
-                    metadata[carried] = previous[carried]
+            # EVERY key the previous sidecar carries that this build does not produce. An allowlist
+            # drifts: it started as ("probes", "gold_item_types") and silently dropped
+            # WorkingMemory's `retrieval_ceiling`, which is stamped by yet another tool. When the
+            # corpus hash matches, any such key is BY DEFINITION a measurement of these exact bytes,
+            # so carrying it is the correct reading and enumerating them is not.
+            _carry_measurements(previous, metadata)
+            if "probes" in previous:
+                metadata["probes"] = previous["probes"]
             # V7 is the one probe the generator owns and has just recomputed from the questions in
             # hand, so it is put back on top of the restored block rather than carried.
             metadata["probes"]["v7_separability"] = {


### PR DESCRIPTION
## The problem

A corpus was a function of (generator, seed, **search algorithm**). Every regeneration re-ran the echo search — so [#210](https://github.com/joslat/AgentEval/pull/210)'s correction to that search silently desynced nine committed corpora from the generators that produce them, while their sidecars went on asserting `generator.tool`/`version`/`seed` as though they still reproduced it.

Nothing was *wrong* with the corpora. They pass every gate, their coverage is in band, and their probe records honestly describe their bytes. The **provenance claim** had become false, and no gate said so.

## The fix

`python gen_typedmemeval_X.py` now rebuilds at the echo the sidecar records — reproducing the committed corpus byte for byte. `--recalibrate` runs the search, and is the deliberate act that moves a corpus and obliges a re-probe.

**All nine reproduce**, including `arithmetic`, `conjunction` and `workingmemory`, which did not before. In seconds, since a pinned rebuild does no searching.

## This replaces most of the planned re-baseline

The verticals whose echoes move need **no probe run at all** — their corpora are valid and honestly measured, and the only defect was provenance. Only `temporal` and `bitemporal`, which carry real corpus fixes, are owed a re-probe. **~2,600 calls rather than ~13,000.**

## Two defects found on the way

**The published per-shape coverage did not describe the shipped corpus.** `calibrate_per_shape` recorded each shape's `best_mean` — the value its own search saw, while every *later* shape's knob was still 0.0 — then rebuilt with all knobs set, which moves the earlier shapes.

| | published | actual |
|---|---|---|
| `arithmetic/delta` | 0.7767 | 0.7350 |
| `arithmetic/duration` | 0.6528 | 0.6250 |
| `conjunction/alias-then-count` | 0.3444 | 0.3356 |
| `semantic/co-reference` | 0.6889 | 0.7222 |

`semantic`'s echo never moved, so this is long-standing and independent of the search fix. No corpus changes, so no probe is invalidated.

**The carry-forward allowlist had already drifted.** `("probes", "gold_item_types")` dropped WorkingMemory's `structure.retrieval_ceiling`, because `structure` *is* rebuilt and the stamped block lives inside it — the parent looked produced while its contents were lost. Now recursive: when the corpus hash matches, any key the old sidecar holds and this build doesn't produce is a measurement of these exact bytes.

## CI

The reproducibility gate ships here, green. It couldn't land earlier without being red on four verticals from the moment it merged — and a gate that lands red is one people learn to skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ