### PR TITLE
TypedMemEval: the honesty pass — stop over-claiming what the numbers say

### DIFF
--- a/docs/benchmarks/typedmemeval/getting-started.md
+++ b/docs/benchmarks/typedmemeval/getting-started.md
@@ -78,6 +78,22 @@ as sensitive data: restrict access, retention, and publication.
 
 ### Typed outcomes, never one percentage
 
+> **Thirteen of the 31 shapes carry fewer than 15 questions, and their figures support diagnosis
+> rather than claims.** ADR-026 says this about the family's cell sizes and the published tables never
+> repeated it, so a six-question rate has been reading like a measurement. The threshold is a
+> judgement — 15 is where a single question stops moving a rate by more than ~7 points — but the
+> shapes below it are a fact:
+>
+> | vertical | shapes under 15 questions |
+> |---|---|
+> | `prospective` | `expiring-validity` (6), `not-yet-true` (6), `due-later-reminder` (8), `seed-carry-over` (12) |
+> | `workingmemory` | all five distance rungs (12 each) |
+> | `arithmetic` | `delta` (10), `duration` (12), `count` (14), `sum` (14) |
+>
+> On a six-question shape one question is 0.167 of the rate, so `not-yet-true`'s headroom of 0.1667
+> **is one question**. Quote these shapes to diagnose where a system struggles; do not quote them as
+> a measured capability, and do not rank two systems on a difference of one or two items.
+
 Every result reports a vector, per vertical and per shape, always with its `n`:
 
 | Outcome | Meaning |
@@ -407,12 +423,31 @@ gold is itself an abstention.
 > - `V9` — accuracy given the **top-`K_ref` sessions a plain BM25 retriever returns**. A lexical
 >   baseline selector, and the arm that was missing.
 >
-> **`V1 − V9` is the headroom a better retriever can capture.** `V1 − V8` is not a headroom number:
-> it only asks whether distractors confuse a reader who already has everything, and on these corpora
-> the answer is mostly no. Reading `V1 − V8 ≈ 0` as "retrieval quality cannot matter here" was a
-> mistake — a real system does not dump the haystack into context, it *selects*, and selecting badly
-> is far worse than either arm above. Measured against a lexical baseline, **every vertical has
+> **`V1 − V9` is what a PERFECT SELECTOR would capture — an upper bound, and on some shapes an
+> unreachable one.** `V1 − V8` is not a headroom number: it only asks whether distractors confuse a
+> reader who already has everything. Reading `V1 − V8 ≈ 0` as "retrieval quality cannot matter here"
+> was a mistake — a real system does not dump the haystack into context, it *selects*, and selecting
+> badly is far worse than either arm above. Measured against a lexical baseline, **every vertical has
 > substantial headroom, from 0.12 to 0.62.**
+>
+> **But `V1 − V9` is NOT "the headroom a better retriever can capture", which is what this passage
+> used to say.** A real retriever returns gold *plus* whatever else it ranks highly, so it can never
+> beat having everything: **its ceiling is V8, not V1.** Where the two diverge, most of the published
+> headroom is unbuyable. `V9 − V8` is the reachable half, and it is published per shape as
+> `headroom_reachable` alongside `limited_by`, which says whether a shape is retrieval-limited or
+> reasoning-limited (ADR-028 §3e).
+>
+> | shape | `V1 − V9` published | `V8 − V9` reachable | limited by |
+> |---|---|---|---|
+> | `prospective/due-window` | **0.94** | **0.17** | reasoning |
+> | `episodic/participant-attribution` | 0.20 | 0.13 | retrieval |
+> | `bitemporal/belief-at-instant` | 0.31 | 0.22 | retrieval |
+> | `temporal/occurrence-order` | 0.75 | 0.75 | retrieval |
+>
+> **Read the reachable column before buying retrieval work.** `due-window`'s V8 is 4/18 — a reader
+> holding the entire haystack still fails 78% of the time — so a team that responds to its 0.94 by
+> improving retrieval gets almost nothing. `occurrence-order`, where the two columns agree, is the
+> shape where retrieval work pays in full.
 >
 > Episodic's interference cost of **−0.04** is real rather than rounding: two `participant-attribution`
 > questions fail on gold alone and succeed on the whole haystack, because gold-only strips the

--- a/tests/AgentEval.Memory.Tests/TypedMemEvalCoverageBandTests.cs
+++ b/tests/AgentEval.Memory.Tests/TypedMemEvalCoverageBandTests.cs
@@ -1,0 +1,200 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using AgentEval.Memory.External.TypedMemEval;
+using Xunit;
+
+namespace AgentEval.Memory.Tests;
+
+/// <summary>
+/// Every shape's realised coverage must sit inside the declared band, and every multi-shape vertical
+/// must publish enough per-shape detail to check that.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ADR-026 declares a BM25 coverage band of [0.50, 0.90] and ADR-028 §3d keeps it as the calibration
+/// TARGET. Nothing enforced it per shape. The vertical MEAN is what gets checked at generation time,
+/// and a mean is satisfiable by averaging: Arithmetic once calibrated to 0.700 — dead on target —
+/// while its shapes sat at 0.857 / 0.947 / 0.083 / 0.894. Per-shape calibration was built to stop
+/// that, and then no gate confirmed the result.
+/// </para>
+/// <para>
+/// Three shapes are outside the band right now and nothing reports it, which is the whole argument
+/// for this test. It is a RATCHET rather than a wall, for the reason the discrimination ratchet
+/// beside it gives: a gate that is red for the life of a known-weak shape stops being read, and a
+/// regression introduced while fixing something else then lands invisibly. Listed shapes carry their
+/// measured value and may move toward the band but not away from it; anything unlisted must be in
+/// band outright.
+/// </para>
+/// </remarks>
+public class TypedMemEvalCoverageBandTests
+{
+    /// <summary>ADR-026's declared BM25 coverage band. Constants here, never read from the artifact.</summary>
+    private const double BandLow = 0.50;
+    private const double BandHigh = 0.90;
+
+    /// <summary>
+    /// Shapes outside the band today, with the coverage measured on the shipped corpus.
+    /// </summary>
+    /// <remarks>
+    /// Each is a real finding, not a tolerance:
+    /// <list type="bullet">
+    /// <item><c>conjunction/alias-then-count</c> — legitimately hard rather than broken. V1 is 15/15,
+    /// so the corpus is answerable; BM25 simply cannot find the evidence, which is the point of a
+    /// retrieval benchmark. Declared rather than tuned, because tuning it toward 0.70 would trade
+    /// away the widest headroom in the family (0.93).</item>
+    /// <item><c>prospective/due-window</c> — below the floor AND reasoning-limited (V8 4/18), so it is
+    /// hard in two different ways at once. Scoped for redesign.</item>
+    /// <item><c>prospective/not-yet-true</c> — SATURATED at 1.0. BM25 returns gold for every question,
+    /// and its headroom of 0.1667 is one question out of six. This is the one entry here that is a
+    /// defect rather than a declared property.</item>
+    /// </list>
+    /// </remarks>
+    private static readonly Dictionary<(TypedMemEvalVertical, string), double> OutOfBand =
+        new()
+        {
+            [(TypedMemEvalVertical.Conjunction, "alias-then-count")] = 0.3356,
+            [(TypedMemEvalVertical.Prospective, "due-window")] = 0.4352,
+            [(TypedMemEvalVertical.Prospective, "not-yet-true")] = 1.0000,
+        };
+
+    /// <summary>
+    /// Multi-shape verticals that publish no per-shape coverage, so their shapes cannot be checked.
+    /// </summary>
+    /// <remarks>
+    /// These calibrate on a single knob, so the sidecar carries only a vertical mean. That is exactly
+    /// the condition under which a collapsed shape hides — and skipping them silently would make this
+    /// gate decoration for a third of the family. Listing them makes the gap a declared, testable
+    /// fact: each is fixed by opting into per-shape calibration, which changes the corpus and so owes
+    /// a re-probe.
+    /// </remarks>
+    private static readonly HashSet<TypedMemEvalVertical> NoPerShapeCoverage =
+        new()
+        {
+            TypedMemEvalVertical.Temporal,
+            TypedMemEvalVertical.Forgetting,
+            TypedMemEvalVertical.WorkingMemory,
+        };
+
+    public static TheoryData<TypedMemEvalVertical> AllVerticals()
+    {
+        var data = new TheoryData<TypedMemEvalVertical>();
+        foreach (var vertical in System.Enum.GetValues<TypedMemEvalVertical>())
+        {
+            data.Add(vertical);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void EveryShape_SitsInsideTheCoverageBand(TypedMemEvalVertical vertical)
+    {
+        var perShape = PerShapeCoverage(vertical);
+        if (perShape.Count == 0)
+        {
+            return;     // covered by MultiShapeVerticals_PublishPerShapeCoverage
+        }
+
+        foreach (var (shape, coverage) in perShape)
+        {
+            if (OutOfBand.TryGetValue((vertical, shape), out var recorded))
+            {
+                // May move TOWARD the band, never further from it. Distance is measured from
+                // whichever edge it sits outside, so a saturated shape and a collapsed one are both
+                // held by the same rule.
+                var recordedDistance = DistanceOutside(recorded);
+                var currentDistance = DistanceOutside(coverage);
+                Assert.True(
+                    currentDistance <= recordedDistance + 1e-4,
+                    $"{vertical} shape '{shape}' moved FURTHER outside the band: coverage "
+                    + $"{coverage:F4} against a recorded {recorded:F4}. Declared out-of-band shapes "
+                    + "may improve, but they may not get worse.");
+                continue;
+            }
+
+            Assert.True(
+                coverage >= BandLow && coverage <= BandHigh,
+                $"{vertical} shape '{shape}' has realised coverage {coverage:F4}, outside the "
+                + $"[{BandLow}, {BandHigh}] band. A vertical MEAN in range hides this — which is the "
+                + "averaging defect per-shape calibration exists to refuse. Either bring it into "
+                + "band, or add it to OutOfBand with its measured value and the reason it belongs "
+                + "there.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllVerticals))]
+    public void MultiShapeVerticals_PublishPerShapeCoverage(TypedMemEvalVertical vertical)
+    {
+        // A vertical with one shape has nothing to decompose, so the mean IS the per-shape figure.
+        if (ShapeCount(vertical) < 2)
+        {
+            return;
+        }
+
+        var published = PerShapeCoverage(vertical).Count > 0;
+
+        if (NoPerShapeCoverage.Contains(vertical))
+        {
+            // A ratchet in the other direction: once a vertical starts publishing per-shape coverage
+            // it must not stop, and the declared list must shrink rather than be quietly kept.
+            if (published)
+            {
+                Assert.Fail(
+                    $"{vertical} now publishes per-shape coverage — remove it from "
+                    + "NoPerShapeCoverage so the band check applies to it.");
+            }
+
+            return;
+        }
+
+        Assert.True(
+            published,
+            $"{vertical} has {ShapeCount(vertical)} shapes and publishes no per-shape coverage, so "
+            + "no gate can tell whether any of them left the band. Opt the generator into per-shape "
+            + "calibration, or declare the gap in NoPerShapeCoverage.");
+    }
+
+    /// <summary>How far outside [BandLow, BandHigh] a value sits; 0 when inside.</summary>
+    private static double DistanceOutside(double coverage) =>
+        coverage < BandLow ? BandLow - coverage
+        : coverage > BandHigh ? coverage - BandHigh
+        : 0.0;
+
+    private static int ShapeCount(TypedMemEvalVertical vertical)
+    {
+        var metadata = JsonDocument.Parse(TypedMemEvalCorpus.ReadMetadataJson(vertical)).RootElement;
+        if (!metadata.TryGetProperty("probes", out var probes)
+            || !probes.TryGetProperty("by_shape", out var byShape))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var _ in byShape.EnumerateObject())
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static Dictionary<string, double> PerShapeCoverage(TypedMemEvalVertical vertical)
+    {
+        var metadata = JsonDocument.Parse(TypedMemEvalCorpus.ReadMetadataJson(vertical)).RootElement;
+        var result = new Dictionary<string, double>();
+        if (!metadata.TryGetProperty("coverage", out var coverage)
+            || !coverage.TryGetProperty("per_shape_realised", out var perShape))
+        {
+            return result;
+        }
+
+        foreach (var shape in perShape.EnumerateObject())
+        {
+            result[shape.Name] = shape.Value.GetDouble();
+        }
+
+        return result;
+    }
+}

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import sys
@@ -1189,6 +1190,15 @@ def probe_vertical(vertical: str, limit: int | None, workers: int) -> dict:
 #: retriever exists, because the entire scale is BM25-relative.
 DISCRIMINATION_FLOOR = 0.15
 
+#: Standard errors of separation a PAIRED shape must show, beside the scaled headroom floor.
+#:
+#: Two is the conventional "not noise" bar and is deliberately modest: this is a second condition on
+#: an already-scaled floor, not the primary one. It exists because a headroom floor on a small pair
+#: count can be cleared by a difference of two or three pairs -- belief-at-instant once sat at
+#: 3 of 18, about 1.7 sd -- and no scaling of the floor detects that, because the problem is the
+#: SAMPLE, not the metric.
+PAIR_SEPARATION_FLOOR_SD = 2.0
+
 
 def _discrimination(group: list[dict]) -> dict:
     """How this shape is hard, and whether it can rank anything. ADR-028 SS3e.
@@ -1289,13 +1299,32 @@ def _pair_discrimination(group: list[dict], arms: dict) -> dict:
 
     pair_headroom = v1_hits / v1_n - v9_hits / v9_n
     amplification = arm_rate("v1") + arm_rate("v9")
+
+    # SEPARATION IN STANDARD ERRORS, because the scaled floor alone cannot carry the verdict.
+    #
+    # The scaling assumes independent arms and they measurably are not, so it is conservative by an
+    # unknown amount -- and correcting it from the observed data would be the artifact supplying its
+    # own pass, which is the exact failure this family keeps finding. So the floor STAYS as declared,
+    # and this is added beside it: how many standard errors separate the two arms, on a binomial
+    # error for the pair count. It assumes nothing about correlation, and it is the argument that
+    # actually decided belief-at-instant on the previous corpus -- 3 pairs of separation on n=18,
+    # about 1.7 sd, which no reading of the amplification rescues.
+    #
+    # A shape must now clear BOTH. Either alone can be argued with; together they cannot.
+    v9_rate = v9_hits / v9_n
+    spread = math.sqrt(max(v9_n * v9_rate * (1.0 - v9_rate), 1e-9))
+    separation_sd = (v1_hits - v9_hits) / spread if spread else 0.0
+
     row = {
         "pairs": len(complete),
         "pair_v1_both_arms": f"{v1_hits}/{v1_n}",
         "pair_v9_both_arms": f"{v9_hits}/{v9_n}",
         "pair_headroom": round(pair_headroom, 4),
         "pair_floor_scaled": round(DISCRIMINATION_FLOOR * amplification, 4),
-        "pair_discriminates": pair_headroom >= DISCRIMINATION_FLOOR * amplification,
+        "pair_separation_sd": round(separation_sd, 3),
+        "pair_separation_floor_sd": PAIR_SEPARATION_FLOOR_SD,
+        "pair_discriminates": (pair_headroom >= DISCRIMINATION_FLOOR * amplification
+                               and separation_sd >= PAIR_SEPARATION_FLOOR_SD),
     }
     v8_hits, v8_n = both("v8")
     if v8_n:
@@ -1304,7 +1333,10 @@ def _pair_discrimination(group: list[dict], arms: dict) -> dict:
         "Both arms of one pair scored together, because a system that answers only the valid-time "
         "arm has not shown it can represent two clocks. Compare pair_headroom against "
         "pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens "
-        "headroom mechanically, and the scaled floor removes that gain rather than banking it.")
+        "headroom mechanically, and the scaled floor removes that gain rather than banking it. "
+        "pair_discriminates requires BOTH that floor and pair_separation_sd, because the floor's "
+        "independence assumption is measurably false and conservative by an unknown amount, while "
+        "the standard-error separation assumes nothing about correlation.")
     return row
 
 
@@ -1479,6 +1511,26 @@ def self_test() -> None:
     check("a separating shape passes", row["pair_discriminates"], True)
     check("its pair headroom", row["pair_headroom"], round(1.0 - 7 / 12, 4))
 
+    # THE CASE THE SCALED FLOOR ALONE CANNOT CATCH, chosen by searching the space rather than
+    # guessed: over pair counts 4-40 the floor passes while the separation fails in 1,567
+    # configurations, so the second condition is load-bearing rather than decorative. This is one of
+    # them -- 4 pairs, V1 3/4 against V9 2/4, which reads headroom 0.25 against a floor of 0.1875
+    # and is one standard error. A difference of a single pair, reported as discrimination.
+    #
+    # (My first attempt at this case was arithmetically wrong -- it computed to exactly 2.0 sd and
+    # passed. The searched version replaces a guess with a measurement, which is the whole habit.)
+    tiny = [({**hit, "v1": False, "v9": False}, {**hit, "v1": False, "v9": False}),
+            ({**hit, "v9": False}, {**hit, "v9": False}),
+            ({**hit}, {**hit}),
+            ({**hit}, {**hit})]
+    records, arms = paired(tiny)
+    row = _pair_discrimination(records, arms)
+    check("a 4-pair shape clears the scaled headroom floor",
+          row["pair_headroom"] > row["pair_floor_scaled"], True)
+    check("its separation is one standard error", row["pair_separation_sd"], 1.0)
+    check("so it does NOT discriminate, on the sample rather than the metric",
+          row["pair_discriminates"], False)
+
     # Unpaired shapes must emit NOTHING rather than a degenerate row -- eight of the nine verticals
     # have no arms, and a zero-filled block there would read as a measured result.
     unpaired = [{"question_id": "solo", **hit}]
@@ -1494,7 +1546,7 @@ def self_test() -> None:
             print(f"self-test FAIL  {f}")
         raise SystemExit(1)
     print("self-test OK  (10 evidence-screen cases, 6 arm-attribution cases, 7 silence cases, "
-          "8 paired-arm cases)")
+          "11 paired-arm cases)")
 
 
 def restamp_empty_rates_from_cache(verticals: list[str]) -> None:


### PR DESCRIPTION
Wave 1 of the TypedMemEval plan: everything that improves what we publish **without touching a corpus**, so none of it costs a probe run.

## A per-shape coverage band gate

ADR-026 declares a band of [0.50, 0.90]; nothing enforced it *per shape*. Only the vertical **mean** is checked at generation, and a mean is satisfiable by averaging — Arithmetic once calibrated to 0.700, dead on target, while its shapes sat at 0.857 / 0.947 / **0.083** / 0.894.

Three shapes are outside the band today and nothing reported it:

| shape | coverage | what it is |
|---|---|---|
| `conjunction/alias-then-count` | 0.3356 | legitimately hard — V1 is 15/15, BM25 just can't find it |
| `prospective/due-window` | 0.4352 | below floor *and* reasoning-limited |
| `prospective/not-yet-true` | **1.0000** | **saturated** — the one entry that's a defect, not a property |

A ratchet, like the discrimination one beside it: listed shapes may move *toward* the band and not away; anything unlisted must be in band outright. Green on day one, and verified to fail in both directions.

**It also checks that the check can run.** Three multi-shape verticals — `temporal`, `forgetting`, `workingmemory` — publish no per-shape coverage at all, so a collapsed shape in any of them is invisible. Skipping them silently would make this gate decoration for a third of the family, so the gap is declared and testable instead.

## Paired discrimination now needs two conditions

`pair_floor_scaled` assumes the two arms are independent and they measurably are not, so it's conservative by an unknown amount — and correcting it from the observed data would be **the artifact supplying its own pass**. So the floor stays as declared, and a standard-error separation is added beside it.

Searched rather than argued: over pair counts 4–40, the floor passes while the separation fails in **1,567 configurations**, so the second condition is load-bearing. `n=4` with V1 3/4 against V9 2/4 reads headroom 0.25 against a floor of 0.1875 and is **one standard error** — a single pair of difference, reported as discrimination.

Both shipped shapes clear it: 4.7 sd and 4.1 sd.

*(The first draft of that self-test case was arithmetically wrong — it computed to exactly 2.0 sd and passed. Searching the space replaced a guess with a measurement.)*

## The guide said something false

It read: **"`V1 − V9` is the headroom a better retriever can capture."**

A real retriever returns gold *plus* whatever else it ranks highly, so it can never beat having everything — its ceiling is **V8, not V1** (ADR-028 §3e). `headroom_reachable` has been in the sidecar since #208 and the word "reachable" appeared **zero times** in the published docs.

| shape | published | reachable | limited by |
|---|---|---|---|
| `prospective/due-window` | **0.94** | **0.17** | reasoning |
| `temporal/occurrence-order` | 0.75 | 0.75 | retrieval |

`due-window`'s V8 is 4/18 — a reader holding the whole haystack still fails 78% of the time — so a team responding to the headline by buying retrieval gets nothing.

## Thirteen of 31 shapes carry fewer than 15 questions

ADR-026 says small cells support diagnosis rather than claims; the published tables never repeated it, so a six-question rate has been reading like a measurement. On a six-question shape one question is 0.167 of the rate — so `not-yet-true`'s headroom of 0.1667 **is one question**.

279/279 memory tests pass. No corpus changes, so no probe is invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ