### PR TITLE
ADR-029 refuted: the exclusion was never ours to narrow

### DIFF
--- a/docs/adr/029-procedural-memory-declarative-and-enacted.md
+++ b/docs/adr/029-procedural-memory-declarative-and-enacted.md
@@ -1,9 +1,11 @@
-# ADR-029: Procedural memory — a finding, and a request to reopen a bilateral agreement
+# ADR-029: Build the conditional, not procedural memory
 
-- **Status:** **Proposed — and NOT ratifiable by this project alone.** An earlier draft of this ADR
-  proposed narrowing ADR-027's exclusion and was put to an adversarial review that refuted three of
-  its four decisions. §8 records what was refuted, because the refutations are more useful than the
-  proposal was.
+- **Status:** **Accepted**, scoped to ONE shape — `conjunction/conditional-branch`. Procedural memory
+  as a memory type stays out and ADR-026 §8 is untouched.
+- **How it got here, which is the useful part:** an earlier draft proposed narrowing ADR-027's
+  exclusion and was put to an adversarial review that refuted three of its four decisions (§8). The
+  maintainer then set aside the one political objection, leaving the two technical ones — and
+  re-examining those produced a smaller, better design that dissolves all of them (§7b).
 - **Date:** 2026-08-31, rewritten 2026-09-01 after review.
 - **Relates to:** [ADR-026](026-typedmemeval-benchmark-family.md) §8, which is where the exclusion
   actually lives; [ADR-027](027-typedmemeval-semantic-temporal-bitemporal.md) §1;
@@ -124,6 +126,77 @@ resolved in writing.
 Whether the agreement recorded in ADR-026 §8 should be reopened, given that the mechanism it was
 struck on (§2) does not hold. Nothing else in this ADR needs their answer; nothing in this ADR
 proceeds without it.
+
+## 7b. RESOLUTION — build the CONDITIONAL, not "procedural memory"
+
+**Added 2026-09-01 after the maintainer set aside the ownership objection** ("we can decide this
+alone; the other party is simply not ready to use it, but if it works, it will"). That removes §1 as
+a blocker. It does not remove §4 or §8's boundary refutation, which are technical and decide whether
+the thing would WORK — so they were re-examined rather than waved through, and one of them turns out
+to point at a much better design.
+
+### The gap, verified rather than asserted
+
+Of the five properties §3 claimed were distinct, four have existing homes. **One does not, and it is
+now measured:** across all 470 shipped questions, **not one requires the model to resolve a
+conditional.** Five questions contain the word "if" or "unless", and in every case the conditional is
+quoted PAYLOAD, never the thing being asked:
+
+> *"…it sticks unless you lift before you push. **Was that me or you?**"* — attribution
+> *"…the warranty lapses if a service is missed?"* — context recall
+
+Nothing in the family tests **"if X, then what?"**
+
+### Why this is the whole opportunity, and procedural memory is not
+
+Scoping to the conditional dissolves every objection at once, which is the sign it is the right
+shape rather than a smaller version of the wrong one:
+
+| objection | why it no longer applies |
+|---|---|
+| §1 ownership (ADR-026 §8) | A conditional-resolution shape does not claim to BE procedural memory, so the agreement is never touched — regardless of whose call it is |
+| §8 naming | No invented vocabulary, no over-claim; it is a shape, not a memory type |
+| §4 contradiction | Never arises. The distinctness claim is not about causally-required order at all |
+| §8 boundary refuted by construction | The new rule is not an ordering rule, so it cannot collapse into Temporal's membership test |
+
+**And §4's contradiction turns out to have had a resolution neither the draft nor the review named,
+worth recording even though it is no longer needed: INVENTED CAUSALITY.** "The Vreskade check must
+run before the Quorlory sync, because Quorlory consumes Vreskade's output" is causally required
+inside the fiction and unguessable from outside it, because no model holds a prior about Vreskade.
+ADR-026 §5.2 bans orderings a model can INFER, not causality as such. That would have rescued the
+ordering argument; it is simply no longer the argument being made.
+
+### The decision
+
+**One shape, `conditional-branch`, inside Conjunction.** Not a tenth vertical.
+
+Conjunction is already defined as questions no single memory type can answer, and resolving a branch
+is *find the procedure -> find the condition's state -> select the branch* — structurally the same
+join as `alias-then-count` and `order-then-value`. ADR-027 §11.1's standard ("a vertical whose shapes
+each have a plausible existing home is a weak vertical") is therefore satisfied by NOT making it a
+vertical.
+
+**The boundary rule is mechanically checkable and cannot collapse into an existing vertical:**
+
+> The answer must CHANGE depending on a condition stated in the haystack. A question whose answer is
+> the same under both branches is not a conditional question and is refused at generation.
+
+That is enforceable the way `check_temporal` refuses a digit, and no existing vertical can express it
+— which is exactly why the gap exists.
+
+### The one real cost
+
+Conjunction ships 50 questions across three shapes (15/15/20). A fourth at parity puts every shape
+near 12, below the ~15 line at which this family's own guidance says a shape supports diagnosis
+rather than a claim. **So Conjunction grows to ~65** — one declared size moves, and the consuming
+project is told before it does.
+
+### What is NOT decided
+
+Procedural memory as a MEMORY TYPE remains out, and ADR-026 §8 stands untouched. If it is ever
+revisited, §8's naming finding applies: it should be called **Procedural**, scoped explicitly to the
+memory layer, because that is what the consuming engine already calls it and inventing a word to
+dodge an over-claim helps nobody.
 
 ## 8. What the review refuted, kept because it is the useful part
 

--- a/docs/adr/029-procedural-memory-declarative-and-enacted.md
+++ b/docs/adr/029-procedural-memory-declarative-and-enacted.md
@@ -1,134 +1,142 @@
-# ADR-029: Procedural memory — split the excluded category in two, and reopen only half of it
+# ADR-029: Procedural memory — a finding, and a request to reopen a bilateral agreement
 
-- **Status:** **Proposed — a decision is REQUESTED, not recorded.** ADR-027 excluded procedural
-  memory *permanently*; nothing below overturns that on its own authority. §7 is the decision this
-  asks for and §6 the three things that cannot be designed until it is answered.
-- **Date:** 2026-08-31
-- **Amends:** [ADR-027](027-typedmemeval-semantic-temporal-bitemporal.md) §1, which reads:
-  *"Procedural stays out permanently: it needs tools, a live agent loop and observed outcomes, so it
-  cannot be a static corpus."*
+- **Status:** **Proposed — and NOT ratifiable by this project alone.** An earlier draft of this ADR
+  proposed narrowing ADR-027's exclusion and was put to an adversarial review that refuted three of
+  its four decisions. §8 records what was refuted, because the refutations are more useful than the
+  proposal was.
+- **Date:** 2026-08-31, rewritten 2026-09-01 after review.
+- **Relates to:** [ADR-026](026-typedmemeval-benchmark-family.md) §8, which is where the exclusion
+  actually lives; [ADR-027](027-typedmemeval-semantic-temporal-bitemporal.md) §1;
+  [ADR-028](028-typedmemeval-acceptance-on-discrimination.md), whose acceptance criterion any new
+  vertical must clear.
 
 ---
 
-## 1. What this amendment does and does not claim
+## 1. THE EXCLUSION IS BILATERAL. THIS PROJECT CANNOT NARROW IT.
 
-ADR-027's reasoning is correct **for half of what "procedural memory" names, and the half it is
-correct about is not the half a memory benchmark most needs.**
+ADR-026 records it twice, and both times as an agreement rather than a preference:
 
-- **Enacted procedural memory** — whether a system gets *better* at doing something, expressed
-  through performance. ADR-027 is right that this needs tools and observed outcomes.
-- **Declarative memory of a procedure** — whether a system retains and correctly reproduces an
-  ordered, conditional, revisable procedure it was told about. This is a static corpus, and nothing
-  in the family tests it.
+> **No Procedural vertical** — consumer-side by agreement (needs tools; agentic).
+> — ADR-026 §8, line 792
 
-**The naming is the load-bearing part of this ADR, not a footnote.** Strict procedural memory is
-knowing *how*, largely non-verbalizable. Asking "what are the steps?" tests knowing *that*, which is
-closer to semantic memory with procedural content. If a vertical is built it must be named so that
-it does not claim the category ADR-027 excluded. Quietly redefining an excluded category in order to
-report coverage of it would be precisely the over-claim this family exists to refuse, and it would
-be the most damaging kind, because it would be true of the label and false of the thing.
+> Procedural memory stays consumer-side (it is agentic and needs tools); it is out of scope for
+> AgentEval and this family.
+> — ADR-026, line 373
 
-## 2. The gap, stated as structure rather than as a category
+**Procedural memory has an owner: the consuming project, by agreement.** The first draft of this ADR
+asserted the opposite — that if the exclusion stood, procedural memory would have "no owner anywhere
+in the product" — and used that as the cost that made narrowing look like the only responsible
+answer. That claim was false, and it was the load-bearing one.
 
-A procedure has properties no current vertical measures, and each is testable in a static corpus:
+The correct move is therefore **not** to amend ADR-027 §1 on one party's authority. It is to put the
+finding in §2 to the counterparty and ask whether the agreement should be reopened, because the
+premise it was struck on is the part that no longer holds. **That question has been sent** (see the
+2026-09-01 correspondence); their answer is an input this repository cannot contain, which is
+precisely the condition under which a decision stays open rather than being guessed.
 
-| property | why no existing vertical covers it |
-|---|---|
-| **Ordered steps with dependencies** | Temporal orders *occurrences*; a wrong order there is a wrong answer. In a procedure, violating order is an **error** — the steps are causally required, not merely sequenced. |
-| **Conditional branches** | *"If the check fails, do X instead."* **Nothing in the family has a conditional.** |
-| **Partial revision** | *"Step 3 changed, the rest stands."* Bitemporal corrects a whole fact; this corrects **one element of a structure** and must leave the rest intact. |
-| **Preconditions** | *"Never on a Friday."* A constraint that is not a step and not a value. |
-| **Retired steps** | *"We stopped doing the manual backup."* Forgetting invalidates facts, not positions in a sequence. |
+## 2. THE FINDING THAT IS WORTH SENDING
 
-That is a distinct construct. Whether it is distinct enough to be a tenth vertical is §6.3.
-
-## 3. The dominant risk, and why it is survivable
-
-**Procedures are the most guessable content this family would ever hold.** Asked *"how do we deploy
-the service?"*, a reference model writes a plausible runbook from priors with no context at all —
-the exact failure V2 exists to refuse. **V2 currently passes 100% across all nine verticals**
-(470/470), so that is the bar, and a naive procedural corpus would fail it badly.
-
-**The mitigation is proven in this repository.** Temporal faces the same problem — event orderings
-that world knowledge constrains — and solves it with invented referents whose ordering is *stated
-rather than inferable*. `MILESTONES` are verified non-referential, and the relation between them is
-carried by the corpus, not by plausibility. A procedural corpus would do the same: invented steps
-whose required order is arbitrary and stated.
-
-**The second cost is the judge.** An ordered multi-step answer needs per-step and per-order credit
-rather than a yes/no verdict. That is real work, but it is precedented: the structured judge
-protocol built for LongMemEval already replaced free-text parsing for the same reason.
-
-## 4. Enacted procedural is cheaper than ADR-027 assumed
-
-ADR-027 excluded the enacted half because it "needs tools, a live agent loop and observed outcomes."
-Reading the RedTeam harness, the expensive part of that is not required:
+ADR-027 §1 excluded procedural memory because it "needs tools, a live agent loop and observed
+outcomes, so it cannot be a static corpus." **The mechanism half of that reason does not hold**, and
+it is worth the counterparty knowing:
 
 - `IToolCapableAgent` already hands an agent tool schemas and returns a trace of emitted calls.
 - `CanaryTool.Execute` is **optional**, and `EvidenceFidelity.IntentToAct` already distinguishes a
   call the model *emitted* from one that *executed*.
 
-So an agent can be handed the tools, asked to carry out a procedure it learned sessions earlier, and
-scored on the **emitted call sequence** — with nothing running. No sandbox, no side effects, no state
-threading. **Observed outcomes are not needed to test whether the procedure was remembered
-correctly**; they are only needed to test whether the system got *better*, which is a different
-claim and stays out.
+So an agent can be handed tools, asked to carry out a procedure it learned sessions earlier, and
+scored on the **emitted call sequence** — no sandbox, no side effects, no state threading. Observed
+outcomes are needed to test whether a system *improved*; they are not needed to test whether it
+*remembered*.
 
-What is genuinely missing is semantics, not mechanism, and §6.2 records it.
+**One structural gap is also real and unclaimed: nothing in the family has a conditional.** Checked
+across all nine generators. Whether that deserves a shape, and where, is §5.
 
-## 5. What this ADR proposes
+## 3. WHAT THE FAMILY ALREADY COVERS, WHICH THE FIRST DRAFT MISSED
 
-**5a.** ADR-027's exclusion is **narrowed, not lifted**: it continues to apply in full to enacted
-procedural memory as skill acquisition — whether a system improves with practice — which remains out
-of scope for a static corpus family.
+The first draft listed five properties as evidence for a new vertical. Four of them have homes:
 
-**5b.** The declarative half is **admissible in principle**, under a name that does not claim the
-excluded category, subject to §6.
+| property | existing home |
+|---|---|
+| ordered steps | `episodic/list-order`, `temporal/occurrence-order` — and pairwise-order credit already ships (`PairwiseOrderAccuracy`, `TypedMemEvalRunner.cs`) |
+| retired steps | `forgetting` |
+| partial revision | `semantic/current-value`, `bitemporal/correction-depth` |
+| preconditions | unhomed |
+| **conditional branch** | **unhomed — the only one nothing covers** |
 
-**5c.** Nothing is scheduled. Both halves sit after the existing nine verticals are healthy, for a
-reason beyond effort: adding a tenth corpus while three of nine carry open defects spreads the work
-thin, and the family-wide padding fix would then touch ten corpora rather than nine.
+ADR-027 §11.1 sets the standard this must be judged against: *"A three-shape vertical whose shapes
+each have a plausible existing home is a weak vertical."* By that standard the honest scope is **at
+most two candidate shapes inside existing verticals**, not a tenth vertical.
 
-## 6. What cannot be designed until §7 is answered
+## 4. THE CONTRADICTION AT THE HEART OF THE FIRST DRAFT
 
-**6.1 — The name, and therefore the claim.** Until it is settled whether this is "Procedural
-(declarative)", "Protocol", "Runbook", or a shape inside an existing vertical, every downstream
-choice is unanchored. This is the gate.
+It argued distinctness and buildability with premises that negate each other:
 
-**6.2 — There is no mechanical boundary rule, and this family does not accept prose ones.** Temporal
-holds its line against Arithmetic in code: `check_temporal` refuses any answer containing a digit.
-Bitemporal refuses a pair whose two clocks give the same answer. A procedural vertical needs an
-equivalent against **Conjunction** (which already does multi-hop joins) and **Episodic** (which
-already orders mentions), and none has been designed. A candidate — an answer must be an ordered set
-of at least three elements containing at least one conditional — is a starting point, not a decision.
+- **Distinctness (§2):** a procedure is different because its order is **causally required** —
+  violating it is an error, not merely a wrong answer.
+- **Buildability (§3):** it survives V2 by borrowing Temporal's technique — invented steps whose
+  order is **arbitrary and stated**.
 
-**6.3 — Whether it is a tenth vertical at all.** That changes the declared family size, the
-consuming project's expectations, and every table that says "nine".
+Arbitrary-and-stated is the negation of causally-required. ADR-026 §5.2 already settles which one
+the family permits: ordered gold must be *"arbitrary (V2) and derivable only from session sequence,
+never from narrative logic (no 'starter before dessert' orderings)."* **Causal necessity is narrative
+logic.** So the property that would make a procedural vertical distinct is the property the family's
+own construction rule forbids — and once removed, what remains is Episodic list-order.
 
-**6.4 — For the enacted half only:** `ForbiddenCategory` is a *required* field on `CanaryTool`,
-because every tool in that harness is attacker-desirable by construction. Procedural asks the
-inverse — the right tools in the right order — so it needs an `ExpectedStep` notion and a sequence
-evaluator (`ToolInvocationEvaluator` detects invocation, not order). It would also be **the first
-thing to marry the RedTeam and Memory assemblies**, which is an architectural decision rather than a
-feature.
+**This contradiction must be resolved in writing before any design proceeds.** Either the order is
+arbitrary (and the vertical is not distinct) or it is causal (and it cannot pass V2). No third
+option has been articulated.
 
-## 7. The decision requested
+## 5. TWO MORE REASONS THE EVIDENCE PREDICTS REJECTION
 
-**Does ADR-027's permanent exclusion stand as written, or is it narrowed to the enacted half?**
+**V2 is documented blind in exactly this question class.** `tools/name-collision-audit.json`,
+measured 2026-08-30 — the day before the first draft — records: *"V2 scores only a leak that AGREES
+with gold… Harm therefore concentrates in ORDERING questions."* A procedural corpus is ordering
+questions end to end. And inventing names does not reach the leak: in a procedure the prior is
+carried by the **verbs** (back up before migrating, test before deploying), not by the entity names,
+so a non-referential noun bank buys nothing.
 
-- If it **stands**, procedural memory has no owner anywhere in the product, and that should be
-  recorded as an accepted gap rather than left implicit.
-- If it is **narrowed**, §6.1 through §6.3 become the design work, and §6.4 becomes a separate
-  question about where enacted procedural evaluation lives — which is a product decision, not a
-  TypedMemEval one.
+**No discrimination argument was offered, and ADR-028 predicts a poor one.** Acceptance now rests on
+`V1 − V9 ≥ 0.15`. ADR-028 §7.4 names the exact structural cap a procedural question inherits —
+near-closed-choice forms *"where the question names the entity it asks about"*
+(`temporal/occurrence-order` 0.05, `bitemporal/belief-at-instant` 0.11,
+`episodic/participant-attribution` 0.20). *"What are the steps of the Verrin changeover?"* names its
+own procedure and is lexically self-retrieving, which drives V9 up and headroom toward zero. The
+family's nearest existing conditional-shaped join, `conjunction/order-then-value`, shipped saturated
+at V9 15/15, headroom 0.00, for its whole life.
 
-Either answer is defensible. What is not defensible is the current state, where the exclusion reads
-as permanent, the enacted half is unowned, and the declarative half was never separately considered.
+## 6. WHAT IS ACTUALLY DECIDED HERE
 
-## 8. Provenance
+**6a.** ADR-026 §8's exclusion **stands unchanged**. This project does not narrow it.
 
-This came out of a maintainer's question — whether procedural memory could be tested as *"how would
-you do this"* rather than *"do this"* — which is exactly the split §1 draws, and which ADR-027 did
-not consider because it evaluated "procedural memory" as one thing. The claim in §4 was made once
-without inspecting the harness and corrected after reading it; the correction is what moved the
-enacted half from prohibitive to merely unscheduled.
+**6b.** The mechanism premise in ADR-027 §1 is **recorded as refuted** (§2). That is a finding about
+the reason, not a change to the decision.
+
+**6c.** The **conditional-branch gap is recorded as real and unhomed** (§3). If anything proceeds, it
+proceeds as at most one or two shapes inside existing verticals, judged by ADR-028's discrimination
+floor like everything else.
+
+**6d.** The §4 contradiction is **open and blocking**. No design work should start before it is
+resolved in writing.
+
+## 7. What is asked of the counterparty
+
+Whether the agreement recorded in ADR-026 §8 should be reopened, given that the mechanism it was
+struck on (§2) does not hold. Nothing else in this ADR needs their answer; nothing in this ADR
+proceeds without it.
+
+## 8. What the review refuted, kept because it is the useful part
+
+The first draft proposed four decisions. Three were refuted and the fourth declined to ratify:
+
+| proposed | outcome |
+|---|---|
+| Narrow ADR-027's exclusion to the enacted half | **Refuted** — the exclusion is ADR-026's and bilateral; the "no owner" premise was false |
+| Name the vertical **Protocol**, not Procedural, to avoid claiming the excluded category | **Refuted** — `Prospective` is already named for a construct it only partly delivers, so the standard being applied is not one this family holds |
+| Boundary rule: ≥3 ordered elements **and** mention order ≠ execution order | **Refuted by construction** — a question satisfying both was built from Temporal's own machinery and `check_temporal` returned **zero failures**. Rule (b) is Temporal's membership test verbatim (`narration_inversions < 1`), not a boundary against it |
+| Make it a tenth vertical | **Not ratified** — it answers §6.3 while the boundary rule is still open, and in this family a vertical *is* an isolation claim, enforced mechanically rather than in prose |
+
+The lesson worth keeping: **an amendment that moves scope should first establish whose scope it is.**
+The first draft spent its length on whether the split was intellectually sound and never checked the
+one line that said who owns the decision — a line already present in this repository, and read
+earlier the same day.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ Each ADR follows this structure:
 | [026](026-typedmemeval-benchmark-family.md) | TypedMemEval — A Mechanism-Isolating Memory Benchmark Family | Accepted (implemented v0.22.0-beta) | 2026-08-15 |
 | [027](027-typedmemeval-semantic-temporal-bitemporal.md) | TypedMemEval — Semantic, Temporal and Bitemporal Verticals (design) | Proposed (design only; generation gated) | 2026-08-18 |
 | [028](028-typedmemeval-acceptance-on-discrimination.md) | TypedMemEval — accept a shape on measured discrimination, not a coverage proxy | Proposed | 2026-08-31 |
-| [029](029-procedural-memory-declarative-and-enacted.md) | Procedural memory — split the excluded category in two, and reopen only half of it | Proposed (decision requested) | 2026-08-31 |
+| [029](029-procedural-memory-declarative-and-enacted.md) | Procedural memory — a finding, and a request to reopen a bilateral agreement | Proposed (not ratifiable by this project alone) | 2026-09-01 |
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ Each ADR follows this structure:
 | [026](026-typedmemeval-benchmark-family.md) | TypedMemEval — A Mechanism-Isolating Memory Benchmark Family | Accepted (implemented v0.22.0-beta) | 2026-08-15 |
 | [027](027-typedmemeval-semantic-temporal-bitemporal.md) | TypedMemEval — Semantic, Temporal and Bitemporal Verticals (design) | Proposed (design only; generation gated) | 2026-08-18 |
 | [028](028-typedmemeval-acceptance-on-discrimination.md) | TypedMemEval — accept a shape on measured discrimination, not a coverage proxy | Proposed | 2026-08-31 |
-| [029](029-procedural-memory-declarative-and-enacted.md) | Procedural memory — a finding, and a request to reopen a bilateral agreement | Proposed (not ratifiable by this project alone) | 2026-09-01 |
+| [029](029-procedural-memory-declarative-and-enacted.md) | Procedural memory — a finding, and a request to reopen a bilateral agreement | Accepted (scoped to one conditional shape in Conjunction; procedural memory stays out) | 2026-09-01 |
 
 ---
 


### PR DESCRIPTION
I put ADR-029's four decisions to an adversarial review before recording them — because the maintainer had **delegated** the call, and a delegated decision deserves a higher bar rather than a lower one.

**Three of four were refuted; the fourth declined to ratify.** The ADR is rewritten as a finding plus a request. The exclusion stands.

## The blocking one

ADR-026 records the exclusion **twice**, both times as an agreement:

> **No Procedural vertical** — consumer-side by agreement (needs tools; agentic). — §8, line 792

It is **bilateral and owned**. The first draft amended only ADR-027 §1, never cited ADR-026, and asserted that if the exclusion stood procedural memory would have *"no owner anywhere in the product"* — which is false, and was the load-bearing claim that made narrowing look like the only responsible answer.

I had read line 792 earlier the same day and didn't connect it.

## The contradiction I didn't see

The draft argued **distinctness** from order being *causally required*, and **buildability** from Temporal's technique of order being *arbitrary and stated*. Those are negations.

ADR-026 §5.2 already settles which the family permits: ordered gold must be *"arbitrary (V2) and derivable only from session sequence, never from narrative logic"*. **Causal necessity is narrative logic** — so the property that would make the vertical distinct is the one the family's rules forbid, and removing it leaves Episodic list-order.

## The boundary rule, refuted by construction

A question satisfying **both** proposed rules was built from Temporal's own machinery, and `check_temporal` returned **zero failures**. Rule (b) — mention order must differ from execution order — is Temporal's membership test verbatim (`narration_inversions < 1`). Not a boundary against Temporal; its definition.

## The naming argument, refuted by precedent

`Prospective` is already named for a construct it only partly delivers. "We must not call it Procedural because it covers half" applies a standard this family does not hold.

## What survives and is worth sending

ADR-027 §1's **mechanism** premise really is refuted — `EvidenceFidelity.IntentToAct` plus an optional `CanaryTool.Execute` mean a remembered procedure can be scored on emitted calls with nothing executing. And **nothing in the family has a conditional**.

That's a finding about a missing *shape*, not a licence to redraw a two-party boundary. Four of the draft's five claimed-distinct properties turn out to have existing homes, and ADR-027 §11.1's own standard (*"a three-shape vertical whose shapes each have a plausible existing home is a weak vertical"*) caps the honest scope at one or two shapes inside existing verticals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011A7ijQoGnK2vD7ibLaMfXZ