### PR TITLE
The release gate labelled three CLI builds "any" and refused them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,26 @@ jobs:
           Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
           [IO.Compression.ZipFile]::ExtractToDirectory($pkg.FullName, $dir)
           foreach ($dll in Get-ChildItem $dir -Recurse -Filter 'AgentEval.Memory.dll') {
-            $tfm = Split-Path -Leaf (Split-Path -Parent $dll.FullName)
+            # DERIVED BY SEARCHING THE PATH, not by taking the parent directory.
+            #
+            # `lib/<tfm>/X.dll` puts the framework in the parent, but a dotnet TOOL package uses
+            # `tools/<tfm>/any/X.dll`, so the parent is the literal string "any". Taking the parent
+            # blindly labelled all three CLI builds "any", and the per-framework MVID check then
+            # correctly reported that framework "any" ships two different builds -- a true statement
+            # about a label that does not exist. This walks up until it finds a real framework
+            # folder.
+            $tfm = $null
+            $probe = $dll.Directory
+            while ($probe -and -not $tfm) {
+              if ($probe.Name -match '^net(standard)?[0-9]') { $tfm = $probe.Name }
+              $probe = $probe.Parent
+            }
+            if (-not $tfm) {
+              # Refuse rather than group under a made-up label. A check that cannot say WHICH
+              # framework it just verified cannot claim to have verified them all.
+              Write-Host "::error::Could not derive a target framework from $($dll.FullName). Refusing to verify an assembly it cannot attribute."
+              exit 1
+            }
             $label = "$($pkg.Name)/$tfm"
             $asm = [Reflection.Assembly]::Load([IO.File]::ReadAllBytes($dll.FullName))
             # The MVID is unique per compilation. Collecting them lets the step PROVE it opened a


### PR DESCRIPTION
Second false positive in the same check, in a different place, found by the same release.

`lib/<tfm>/X.dll` puts the framework in the parent directory, so taking the parent works there. **A dotnet tool package does not** — `AgentEval.Cli` packs as a tool and uses `tools/<tfm>/any/X.dll`, so the parent is the literal string `any`.

All three CLI builds were labelled `any`, and the per-framework MVID check then reported — correctly, about a label that does not exist — that framework `any` ships two different builds.

The framework is now found by walking **up** the path to the first directory matching `^net(standard)?[0-9]`, which is right for both layouts.

**And it now refuses rather than guesses.** If no framework directory is found, the step exits instead of grouping the assembly under a made-up label: *a check that cannot say which framework it just verified cannot claim to have verified them all.* That property is what the first version lacked — it would have carried on happily calling something `any` — and it is why this reached a release instead of failing at authoring time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ