### PR TITLE
ADR-029: procedural memory, and a separation figure that could report 284,604 sd

### DIFF
--- a/docs/adr/029-procedural-memory-declarative-and-enacted.md
+++ b/docs/adr/029-procedural-memory-declarative-and-enacted.md
@@ -1,0 +1,134 @@
+# ADR-029: Procedural memory — split the excluded category in two, and reopen only half of it
+
+- **Status:** **Proposed — a decision is REQUESTED, not recorded.** ADR-027 excluded procedural
+  memory *permanently*; nothing below overturns that on its own authority. §7 is the decision this
+  asks for and §6 the three things that cannot be designed until it is answered.
+- **Date:** 2026-08-31
+- **Amends:** [ADR-027](027-typedmemeval-semantic-temporal-bitemporal.md) §1, which reads:
+  *"Procedural stays out permanently: it needs tools, a live agent loop and observed outcomes, so it
+  cannot be a static corpus."*
+
+---
+
+## 1. What this amendment does and does not claim
+
+ADR-027's reasoning is correct **for half of what "procedural memory" names, and the half it is
+correct about is not the half a memory benchmark most needs.**
+
+- **Enacted procedural memory** — whether a system gets *better* at doing something, expressed
+  through performance. ADR-027 is right that this needs tools and observed outcomes.
+- **Declarative memory of a procedure** — whether a system retains and correctly reproduces an
+  ordered, conditional, revisable procedure it was told about. This is a static corpus, and nothing
+  in the family tests it.
+
+**The naming is the load-bearing part of this ADR, not a footnote.** Strict procedural memory is
+knowing *how*, largely non-verbalizable. Asking "what are the steps?" tests knowing *that*, which is
+closer to semantic memory with procedural content. If a vertical is built it must be named so that
+it does not claim the category ADR-027 excluded. Quietly redefining an excluded category in order to
+report coverage of it would be precisely the over-claim this family exists to refuse, and it would
+be the most damaging kind, because it would be true of the label and false of the thing.
+
+## 2. The gap, stated as structure rather than as a category
+
+A procedure has properties no current vertical measures, and each is testable in a static corpus:
+
+| property | why no existing vertical covers it |
+|---|---|
+| **Ordered steps with dependencies** | Temporal orders *occurrences*; a wrong order there is a wrong answer. In a procedure, violating order is an **error** — the steps are causally required, not merely sequenced. |
+| **Conditional branches** | *"If the check fails, do X instead."* **Nothing in the family has a conditional.** |
+| **Partial revision** | *"Step 3 changed, the rest stands."* Bitemporal corrects a whole fact; this corrects **one element of a structure** and must leave the rest intact. |
+| **Preconditions** | *"Never on a Friday."* A constraint that is not a step and not a value. |
+| **Retired steps** | *"We stopped doing the manual backup."* Forgetting invalidates facts, not positions in a sequence. |
+
+That is a distinct construct. Whether it is distinct enough to be a tenth vertical is §6.3.
+
+## 3. The dominant risk, and why it is survivable
+
+**Procedures are the most guessable content this family would ever hold.** Asked *"how do we deploy
+the service?"*, a reference model writes a plausible runbook from priors with no context at all —
+the exact failure V2 exists to refuse. **V2 currently passes 100% across all nine verticals**
+(470/470), so that is the bar, and a naive procedural corpus would fail it badly.
+
+**The mitigation is proven in this repository.** Temporal faces the same problem — event orderings
+that world knowledge constrains — and solves it with invented referents whose ordering is *stated
+rather than inferable*. `MILESTONES` are verified non-referential, and the relation between them is
+carried by the corpus, not by plausibility. A procedural corpus would do the same: invented steps
+whose required order is arbitrary and stated.
+
+**The second cost is the judge.** An ordered multi-step answer needs per-step and per-order credit
+rather than a yes/no verdict. That is real work, but it is precedented: the structured judge
+protocol built for LongMemEval already replaced free-text parsing for the same reason.
+
+## 4. Enacted procedural is cheaper than ADR-027 assumed
+
+ADR-027 excluded the enacted half because it "needs tools, a live agent loop and observed outcomes."
+Reading the RedTeam harness, the expensive part of that is not required:
+
+- `IToolCapableAgent` already hands an agent tool schemas and returns a trace of emitted calls.
+- `CanaryTool.Execute` is **optional**, and `EvidenceFidelity.IntentToAct` already distinguishes a
+  call the model *emitted* from one that *executed*.
+
+So an agent can be handed the tools, asked to carry out a procedure it learned sessions earlier, and
+scored on the **emitted call sequence** — with nothing running. No sandbox, no side effects, no state
+threading. **Observed outcomes are not needed to test whether the procedure was remembered
+correctly**; they are only needed to test whether the system got *better*, which is a different
+claim and stays out.
+
+What is genuinely missing is semantics, not mechanism, and §6.2 records it.
+
+## 5. What this ADR proposes
+
+**5a.** ADR-027's exclusion is **narrowed, not lifted**: it continues to apply in full to enacted
+procedural memory as skill acquisition — whether a system improves with practice — which remains out
+of scope for a static corpus family.
+
+**5b.** The declarative half is **admissible in principle**, under a name that does not claim the
+excluded category, subject to §6.
+
+**5c.** Nothing is scheduled. Both halves sit after the existing nine verticals are healthy, for a
+reason beyond effort: adding a tenth corpus while three of nine carry open defects spreads the work
+thin, and the family-wide padding fix would then touch ten corpora rather than nine.
+
+## 6. What cannot be designed until §7 is answered
+
+**6.1 — The name, and therefore the claim.** Until it is settled whether this is "Procedural
+(declarative)", "Protocol", "Runbook", or a shape inside an existing vertical, every downstream
+choice is unanchored. This is the gate.
+
+**6.2 — There is no mechanical boundary rule, and this family does not accept prose ones.** Temporal
+holds its line against Arithmetic in code: `check_temporal` refuses any answer containing a digit.
+Bitemporal refuses a pair whose two clocks give the same answer. A procedural vertical needs an
+equivalent against **Conjunction** (which already does multi-hop joins) and **Episodic** (which
+already orders mentions), and none has been designed. A candidate — an answer must be an ordered set
+of at least three elements containing at least one conditional — is a starting point, not a decision.
+
+**6.3 — Whether it is a tenth vertical at all.** That changes the declared family size, the
+consuming project's expectations, and every table that says "nine".
+
+**6.4 — For the enacted half only:** `ForbiddenCategory` is a *required* field on `CanaryTool`,
+because every tool in that harness is attacker-desirable by construction. Procedural asks the
+inverse — the right tools in the right order — so it needs an `ExpectedStep` notion and a sequence
+evaluator (`ToolInvocationEvaluator` detects invocation, not order). It would also be **the first
+thing to marry the RedTeam and Memory assemblies**, which is an architectural decision rather than a
+feature.
+
+## 7. The decision requested
+
+**Does ADR-027's permanent exclusion stand as written, or is it narrowed to the enacted half?**
+
+- If it **stands**, procedural memory has no owner anywhere in the product, and that should be
+  recorded as an accepted gap rather than left implicit.
+- If it is **narrowed**, §6.1 through §6.3 become the design work, and §6.4 becomes a separate
+  question about where enacted procedural evaluation lives — which is a product decision, not a
+  TypedMemEval one.
+
+Either answer is defensible. What is not defensible is the current state, where the exclusion reads
+as permanent, the enacted half is unowned, and the declarative half was never separately considered.
+
+## 8. Provenance
+
+This came out of a maintainer's question — whether procedural memory could be tested as *"how would
+you do this"* rather than *"do this"* — which is exactly the split §1 draws, and which ADR-027 did
+not consider because it evaluated "procedural memory" as one thing. The claim in §4 was made once
+without inspecting the harness and corrected after reading it; the correction is what moved the
+enacted half from prohibitive to merely unscheduled.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ Each ADR follows this structure:
 | [026](026-typedmemeval-benchmark-family.md) | TypedMemEval — A Mechanism-Isolating Memory Benchmark Family | Accepted (implemented v0.22.0-beta) | 2026-08-15 |
 | [027](027-typedmemeval-semantic-temporal-bitemporal.md) | TypedMemEval — Semantic, Temporal and Bitemporal Verticals (design) | Proposed (design only; generation gated) | 2026-08-18 |
 | [028](028-typedmemeval-acceptance-on-discrimination.md) | TypedMemEval — accept a shape on measured discrimination, not a coverage proxy | Proposed | 2026-08-31 |
+| [029](029-procedural-memory-declarative-and-enacted.md) | Procedural memory — split the excluded category in two, and reopen only half of it | Proposed (decision requested) | 2026-08-31 |
 
 ---
 

--- a/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
+++ b/src/AgentEval.Memory/Data/typedmemeval/prospective/agenteval-typedmemeval-prospective-v5.meta.json
@@ -729,7 +729,7 @@
     },
     "reference_deployment": "gpt-5.5",
     "reference_model_note": "Azure deployment name, not a model identity — a deployment may be repointed at a different model without this value changing.",
-    "run_at": "2026-08-31T13:29:35Z",
+    "run_at": "2026-08-31T22:01:42Z",
     "questions_probed": 50,
     "match_detection": "over-sensitive lexical screen on distinctive tokens, escalated to a reference-model yes/no equivalence judgment; only the judgment decides a match",
     "v1_oracle_answerability": {
@@ -905,7 +905,17 @@
         "discriminates": true,
         "headroom_reachable": 0.5,
         "limited_by": "retrieval",
-        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it.",
+        "pairs": 4,
+        "pair_v1_both_arms": "4/4",
+        "pair_v9_both_arms": "2/4",
+        "pair_headroom": 0.5,
+        "pair_floor_scaled": 0.225,
+        "pair_separation_sd": 2.0,
+        "pair_separation_floor_sd": 2.0,
+        "pair_discriminates": true,
+        "pair_v8_both_arms": "4/4",
+        "pair_reading": "Both arms of one pair scored together, because a system that answers only the valid-time arm has not shown it can represent two clocks. Compare pair_headroom against pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens headroom mechanically, and the scaled floor removes that gain rather than banking it. pair_discriminates requires BOTH that floor and pair_separation_sd, because the floor's independence assumption is measurably false and conservative by an unknown amount, while the standard-error separation assumes nothing about correlation."
       },
       "due-window": {
         "questions": 18,
@@ -922,7 +932,17 @@
         "discriminates": true,
         "headroom_reachable": 0.1667,
         "limited_by": "reasoning",
-        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it.",
+        "pairs": 9,
+        "pair_v1_both_arms": "9/9",
+        "pair_v9_both_arms": "0/9",
+        "pair_headroom": 1.0,
+        "pair_floor_scaled": 0.1583,
+        "pair_separation_sd": 13.765,
+        "pair_separation_floor_sd": 2.0,
+        "pair_discriminates": true,
+        "pair_v8_both_arms": "1/9",
+        "pair_reading": "Both arms of one pair scored together, because a system that answers only the valid-time arm has not shown it can represent two clocks. Compare pair_headroom against pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens headroom mechanically, and the scaled floor removes that gain rather than banking it. pair_discriminates requires BOTH that floor and pair_separation_sd, because the floor's independence assumption is measurably false and conservative by an unknown amount, while the standard-error separation assumes nothing about correlation."
       },
       "expiring-validity": {
         "questions": 6,
@@ -939,7 +959,17 @@
         "discriminates": true,
         "headroom_reachable": 0.3333,
         "limited_by": "retrieval",
-        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it.",
+        "pairs": 3,
+        "pair_v1_both_arms": "3/3",
+        "pair_v9_both_arms": "2/3",
+        "pair_headroom": 0.3333,
+        "pair_floor_scaled": 0.25,
+        "pair_separation_sd": 1.193,
+        "pair_separation_floor_sd": 2.0,
+        "pair_discriminates": false,
+        "pair_v8_both_arms": "3/3",
+        "pair_reading": "Both arms of one pair scored together, because a system that answers only the valid-time arm has not shown it can represent two clocks. Compare pair_headroom against pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens headroom mechanically, and the scaled floor removes that gain rather than banking it. pair_discriminates requires BOTH that floor and pair_separation_sd, because the floor's independence assumption is measurably false and conservative by an unknown amount, while the standard-error separation assumes nothing about correlation."
       },
       "not-yet-true": {
         "questions": 6,
@@ -956,7 +986,17 @@
         "discriminates": true,
         "headroom_reachable": 0.1667,
         "limited_by": "retrieval",
-        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it."
+        "reading": "headroom_perfect_selector is V1-V9, what a selector returning ONLY gold would buy. headroom_reachable is V8-V9, what a real retriever can reach, because returning more than gold cannot beat having everything. Where these diverge the shape is reasoning-limited and retrieval work will not move it.",
+        "pairs": 3,
+        "pair_v1_both_arms": "3/3",
+        "pair_v9_both_arms": "2/3",
+        "pair_headroom": 0.3333,
+        "pair_floor_scaled": 0.275,
+        "pair_separation_sd": 1.193,
+        "pair_separation_floor_sd": 2.0,
+        "pair_discriminates": false,
+        "pair_v8_both_arms": "3/3",
+        "pair_reading": "Both arms of one pair scored together, because a system that answers only the valid-time arm has not shown it can represent two clocks. Compare pair_headroom against pair_floor_scaled, NOT against the unpaired floor: conjoining two measurements widens headroom mechanically, and the scaled floor removes that gain rather than banking it. pair_discriminates requires BOTH that floor and pair_separation_sd, because the floor's independence assumption is measurably false and conservative by an unknown amount, while the standard-error separation assumes nothing about correlation."
       },
       "seed-carry-over": {
         "questions": 12,

--- a/tools/run_typedmemeval_probes.py
+++ b/tools/run_typedmemeval_probes.py
@@ -1311,8 +1311,15 @@ def _pair_discrimination(group: list[dict], arms: dict) -> dict:
     # about 1.7 sd, which no reading of the amplification rescues.
     #
     # A shape must now clear BOTH. Either alone can be argued with; together they cannot.
-    v9_rate = v9_hits / v9_n
-    spread = math.sqrt(max(v9_n * v9_rate * (1.0 - v9_rate), 1e-9))
+    # SMOOTHED FOR THE STANDARD ERROR ONLY. A binomial SE is ZERO at rates 0 and 1, and both occur
+    # here -- prospective/due-window came in at 0/9 both-arms. Guarding with max(..., 1e-9) does not
+    # handle that, it disguises it: the reported separation was 284,604 sd, a number that means
+    # nothing and would sail through any floor. The rate is nudged half an observation off the
+    # boundary (Jeffreys-style) before the SE is taken, so a degenerate split reports a large but
+    # FINITE separation -- 0/9 becomes about 13.8 sd, which is the honest reading of "no overlap on
+    # nine pairs". The headroom itself is still computed from the raw rates.
+    smoothed = (v9_hits + 0.5) / (v9_n + 1)
+    spread = math.sqrt(v9_n * smoothed * (1.0 - smoothed))
     separation_sd = (v1_hits - v9_hits) / spread if spread else 0.0
 
     row = {
@@ -1531,6 +1538,17 @@ def self_test() -> None:
     check("so it does NOT discriminate, on the sample rather than the metric",
           row["pair_discriminates"], False)
 
+    # THE BOUNDARY CASE, which the first version of this reported as 284,604 sd. A both-arms V9 of
+    # 0/n has a binomial SE of exactly zero, so the separation is only finite because the rate is
+    # smoothed off the boundary first. An infinity here is worse than a wrong number: it clears
+    # every floor by construction, which is the shape of a guard that cannot fail.
+    degenerate = [({**hit}, {**hit, "v9": False}) for _ in range(9)]
+    records, arms = paired(degenerate)
+    row = _pair_discrimination(records, arms)
+    check("a 0/n split reports a FINITE separation", row["pair_separation_sd"] < 100, True)
+    check("and still reads as clearly separated", row["pair_separation_sd"] > 5, True)
+    check("and discriminates", row["pair_discriminates"], True)
+
     # Unpaired shapes must emit NOTHING rather than a degenerate row -- eight of the nine verticals
     # have no arms, and a zero-filled block there would read as a measured result.
     unpaired = [{"question_id": "solo", **hit}]
@@ -1546,7 +1564,7 @@ def self_test() -> None:
             print(f"self-test FAIL  {f}")
         raise SystemExit(1)
     print("self-test OK  (10 evidence-screen cases, 6 arm-attribution cases, 7 silence cases, "
-          "11 paired-arm cases)")
+          "14 paired-arm cases)")
 
 
 def restamp_empty_rates_from_cache(verticals: list[str]) -> None:


### PR DESCRIPTION
Two things, both without corpus changes.

## ADR-029 — Proposed, **decision requested**

Splits the category [ADR-027](docs/adr/027-typedmemeval-semantic-temporal-bitemporal.md) excluded *permanently*. That exclusion is right for the **enacted** half — whether a system gets *better* at doing something — and not for the **declarative** half, which is a static corpus and which nothing in the family tests:

| property | why no existing vertical covers it |
|---|---|
| ordered steps with dependencies | Temporal orders *occurrences*; a wrong order there is a wrong answer. In a procedure it's an **error**. |
| conditional branches | **Nothing in the family has a conditional.** |
| partial revision | Bitemporal corrects a whole fact; this corrects **one element of a structure**. |
| preconditions, retired steps | Neither a step nor a value; a position removed from a sequence. |

It **narrows rather than lifts**, and it does **not decide** — overturning a permanent exclusion is the maintainer's call.

**The naming is the load-bearing part.** "What are the steps?" tests knowing *that*, not knowing *how*, so a vertical must be named so it doesn't claim the excluded category. Redefining it quietly to report coverage would be the most damaging kind of over-claim: true of the label, false of the thing.

§6 lists what can't be designed until §7 is answered — including that **no mechanical boundary rule exists** against Conjunction and Episodic. This family enforces boundaries in code (`check_temporal` refuses any answer containing a digit); prose ones don't hold.

Enacted procedural is also cheaper than ADR-027 assumed, and I had the reason wrong until I read the harness: `EvidenceFidelity.IntentToAct` already separates an emitted call from an executed one and `CanaryTool.Execute` is optional — so scoring a *remembered* procedure needs no sandbox and no side effects.

## A boundary bug in the instrument shipped in #216

A binomial standard error is **zero** at rates 0 and 1, and both occur — `prospective/due-window` came in at 0/9 both-arms and the separation reported **284,604 sd**.

`max(..., 1e-9)` didn't handle that, it disguised it. **An infinity is worse than a wrong number here: it clears every floor by construction, which is the shape of a guard that cannot fail.** The rate is now nudged half an observation off the boundary before the SE is taken, so 0/9 reads 13.8 sd. Three self-test cases pin it.

The pair instrument turned out to apply to prospective too (19 before/after pairs), so its rows are stamped here. **Corpus unchanged (`a570b890a5b9`), so no probe is invalidated** — and the instrument earned itself twice immediately: catching its own boundary bug, and reporting `expiring-validity` and `not-yet-true` as non-discriminating at 1.19 sd on three pairs.

## Not in this PR — Wave 2 is blocked

The `due-window` wrong-key fix is verified and measured (V8 4/18 → **13/18**, reachable headroom 0.17 → **0.44**, and the shape moves from reasoning-limited to retrieval-limited) but **cannot land**: four variants, and separability decides on rng rather than on the change. Recorded in `strategy/TypedMemEval/` with the code and the evidence.

**S3 moves before Wave 2, not after it in Wave 4.** The triage plan had that ordering wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ